### PR TITLE
Write the Chinese in written register, and localize Settings

### DIFF
--- a/Resources/i18n/_glossary.json
+++ b/Resources/i18n/_glossary.json
@@ -40,19 +40,20 @@
     "Grok Bot"
   ],
   "products": [
+    "Chrome",
+    "Finder",
+    "Firefox",
+    "GitHub",
+    "Keychain",
+    "MCP",
+    "Safari",
+    "Sparkle",
+    "Terminal",
     "Vibe Bar",
     "Workbench",
-    "Sparkle",
-    "Keychain",
-    "Terminal",
+    "agent-session-kit",
     "iTerm2",
-    "Finder",
-    "Safari",
-    "Chrome",
-    "Firefox",
-    "macOS",
-    "MCP",
-    "GitHub"
+    "macOS"
   ],
   "modelFamilies": [
     "Sonnet",

--- a/Resources/i18n/_glossary.json
+++ b/Resources/i18n/_glossary.json
@@ -49,6 +49,7 @@
     "Safari",
     "Sparkle",
     "Terminal",
+    "VB",
     "Vibe Bar",
     "Workbench",
     "agent-session-kit",

--- a/Resources/i18n/en.json
+++ b/Resources/i18n/en.json
@@ -1,7 +1,15 @@
 {
+  "common.add": {
+    "comment": "Button that appends an entry to a list",
+    "value": "Add"
+  },
   "common.all": {
     "comment": "Filter chip or menu entry that selects every item.",
     "value": "All"
+  },
+  "common.auto": {
+    "comment": "Picker option and field placeholder meaning 'let Vibe Bar decide'",
+    "value": "Auto"
   },
   "common.cancel": {
     "comment": "Button that abandons an action in progress.",
@@ -10,6 +18,10 @@
   "common.clear": {
     "comment": "Button that empties a search field or resets a filter.",
     "value": "Clear"
+  },
+  "common.copied": {
+    "comment": "Confirmation shown in place of the Copy button",
+    "value": "Copied"
   },
   "common.copy": {
     "comment": "Button that copies the adjacent value to the clipboard.",
@@ -89,6 +101,10 @@
     "comment": "Button that closes a sheet or leaves an editing mode.",
     "value": "Done"
   },
+  "common.dragToReorder": {
+    "comment": "Tooltip on a drag handle",
+    "value": "Drag to reorder"
+  },
   "common.duration.days": {
     "args": {
       "days": "int"
@@ -134,6 +150,10 @@
     "comment": "Countdown that has reached zero",
     "value": "now"
   },
+  "common.name": {
+    "comment": "Field label for a user-chosen name",
+    "value": "Name"
+  },
   "common.off": {
     "comment": "A toggle's state, read as a value in a summary row",
     "value": "Off"
@@ -157,6 +177,10 @@
     "comment": "A whole percentage. Both languages use the sign the same way; the key exists so a language that does not can move it.",
     "value": "{value}%"
   },
+  "common.provider": {
+    "comment": "Picker label for choosing a provider",
+    "value": "Provider"
+  },
   "common.refresh": {
     "comment": "Generic refresh button and tooltip",
     "value": "Refresh"
@@ -165,9 +189,21 @@
     "comment": "Tooltip on a per-card refresh button",
     "value": "Refresh this section"
   },
+  "common.remove": {
+    "comment": "Button that takes an item out of a list",
+    "value": "Remove"
+  },
   "common.retry": {
     "comment": "Button on a failure state",
     "value": "Retry"
+  },
+  "common.retryNow": {
+    "comment": "Button that retries immediately, skipping a cooldown",
+    "value": "Retry now"
+  },
+  "common.save": {
+    "comment": "Button that commits an edited value",
+    "value": "Save"
   },
   "common.updated.daysAgo": {
     "args": {
@@ -1495,6 +1531,130 @@
     "comment": "Inline error row; reason is a provider message and is not translated",
     "value": "Update failed: {reason}"
   },
+  "settings.antigravityCookieEnabled": {
+    "comment": "Hint under the Antigravity source picker",
+    "value": "Antigravity cookie import is enabled — sign in at antigravity.google first."
+  },
+  "settings.antigravityLocalOnly": {
+    "comment": "Hint under the Antigravity source picker",
+    "value": "Antigravity reads the locally running language server. Cookie import is deferred until the Antigravity Cloud endpoint ships."
+  },
+  "settings.antigravitySource": {
+    "comment": "Picker label",
+    "value": "Antigravity source"
+  },
+  "settings.appVersion": {
+    "comment": "Current version line; version is a raw version string",
+    "value": "Vibe Bar {version}"
+  },
+  "settings.bundled": {
+    "comment": "Badge on the version currently compiled in",
+    "value": "bundled"
+  },
+  "settings.checkConnections": {
+    "comment": "Button that probes a company's credentials; company is an L1 company name and is never translated",
+    "value": "Check {company} connections"
+  },
+  "settings.checkForUpdates": {
+    "comment": "Button label",
+    "value": "Check for Updates…"
+  },
+  "settings.checkKitUpdates": {
+    "comment": "Button that queries GitHub for a newer agent-session-kit",
+    "value": "Check for kit updates"
+  },
+  "settings.checkingGitHub": {
+    "comment": "Progress line while an update check runs",
+    "value": "Checking github.com for the newest release…"
+  },
+  "settings.clearCostData": {
+    "comment": "Button label",
+    "value": "Clear cost data"
+  },
+  "settings.connectionHealth": {
+    "comment": "Heading over the per-provider connection rows",
+    "value": "Connection health"
+  },
+  "settings.costDataIntro": {
+    "comment": "Intro under the Cost Data heading",
+    "value": "Cost is computed from local CLI session JSONL logs at ~/.codex/sessions and ~/.claude/projects. Web/desktop usage is not tracked."
+  },
+  "settings.couldNotDeleteCookies": {
+    "comment": "Error under the delete-cookies button",
+    "value": "Could not delete saved cookies."
+  },
+  "settings.couldNotDeleteGeminiCookies": {
+    "comment": "Error line",
+    "value": "Could not delete saved Gemini cookies."
+  },
+  "settings.couldNotDeleteGrokCookies": {
+    "comment": "Error line",
+    "value": "Could not delete saved Grok cookies."
+  },
+  "settings.cursorNoSession": {
+    "comment": "Credential state line",
+    "value": "No usable Cursor.app session — import cursor.com cookies below."
+  },
+  "settings.cursorSessionDetected": {
+    "comment": "Credential state line",
+    "value": "Cursor.app signed-in session detected"
+  },
+  "settings.cursorSource": {
+    "comment": "Row label",
+    "value": "Cursor source"
+  },
+  "settings.cursorSourceValue": {
+    "comment": "Value beside the Cursor source row",
+    "value": "Cursor.app → Web"
+  },
+  "settings.deleteCookies": {
+    "comment": "Button that clears a provider's stored cookies",
+    "value": "Delete cookies"
+  },
+  "settings.deleteGeminiCookies": {
+    "comment": "Button label",
+    "value": "Delete Gemini cookies"
+  },
+  "settings.deleteGrokCookies": {
+    "comment": "Button label",
+    "value": "Delete Grok cookies"
+  },
+  "settings.externalChange.title": {
+    "comment": "Banner shown when a second client overwrote a setting this one had changed",
+    "value": "Another Vibe Bar replaced your change"
+  },
+  "settings.geminiCookiesSaved": {
+    "comment": "Confirmation line",
+    "value": "Gemini cookies saved."
+  },
+  "settings.geminiShared": {
+    "comment": "Explanation on the Google AI settings page",
+    "value": "Gemini and Antigravity share the same Google AI subscription quota. Cookie import is the only supported web path — there is no WebView login."
+  },
+  "settings.geminiSource": {
+    "comment": "Row label for where Gemini quota is read from",
+    "value": "Gemini source"
+  },
+  "settings.grokAuthDetected": {
+    "comment": "Credential state line; the path is never translated",
+    "value": "~/.grok/auth.json detected"
+  },
+  "settings.grokCookiesSaved": {
+    "comment": "Confirmation line",
+    "value": "Grok cookies saved."
+  },
+  "settings.keepHistory": {
+    "comment": "Picker label for the retention window",
+    "value": "Keep history"
+  },
+  "settings.keepHistoryDetail": {
+    "comment": "Caption under the retention picker",
+    "value": "Applies to cost history and subscription fill history."
+  },
+  "settings.kitDetail": {
+    "comment": "Description of the bundled agent-session-kit component",
+    "value": "Session discovery, harness naming, and the MCP transport. A separate repository, pinned to an exact tag and compiled into this build."
+  },
   "settings.language.caption": {
     "comment": "Caption under the language picker in Settings",
     "value": "Vibe Bar follows the macOS language unless you pick one here. Provider, model and harness names stay as their owners spell them."
@@ -1506,6 +1666,775 @@
   "settings.language.title": {
     "comment": "Settings row label for the in-app language override",
     "value": "Language"
+  },
+  "settings.mcp.allowRefresh": {
+    "comment": "Toggle label",
+    "value": "Allow agents to refresh quota"
+  },
+  "settings.mcp.allowRefreshDetail": {
+    "args": {
+      "seconds": "int"
+    },
+    "comment": "Caption under the refresh toggle; quota.refresh is an MCP tool name and is never translated",
+    "value": "With this on, an agent can ask Vibe Bar to re-fetch quota from your providers. Forced refreshes are rate-limited to one every {seconds} seconds. With it off the read-only tools keep working and quota.refresh reports that refreshing is disabled."
+  },
+  "settings.mcp.allowSkills": {
+    "comment": "Toggle label",
+    "value": "Allow agents to install skills"
+  },
+  "settings.mcp.allowSkillsDetail": {
+    "comment": "Caption under the skills toggle; skills.install is an MCP tool name",
+    "value": "With this on, an agent can call skills.install to add a skill from a GitHub repository or a local folder. It goes through the same Skills manager as Workbench → Skills, so it writes only to ~/.agents/skills and the agent skills directories Vibe Bar manages — never over a folder a different skill already holds. With it off the tool reports that installing is disabled."
+  },
+  "settings.mcp.appendCodexConfig": {
+    "comment": "Caption on a copyable config snippet; the path is never translated",
+    "value": "Append to ~/.codex/config.toml."
+  },
+  "settings.mcp.connectAgent": {
+    "comment": "Sub-heading over the setup instructions",
+    "value": "Connect an agent"
+  },
+  "settings.mcp.connectedClients": {
+    "comment": "Row label for the live connection count",
+    "value": "Connected clients"
+  },
+  "settings.mcp.enable": {
+    "comment": "Toggle label",
+    "value": "Enable the local MCP server"
+  },
+  "settings.mcp.intro": {
+    "comment": "Intro paragraph of the MCP settings section",
+    "value": "Vibe Bar can expose this Mac's quota, usage, cost and local agent sessions to your coding agents over MCP. The server listens on a Unix domain socket in your home directory — no network port is opened, and no token is created: the socket's file permissions are the access control."
+  },
+  "settings.mcp.lastActivity": {
+    "comment": "Row label for when a client last spoke to the server",
+    "value": "Last client activity"
+  },
+  "settings.mcp.listening": {
+    "comment": "MCP server state: the socket is accepting connections",
+    "value": "Listening"
+  },
+  "settings.mcp.manualIntro": {
+    "comment": "Intro to the manual client configuration snippets; flag is a command-line flag and is never translated",
+    "value": "Or configure a client by hand. Every client runs the same command — Vibe Bar's own binary with {flag}, which bridges stdin/stdout to the socket above."
+  },
+  "settings.mcp.mergeCursorConfig": {
+    "comment": "Caption on a copyable config snippet",
+    "value": "Merge into ~/.cursor/mcp.json."
+  },
+  "settings.mcp.movePrompt": {
+    "comment": "Warning shown when the app runs from a build directory; path is a filesystem path",
+    "value": "Vibe Bar is running from {path}. Move it to /Applications before saving a client config, or the config breaks the next time you rebuild."
+  },
+  "settings.mcp.notListening": {
+    "comment": "MCP server state: the socket is closed",
+    "value": "Not listening"
+  },
+  "settings.mcp.otherStdioClient": {
+    "comment": "Heading for the generic client snippet",
+    "value": "Any other stdio client"
+  },
+  "settings.mcp.otherStdioDetail": {
+    "comment": "Caption on the generic client snippet",
+    "value": "One entry for the client's own mcpServers map."
+  },
+  "settings.mcp.quickestPath": {
+    "comment": "Caption over the one-line setup prompt",
+    "value": "The quickest path: paste this into any agent and let it configure itself, install the companion skill, and verify the connection."
+  },
+  "settings.mcp.readOnlyDetail": {
+    "comment": "Caption closing the MCP permissions section",
+    "value": "Everything else agents can reach is read-only: quota, token usage, cost, provider status, effective model prices, and the local session index (titles, projects, and — when session body indexing is on — message excerpts). Credentials, cookies and organization ids are never exposed, and email addresses are masked."
+  },
+  "settings.mcp.runInTerminal": {
+    "comment": "Caption on a copyable shell command",
+    "value": "Run in a terminal."
+  },
+  "settings.mcp.setupPrompt": {
+    "comment": "Label for the copyable one-line prompt",
+    "value": "Agent setup prompt"
+  },
+  "settings.mcp.setupPromptDetail": {
+    "comment": "Caption under the setup prompt",
+    "value": "One line, works in any agent that can fetch a URL."
+  },
+  "settings.mcp.socket": {
+    "comment": "Row label for the socket path. The term stays as spelled.",
+    "value": "Socket"
+  },
+  "settings.mcp.socketLifetime": {
+    "comment": "Caption under the MCP status rows. The quoted phrase is the message another tool prints and stays in English.",
+    "value": "The socket exists only while Vibe Bar is running. Agents configured below report “Vibe Bar is not running” when it is quit, which is the intended behaviour."
+  },
+  "settings.mcp.status": {
+    "comment": "Row label for whether the MCP socket is listening. Distinct from status.overview.title, which is a provider's service status.",
+    "value": "Status"
+  },
+  "settings.mcp.title": {
+    "comment": "Settings section heading for the local MCP server",
+    "value": "MCP Server"
+  },
+  "settings.mcp.whatAgentsMayDo": {
+    "comment": "Sub-heading over the permission toggles",
+    "value": "What agents may do"
+  },
+  "settings.menuBarHealthUnavailable": {
+    "comment": "Shown when the watchdog is not running",
+    "value": "The menu bar health monitor is not attached in this process."
+  },
+  "settings.miniWindow.add": {
+    "comment": "Button in the mini windows settings section",
+    "value": "Add a mini window"
+  },
+  "settings.miniWindow.allBucketsIncluded": {
+    "comment": "Empty state under the add-bucket list",
+    "value": "Every known bucket is already in this window."
+  },
+  "settings.miniWindow.dismissBuiltIn": {
+    "comment": "Tooltip on the dismiss button of a built-in bucket",
+    "value": "Dismiss this built-in bucket while the provider is not returning it. It comes back the moment the provider does."
+  },
+  "settings.miniWindow.forgetDiscovered": {
+    "comment": "Tooltip on the dismiss button of a runtime-discovered bucket",
+    "value": "Forget this discovered bucket — drops it from the list and from every window that selected it."
+  },
+  "settings.miniWindow.includeStyle": {
+    "comment": "Tooltip on a style toggle; mode is a display-mode name",
+    "value": "Include {mode} in the double-click cycle"
+  },
+  "settings.miniWindow.lastCannotBeRemoved": {
+    "comment": "Tooltip explaining a disabled remove button",
+    "value": "The last mini window cannot be removed."
+  },
+  "settings.miniWindow.namesAllWindows": {
+    "comment": "Segment label: edit the shared names",
+    "value": "Names: all windows"
+  },
+  "settings.miniWindow.namesThisStyle": {
+    "comment": "Segment label: edit only this display style's overrides; mode is a display-mode name",
+    "value": "Only {mode} here"
+  },
+  "settings.miniWindow.namesThisWindow": {
+    "comment": "Segment label: edit only this window's name overrides",
+    "value": "Only “{name}”"
+  },
+  "settings.miniWindow.noFieldsSelected": {
+    "comment": "Empty state under the field list",
+    "value": "No fields selected — tick some above."
+  },
+  "settings.miniWindow.notInWindow": {
+    "comment": "Caption over the list of buckets not yet in this window",
+    "value": "Not in “{name}” — tick a bucket to add it. Buckets the adapters discover at runtime appear here automatically; a dimmed row is remembered but not in the account's current response, and ✕ dismisses it until the provider returns it."
+  },
+  "settings.miniWindow.offline": {
+    "comment": "Badge on a remote machine's row in the mini window preview",
+    "value": "offline"
+  },
+  "settings.miniWindow.openClose": {
+    "comment": "Button that shows or hides a mini window",
+    "value": "Open / Close"
+  },
+  "settings.miniWindow.overridesStyle": {
+    "comment": "Caption over the per-style name fields",
+    "value": "Overrides for the {mode} style of this window only. An empty field inherits the window name, then the shared one — shown as the placeholder."
+  },
+  "settings.miniWindow.overridesWindow": {
+    "comment": "Caption over the per-window name fields",
+    "value": "Name overrides for this window only. An empty field inherits the shared name — shown as the placeholder."
+  },
+  "settings.miniWindow.position": {
+    "args": {
+      "position": "int"
+    },
+    "comment": "Ordinal badge showing a field's place in the order",
+    "value": "{position}"
+  },
+  "settings.miniWindow.removeFromWindow": {
+    "comment": "Tooltip on a row's remove control",
+    "value": "Remove from this window"
+  },
+  "settings.miniWindow.removeHelp": {
+    "comment": "Tooltip on the remove button",
+    "value": "Remove this mini window"
+  },
+  "settings.miniWindow.stripDensity": {
+    "comment": "Picker label for the mini window's row density",
+    "value": "Strip density"
+  },
+  "settings.miniWindow.styleCycle": {
+    "comment": "Caption over the style cycle picker",
+    "value": "Double-click on the window cycles its style. Tap a style to include it — the badge is its turn in the cycle. Nothing selected means every style, in this order."
+  },
+  "settings.miniWindow.toggleHelp": {
+    "comment": "Tooltip on the open/close button",
+    "value": "Toggle this mini window on screen"
+  },
+  "settings.miniWindow.treeDetail": {
+    "comment": "Caption over the mini window field tree",
+    "value": "One tree for the window — grouped exactly as it folds them (company → SubProvider → quota group → bucket). Drag a row to reorder, ✕ to remove, and rename any level in place. First field renders leftmost (or topmost)."
+  },
+  "settings.misc.accessKeyId": {
+    "comment": "Field placeholder for the AK half of an AK/SK pair",
+    "value": "Access Key ID (AKLT…)"
+  },
+  "settings.misc.akSkSaved": {
+    "comment": "Confirmation under an AK/SK field",
+    "value": "AK/SK saved in Keychain."
+  },
+  "settings.misc.apiKeySaved": {
+    "comment": "Confirmation under a credential field",
+    "value": "API key saved in Keychain."
+  },
+  "settings.misc.clearWorkspace": {
+    "comment": "Tooltip on the button that forgets a stored workspace id",
+    "value": "Clear saved workspace"
+  },
+  "settings.misc.clone": {
+    "comment": "Tooltip on the button that adds a second instance of a provider",
+    "value": "Clone {provider}"
+  },
+  "settings.misc.consoleLink": {
+    "comment": "Console link row; title is the provider's own page name",
+    "value": "{title} →"
+  },
+  "settings.misc.edition": {
+    "comment": "Picker label for a provider's edition (Team, Personal, …)",
+    "value": "Edition"
+  },
+  "settings.misc.githubSignInHint": {
+    "comment": "Hint under the GitHub sign-in row",
+    "value": "Sign in with GitHub device flow."
+  },
+  "settings.misc.githubTokenSaved": {
+    "comment": "Confirmation under the GitHub sign-in row",
+    "value": "GitHub device token saved in Keychain."
+  },
+  "settings.misc.importDetail": {
+    "comment": "Caption under the cookie import button",
+    "value": "Adds or refreshes the first signed-in browser profile found; profiles already imported stay stacked, and this provider's quota is the average across every slot listed above. macOS may ask for your login-keychain password once per Chromium-family browser."
+  },
+  "settings.misc.kiroHint": {
+    "comment": "Hint under the Kiro row; the commands are never translated",
+    "value": "Run `kiro-cli login`, then Vibe Bar probes `kiro-cli chat --no-interactive /usage`."
+  },
+  "settings.misc.noCookieSpec": {
+    "comment": "Shown when a provider has no cookie import path",
+    "value": "No cookie spec is registered for {provider}."
+  },
+  "settings.misc.noCookiesYet": {
+    "comment": "Empty state in the cookie slot list",
+    "value": "No cookies imported yet — import from your browser or paste below."
+  },
+  "settings.misc.probe": {
+    "comment": "Button that runs a local CLI probe",
+    "value": "Probe"
+  },
+  "settings.misc.prompt.copilotHost": {
+    "comment": "Field placeholder",
+    "value": "GitHub Enterprise host (optional, e.g. github.example.com)"
+  },
+  "settings.misc.prompt.dashscope": {
+    "comment": "Field placeholder",
+    "value": "Paste DashScope API key (sk-...) — optional"
+  },
+  "settings.misc.prompt.kilo": {
+    "comment": "Field placeholder",
+    "value": "Paste Kilo API key (optional)"
+  },
+  "settings.misc.prompt.minimax": {
+    "comment": "Field placeholder",
+    "value": "Paste MiniMax Token Plan API key (sk-cp-... or MINIMAX_CODING_API_KEY)"
+  },
+  "settings.misc.prompt.openRouter": {
+    "comment": "Field placeholder",
+    "value": "Paste OpenRouter API key (sk-or-v1-...)"
+  },
+  "settings.misc.prompt.openRouterHost": {
+    "comment": "Field placeholder",
+    "value": "OpenRouter API URL (optional, defaults to https://openrouter.ai/api/v1)"
+  },
+  "settings.misc.prompt.warp": {
+    "comment": "Field placeholder",
+    "value": "Paste Warp API key (wk-...)"
+  },
+  "settings.misc.prompt.workspace": {
+    "comment": "Field placeholder",
+    "value": "Workspace ID or URL (optional, wrk_... or /workspace/wrk_.../go)"
+  },
+  "settings.misc.prompt.zai": {
+    "comment": "Field placeholder; the key prefix is a format example",
+    "value": "Paste Z.ai API key (zai-...)"
+  },
+  "settings.misc.region": {
+    "comment": "Picker label for a provider's service region",
+    "value": "Region"
+  },
+  "settings.misc.removeAkSk": {
+    "comment": "Tooltip on the button that clears a stored AK/SK pair",
+    "value": "Remove stored {provider} AK/SK"
+  },
+  "settings.misc.removeApiKey": {
+    "comment": "Tooltip on the button that clears a stored key",
+    "value": "Remove stored {provider} API key"
+  },
+  "settings.misc.removeCookieSlot": {
+    "comment": "Tooltip on a cookie slot's delete button",
+    "value": "Remove this cookie slot"
+  },
+  "settings.misc.removeCopy": {
+    "comment": "Tooltip on the button that deletes a cloned instance",
+    "value": "Remove this {provider} copy"
+  },
+  "settings.misc.removeCopyButton": {
+    "comment": "Destructive button in the remove-copy dialog",
+    "value": "Remove Copy"
+  },
+  "settings.misc.removeCopyDetail": {
+    "comment": "Confirmation dialog body",
+    "value": "Its saved credentials are deleted from your Keychain — the API key or AK/SK and every imported cookie slot. This cannot be undone."
+  },
+  "settings.misc.removeCopyTitle": {
+    "comment": "Confirmation dialog title",
+    "value": "Remove this {provider} copy?"
+  },
+  "settings.misc.removeGithubToken": {
+    "comment": "Tooltip on the button that clears the GitHub token",
+    "value": "Remove stored GitHub device token"
+  },
+  "settings.misc.rename": {
+    "comment": "Tooltip on the rename button of a cloned instance",
+    "value": "Rename this copy"
+  },
+  "settings.misc.secretAccessKey": {
+    "comment": "Field placeholder for the SK half of an AK/SK pair. The term is the provider's own and stays as spelled.",
+    "value": "Secret Access Key"
+  },
+  "settings.misc.signIn": {
+    "comment": "Button that starts a device-flow sign-in",
+    "value": "Sign in"
+  },
+  "settings.misc.signInViaWeb": {
+    "comment": "Button that opens a WebView login",
+    "value": "Sign in via Web"
+  },
+  "settings.misc.tencentTokenPlanNote": {
+    "comment": "Caption under the Tencent token plan row",
+    "value": "Personal Token Plan is currently available only in China mainland (cn-beijing). Clone this row to track Team and Personal together."
+  },
+  "settings.misc.variant": {
+    "comment": "Picker label for a provider's plan variant",
+    "value": "Variant"
+  },
+  "settings.misc.waiting": {
+    "comment": "Button label while a device-flow sign-in is pending",
+    "value": "Waiting..."
+  },
+  "settings.misc.workspaceNote": {
+    "comment": "Caption under the workspace field",
+    "value": "Only needed when the account owns more than one workspace — otherwise Vibe Bar uses the first one it finds."
+  },
+  "settings.needsSetup": {
+    "comment": "Provider state: credentials are missing",
+    "value": "Needs setup"
+  },
+  "settings.notChecked": {
+    "comment": "Connection state before any probe has run",
+    "value": "Not checked"
+  },
+  "settings.notCheckedYet": {
+    "comment": "Line under the update-check button",
+    "value": "Not checked. Nothing is fetched until you ask."
+  },
+  "settings.openRefreshCooldown": {
+    "comment": "Picker label",
+    "value": "Minimum open-refresh cooldown"
+  },
+  "settings.openRefreshDetail": {
+    "comment": "Caption under the cooldown picker",
+    "value": "Opening the popover refreshes all visible providers at most once per cooldown period."
+  },
+  "settings.openStatusPage": {
+    "comment": "Link to a company's public status page",
+    "value": "Open {company} status page"
+  },
+  "settings.percentShows": {
+    "comment": "Picker label choosing between remaining and used",
+    "value": "Percent shows"
+  },
+  "settings.planBadge": {
+    "comment": "Field label for a user-chosen plan label override",
+    "value": "Plan badge"
+  },
+  "settings.planBadgeDetail": {
+    "comment": "Caption under the plan badge field",
+    "value": "Leave blank to use the detected account plan."
+  },
+  "settings.pricing.addOverride": {
+    "comment": "Button that appends a blank rate card",
+    "value": "Add model override"
+  },
+  "settings.pricing.advancedTiers": {
+    "comment": "Disclosure heading over the threshold rate fields",
+    "value": "Advanced tiers"
+  },
+  "settings.pricing.alwaysWins": {
+    "comment": "Detail beside the local-overrides source",
+    "value": "Always wins"
+  },
+  "settings.pricing.bundledFallback": {
+    "comment": "Name of the lowest-priority price source",
+    "value": "Bundled fallback"
+  },
+  "settings.pricing.cacheReadAbove": {
+    "comment": "Rate field label",
+    "value": "Cache read above"
+  },
+  "settings.pricing.cacheWriteAbove": {
+    "comment": "Rate field label",
+    "value": "Cache write above"
+  },
+  "settings.pricing.deleteOverride": {
+    "comment": "Tooltip on a rate card's delete button",
+    "value": "Delete override"
+  },
+  "settings.pricing.exactModelName": {
+    "comment": "Placeholder in the model-name field of a rate card",
+    "value": "Exact model name"
+  },
+  "settings.pricing.fastMultiplier": {
+    "comment": "Rate field label: the multiplier applied to a fast tier",
+    "value": "Fast multiplier"
+  },
+  "settings.pricing.inputAbove": {
+    "comment": "Rate field label for input tokens beyond the threshold",
+    "value": "Input above"
+  },
+  "settings.pricing.intro": {
+    "comment": "Intro under the Model Pricing heading",
+    "value": "Catalogs refresh in the background. Higher entries win when the same provider and model name appears more than once."
+  },
+  "settings.pricing.localOverrides": {
+    "comment": "Settings section heading over the user's own rate cards",
+    "value": "Local overrides"
+  },
+  "settings.pricing.localOverridesName": {
+    "comment": "Name of the highest-priority price source",
+    "value": "Local overrides"
+  },
+  "settings.pricing.noOverrides": {
+    "comment": "Empty state in the overrides list",
+    "value": "No local overrides."
+  },
+  "settings.pricing.number": {
+    "args": {
+      "number": "int"
+    },
+    "comment": "Ordinal badge beside a price source",
+    "value": "{number}"
+  },
+  "settings.pricing.offlineFloor": {
+    "comment": "Detail beside the bundled source",
+    "value": "Offline floor"
+  },
+  "settings.pricing.outputAbove": {
+    "comment": "Rate field label for output tokens beyond the threshold",
+    "value": "Output above"
+  },
+  "settings.pricing.overridesIntro": {
+    "comment": "Intro under the Local overrides heading",
+    "value": "Prices are USD per one million tokens. Leave cache fields empty when the provider does not publish them."
+  },
+  "settings.pricing.priorityHealth": {
+    "comment": "Settings section heading over the price-source list",
+    "value": "Priority and source health"
+  },
+  "settings.pricing.rateInput": {
+    "comment": "Rate field label: input tokens",
+    "value": "Input"
+  },
+  "settings.pricing.rateOutput": {
+    "comment": "Rate field label: output tokens",
+    "value": "Output"
+  },
+  "settings.pricing.refreshNow": {
+    "comment": "Button that fetches price catalogs immediately",
+    "value": "Refresh now"
+  },
+  "settings.pricing.refreshing": {
+    "comment": "Button label while a price refresh runs",
+    "value": "Refreshing…"
+  },
+  "settings.pricing.thresholdTokens": {
+    "comment": "Field label: the token count above which the higher rates apply",
+    "value": "Threshold tokens"
+  },
+  "settings.pricingDataDate": {
+    "comment": "Footer showing when the bundled price table was built; date is a raw stamp",
+    "value": "Pricing data: {date}"
+  },
+  "settings.privacyDetail": {
+    "comment": "Body of the Privacy section",
+    "value": "Tokens are read from local CLI credentials. Saved OpenAI and Claude Web cookies are stored in macOS Keychain, split by browser and WebView source. Legacy plaintext cookie files under ~/.vibebar/cookies are migrated once and deleted. Settings, quota cache, and cost summaries stay under ~/.vibebar."
+  },
+  "settings.privacyMode": {
+    "comment": "Toggle label",
+    "value": "Privacy mode"
+  },
+  "settings.privacyModeDetail": {
+    "comment": "Caption under the privacy toggle",
+    "value": "Privacy mode keeps cost data off disk and clears local cost history, snapshots, and scan cache."
+  },
+  "settings.ready": {
+    "comment": "Provider state: credentials are usable",
+    "value": "Ready"
+  },
+  "settings.refreshEvery": {
+    "comment": "Picker label for a background refresh interval",
+    "value": "Refresh every"
+  },
+  "settings.refreshOnPopoverOpen": {
+    "comment": "Toggle label",
+    "value": "Refresh when the popover opens"
+  },
+  "settings.releaseNotes": {
+    "comment": "Link label",
+    "value": "Release notes"
+  },
+  "settings.remote.core": {
+    "comment": "Settings section heading. Core is the product term for this Mac's aggregator.",
+    "value": "Remote Core"
+  },
+  "settings.remote.costAggregation": {
+    "comment": "Settings section heading",
+    "value": "Cost aggregation"
+  },
+  "settings.remote.costAggregationIntro": {
+    "comment": "Intro under the cost aggregation heading",
+    "value": "Choose which remote machines join this Mac's local cost and token totals. Selection and aggregation stay on this Core; the Relay never sees plaintext usage."
+  },
+  "settings.remote.differentControlCenter": {
+    "comment": "Toggle that reveals the control-centre URL field",
+    "value": "Use a different control center"
+  },
+  "settings.remote.discard": {
+    "comment": "Button that abandons a pending join",
+    "value": "Discard"
+  },
+  "settings.remote.discardPendingDetail": {
+    "comment": "Confirmation dialog body",
+    "value": "Its pairing code is already spent, and the workspace still counts this Mac as its Core. To join again, revoke this Mac in the web control center, then create a fresh code."
+  },
+  "settings.remote.discardPendingTitle": {
+    "comment": "Confirmation dialog title",
+    "value": "Discard this pending join?"
+  },
+  "settings.remote.disconnect": {
+    "comment": "Settings section heading, and the destructive button in its dialog",
+    "value": "Disconnect"
+  },
+  "settings.remote.disconnectButton": {
+    "comment": "Button that unpairs this Mac",
+    "value": "Disconnect from Workspace…"
+  },
+  "settings.remote.disconnectDetail": {
+    "comment": "Confirmation dialog body",
+    "value": "Reconnecting later requires a new pairing code or provisioning file."
+  },
+  "settings.remote.disconnectIntro": {
+    "comment": "Explanation under the Disconnect heading",
+    "value": "Disconnecting removes this Mac's Relay credential from the Keychain and its workspace binding. Probes keep uploading to the Relay until they are revoked there. Usage already decrypted stays in the local ledger."
+  },
+  "settings.remote.disconnectTitle": {
+    "comment": "Confirmation dialog title",
+    "value": "Disconnect from this workspace?"
+  },
+  "settings.remote.exportIdentity": {
+    "comment": "Button that writes this Mac's public identity to a file",
+    "value": "Export Core Identity…"
+  },
+  "settings.remote.importProvisioning": {
+    "comment": "Button that reads a provisioning file",
+    "value": "Import Provisioning File…"
+  },
+  "settings.remote.join": {
+    "comment": "Button that submits a pairing code",
+    "value": "Join"
+  },
+  "settings.remote.joinIntro": {
+    "comment": "Explanation above the pairing-code field; device is the Mac's name",
+    "value": "Create a Core code in the Vibe Bar control center, then paste it here. This Mac joins as “{device}”."
+  },
+  "settings.remote.joinWithCode": {
+    "comment": "Heading over the pairing-code field",
+    "value": "Join with a code"
+  },
+  "settings.remote.lastSync": {
+    "comment": "Row label for the last sync time",
+    "value": "Last sync"
+  },
+  "settings.remote.machineDetail": {
+    "comment": "Second line of a remote machine row; platform and version are raw values",
+    "value": "{platform} · Probe {version}"
+  },
+  "settings.remote.machinesAppearAfterImport": {
+    "comment": "Empty state in the machine list",
+    "value": "Machines appear here after their first encrypted batch is imported."
+  },
+  "settings.remote.machinesSynced": {
+    "comment": "Row label for the machine count",
+    "value": "Machines synced"
+  },
+  "settings.remote.manualPairingIntro": {
+    "comment": "Explanation of the manual pairing flow",
+    "value": "Pairing runs in three steps: export this Mac's Core identity, register it with your Relay to produce a provisioning file, then import that file here. Importing moves the Relay credential into the macOS Keychain — but the provisioning file itself still contains that credential, so delete the file once the import succeeds."
+  },
+  "settings.remote.notConnected": {
+    "comment": "Explanation shown when no workspace is paired",
+    "value": "This Mac is not connected to a workspace. Remote probes collect normalized usage on your other machines, encrypt it to this Mac's Core keys, and drop it at a Relay — no inbound port is ever opened here."
+  },
+  "settings.remote.orPairManually": {
+    "comment": "Caption above the manual pairing buttons",
+    "value": "Or pair manually."
+  },
+  "settings.remote.pendingIntro": {
+    "comment": "Explanation of a half-finished join",
+    "value": "A previous join was accepted by the control center but never finished saving on this Mac. Its pairing code is already spent, so resume the save instead of requesting a new code."
+  },
+  "settings.remote.provisioning": {
+    "comment": "Settings section heading over the pairing controls",
+    "value": "Provisioning"
+  },
+  "settings.remote.registeredProbes": {
+    "comment": "Row label for the probe count",
+    "value": "Registered probes"
+  },
+  "settings.remote.relay": {
+    "comment": "Row label for the relay URL. The term stays as spelled.",
+    "value": "Relay"
+  },
+  "settings.remote.resumeSaving": {
+    "comment": "Button that finishes a half-completed join",
+    "value": "Resume saving"
+  },
+  "settings.remote.retrySaving": {
+    "comment": "Button that retries a failed save",
+    "value": "Retry saving"
+  },
+  "settings.remote.statusWithCode": {
+    "comment": "Sync status line: a translated title and the raw status code",
+    "value": "{title} · {code}"
+  },
+  "settings.remote.syncNow": {
+    "comment": "Button that pulls remote batches immediately",
+    "value": "Sync now"
+  },
+  "settings.remote.workspace": {
+    "comment": "Row label for the workspace id",
+    "value": "Workspace"
+  },
+  "settings.repository": {
+    "comment": "Link label",
+    "value": "Repository"
+  },
+  "settings.rescanCostLogs": {
+    "comment": "Button label",
+    "value": "Rescan cost logs"
+  },
+  "settings.search": {
+    "comment": "Placeholder in the settings sidebar's search field",
+    "value": "Search settings"
+  },
+  "settings.section.components": {
+    "comment": "Settings section heading listing bundled components. Distinct from status.card.components, which are a provider's status-page components.",
+    "value": "Components"
+  },
+  "settings.section.costData": {
+    "comment": "Settings section heading",
+    "value": "Cost Data"
+  },
+  "settings.section.layout": {
+    "comment": "Settings section heading for page layout",
+    "value": "Layout"
+  },
+  "settings.section.menuBarHealth": {
+    "comment": "Settings section heading for the status-item watchdog",
+    "value": "Menu Bar Health"
+  },
+  "settings.section.miniWindows": {
+    "comment": "Settings section heading",
+    "value": "Mini Windows"
+  },
+  "settings.section.overview": {
+    "comment": "Settings section heading for the Overview surface",
+    "value": "Overview"
+  },
+  "settings.section.privacy": {
+    "comment": "Settings section heading",
+    "value": "Privacy"
+  },
+  "settings.section.refreshing": {
+    "comment": "Settings section heading for refresh intervals. Distinct from status.overview.refreshing, which says a fetch is in flight.",
+    "value": "Refreshing"
+  },
+  "settings.section.system": {
+    "comment": "Settings section heading for login items and the setup assistant. Distinct from settings.language.system, which is a language-picker option meaning 'follow macOS'.",
+    "value": "System"
+  },
+  "settings.section.updates": {
+    "comment": "Settings section heading for the app updater",
+    "value": "Updates"
+  },
+  "settings.showAssistant": {
+    "comment": "Button that reopens the first-run assistant",
+    "value": "Show setup assistant"
+  },
+  "settings.showAssistantDetail": {
+    "comment": "Caption under the assistant button",
+    "value": "Walk through subscriptions, browser cookies, API keys, model pricing and login items again. Nothing is reset."
+  },
+  "settings.sidebar.coreProviders": {
+    "comment": "Sidebar group heading over the four core provider pages",
+    "value": "Core Providers"
+  },
+  "settings.sidebar.disableProvider": {
+    "comment": "Tooltip on the toggle that turns a misc provider off",
+    "value": "Disable Provider"
+  },
+  "settings.sidebar.enableProvider": {
+    "comment": "Tooltip on the toggle that turns a misc provider on",
+    "value": "Enable Provider"
+  },
+  "settings.sidebar.hideFromOverview": {
+    "comment": "Tooltip on the toggle that removes a provider from the Overview",
+    "value": "Hide from Overview"
+  },
+  "settings.sidebar.settings": {
+    "comment": "Sidebar group heading over the static preference pages",
+    "value": "Settings"
+  },
+  "settings.spaceXAIIntro": {
+    "comment": "Explanation on the SpaceXAI settings page",
+    "value": "The SpaceXAI page combines Grok with Cursor. Grok reads `~/.grok/auth.json` or grok.com cookies; Cursor reads Cursor.app first, then cursor.com cookie slots. Grok Bot contributes quota, plus read-only sessions from its local cache — its cloud runs still add no token/cost rows."
+  },
+  "settings.updateChannel": {
+    "comment": "Picker label",
+    "value": "Update channel"
+  },
+  "settings.updateCheckDetail": {
+    "comment": "Caption under the update controls",
+    "value": "Checks the selected channel once a day and asks before installing."
+  },
+  "settings.usageSource": {
+    "comment": "Picker label choosing where a provider's quota is read from",
+    "value": "Usage source"
+  },
+  "settings.webQuota": {
+    "comment": "Value beside the Gemini source row",
+    "value": "Web quota"
+  },
+  "settings.whatChangedIn": {
+    "comment": "Link to a release's notes; version is a tag name",
+    "value": "What changed in {version}"
   },
   "status.card.componentCount": {
     "args": {

--- a/Resources/i18n/en.json
+++ b/Resources/i18n/en.json
@@ -853,6 +853,98 @@
     "comment": "Toggle in the setup assistant. macOS-only.",
     "value": "Launch Vibe Bar at login"
   },
+  "platform.macos.menuBar.color.actual": {
+    "comment": "Menu-bar colour basis: colour by the displayed percentage. macOS-only.",
+    "value": "Actual"
+  },
+  "platform.macos.menuBar.color.actualDetail": {
+    "comment": "Caption under the Actual colour basis. macOS-only.",
+    "value": "Colored by the displayed percentage alone, ignoring the forecast."
+  },
+  "platform.macos.menuBar.color.forecast": {
+    "comment": "Menu-bar colour basis: colour by the forecast verdict. macOS-only.",
+    "value": "Forecast"
+  },
+  "platform.macos.menuBar.color.forecastDetail": {
+    "comment": "Caption under the Forecast colour basis. macOS-only.",
+    "value": "Green projected to last · blue a chunk will likely go unused · orange may run short · red projected to run out. Falls back to the percentage while a quota has too little history to forecast."
+  },
+  "platform.macos.menuBar.displayDensity": {
+    "comment": "Picker choosing the popover density from the menu-bar editor. macOS-only.",
+    "value": "Display density"
+  },
+  "platform.macos.menuBar.fieldStyle.label": {
+    "comment": "Menu-bar field style: show the field's name. macOS-only.",
+    "value": "Label"
+  },
+  "platform.macos.menuBar.fieldStyle.labelDetail": {
+    "comment": "Caption under the Label field style. macOS-only.",
+    "value": "The field's name beside its percent."
+  },
+  "platform.macos.menuBar.fieldStyle.logo": {
+    "comment": "Menu-bar field style: show the provider's logo. macOS-only.",
+    "value": "Logo"
+  },
+  "platform.macos.menuBar.fieldStyle.logoAndLabel": {
+    "comment": "Menu-bar field style. macOS-only.",
+    "value": "Logo and label"
+  },
+  "platform.macos.menuBar.fieldStyle.logoAndLabelDetail": {
+    "comment": "Caption under the Logo and label field style. macOS-only.",
+    "value": "Logo, name, and percent."
+  },
+  "platform.macos.menuBar.fieldStyle.logoDetail": {
+    "comment": "Caption under the Logo field style. macOS-only.",
+    "value": "The provider's logo beside the percent — no text."
+  },
+  "platform.macos.menuBar.fields": {
+    "comment": "Heading over the menu-bar field checklist. macOS-only.",
+    "value": "Fields"
+  },
+  "platform.macos.menuBar.layout": {
+    "comment": "Picker choosing how the menu-bar item is laid out. macOS-only. Distinct from the Layout settings section, which is about page layout.",
+    "value": "Layout"
+  },
+  "platform.macos.menuBar.layout.compact": {
+    "comment": "Menu-bar layout option. macOS-only.",
+    "value": "Compact"
+  },
+  "platform.macos.menuBar.layout.iconOnly": {
+    "comment": "Menu-bar layout option. macOS-only.",
+    "value": "Icon Only"
+  },
+  "platform.macos.menuBar.layout.singleLine": {
+    "comment": "Menu-bar layout option. macOS-only.",
+    "value": "Single line"
+  },
+  "platform.macos.menuBar.layout.twoRows": {
+    "comment": "Menu-bar layout option. macOS-only.",
+    "value": "Two rows"
+  },
+  "platform.macos.menuBar.mergeGroupWindows": {
+    "comment": "Toggle that folds a quota group's windows into one entry. macOS-only.",
+    "value": "Combine a group's windows"
+  },
+  "platform.macos.menuBar.mergeGroupWindowsDetail": {
+    "comment": "Caption under the combine toggle. macOS-only.",
+    "value": "Shows 5 Hours and Weekly as 5%/100% instead of two entries."
+  },
+  "platform.macos.menuBar.overview": {
+    "comment": "The menu-bar item that summarises every provider. macOS-only.",
+    "value": "Overview"
+  },
+  "platform.macos.menuBar.percentColor": {
+    "comment": "Picker choosing what colours the menu-bar percentage. macOS-only.",
+    "value": "Percent color"
+  },
+  "platform.macos.menuBar.showInMenuBar": {
+    "comment": "Toggle in the menu-bar item editor. macOS-only: no other client renders a menu-bar extra.",
+    "value": "Show in menu bar"
+  },
+  "platform.macos.menuBar.showTitleText": {
+    "comment": "Toggle in the menu-bar item editor. macOS-only.",
+    "value": "Show title text"
+  },
   "popover.header.machinesSubtitle": {
     "comment": "Subtitle under the Machines page header",
     "value": "End-to-end encrypted remote usage"
@@ -1591,6 +1683,26 @@
     "comment": "Error line",
     "value": "Could not delete saved Grok cookies."
   },
+  "settings.credentialSource.apiOnly": {
+    "comment": "Misc-provider credential source option",
+    "value": "API / OAuth only"
+  },
+  "settings.credentialSource.auto": {
+    "comment": "Misc-provider credential source option",
+    "value": "Auto"
+  },
+  "settings.credentialSource.browserOnly": {
+    "comment": "Misc-provider credential source option",
+    "value": "Browser only"
+  },
+  "settings.credentialSource.manualOnly": {
+    "comment": "Misc-provider credential source option",
+    "value": "Manual only"
+  },
+  "settings.credentialSource.off": {
+    "comment": "Misc-provider credential source option: do not fetch at all",
+    "value": "Off"
+  },
   "settings.cursorNoSession": {
     "comment": "Credential state line",
     "value": "No usable Cursor.app session — import cursor.com cookies below."
@@ -1618,6 +1730,14 @@
   "settings.deleteGrokCookies": {
     "comment": "Button label",
     "value": "Delete Grok cookies"
+  },
+  "settings.displayMode.remaining": {
+    "comment": "Segmented option: the percentage shows what is left. Title case because it is a picker option; quota.mode.remaining is the lowercase caption under a bar.",
+    "value": "Remaining"
+  },
+  "settings.displayMode.used": {
+    "comment": "Segmented option: the percentage shows what has been spent",
+    "value": "Used"
   },
   "settings.externalChange.title": {
     "comment": "Banner shown when a second client overwrote a setting this one had changed",
@@ -1790,6 +1910,30 @@
     "comment": "Empty state under the add-bucket list",
     "value": "Every known bucket is already in this window."
   },
+  "settings.miniWindow.density.narrow": {
+    "comment": "Mini-window strip density",
+    "value": "Narrow"
+  },
+  "settings.miniWindow.density.narrowDetail": {
+    "comment": "Caption under the Narrow strip density",
+    "value": "The menu bar's compact style: the same cells at the small size."
+  },
+  "settings.miniWindow.density.roomy": {
+    "comment": "Mini-window strip density",
+    "value": "Roomy"
+  },
+  "settings.miniWindow.density.roomyDetail": {
+    "comment": "Caption under the Roomy strip density",
+    "value": "The menu bar's single-line style: every bucket, full label beside its number."
+  },
+  "settings.miniWindow.density.twoLines": {
+    "comment": "Mini-window strip density",
+    "value": "Two Lines"
+  },
+  "settings.miniWindow.density.twoLinesDetail": {
+    "comment": "Caption under the Two Lines strip density",
+    "value": "Menu-bar style: buckets pair into stacked columns, label beside each number."
+  },
   "settings.miniWindow.dismissBuiltIn": {
     "comment": "Tooltip on the dismiss button of a built-in bucket",
     "value": "Dismiss this built-in bucket while the provider is not returning it. It comes back the moment the provider does."
@@ -1805,6 +1949,62 @@
   "settings.miniWindow.lastCannotBeRemoved": {
     "comment": "Tooltip explaining a disabled remove button",
     "value": "The last mini window cannot be removed."
+  },
+  "settings.miniWindow.mode.compact": {
+    "comment": "Mini-window display style",
+    "value": "Compact"
+  },
+  "settings.miniWindow.mode.compactDetail": {
+    "comment": "Caption under the Compact mini-window style",
+    "value": "The same three tiers as vertical bars, sized for a corner."
+  },
+  "settings.miniWindow.mode.focus": {
+    "comment": "Mini-window display style",
+    "value": "Focus"
+  },
+  "settings.miniWindow.mode.focusDetail": {
+    "comment": "Caption under the Focus mini-window style",
+    "value": "One selected bucket at a time, large — click to cycle in your order."
+  },
+  "settings.miniWindow.mode.ledger": {
+    "comment": "Mini-window display style",
+    "value": "Ledger"
+  },
+  "settings.miniWindow.mode.ledgerDetail": {
+    "comment": "Caption under the Ledger mini-window style",
+    "value": "One row per quota bucket — fixed width, grows downward."
+  },
+  "settings.miniWindow.mode.rail": {
+    "comment": "Mini-window display style",
+    "value": "Rail"
+  },
+  "settings.miniWindow.mode.railDetail": {
+    "comment": "Caption under the Rail mini-window style",
+    "value": "The next seven days as a refill lane with the coming resets listed."
+  },
+  "settings.miniWindow.mode.regular": {
+    "comment": "Mini-window display style",
+    "value": "Regular"
+  },
+  "settings.miniWindow.mode.regularDetail": {
+    "comment": "Caption under the Regular mini-window style",
+    "value": "Ring gauges grouped company → SubProvider → quota group."
+  },
+  "settings.miniWindow.mode.strip": {
+    "comment": "Mini-window display style",
+    "value": "Strip"
+  },
+  "settings.miniWindow.mode.stripDetail": {
+    "comment": "Caption under the Strip mini-window style",
+    "value": "A slim line mirroring the menu bar's styles — one cell per bucket."
+  },
+  "settings.miniWindow.mode.tiles": {
+    "comment": "Mini-window display style",
+    "value": "Tiles"
+  },
+  "settings.miniWindow.mode.tilesDetail": {
+    "comment": "Caption under the Tiles mini-window style",
+    "value": "A grid of tiles with a big number and a severity stripe."
   },
   "settings.miniWindow.namesAllWindows": {
     "comment": "Segment label: edit the shared names",
@@ -1969,6 +2169,34 @@
     "comment": "Picker label for a provider's service region",
     "value": "Region"
   },
+  "settings.misc.region.auto": {
+    "comment": "Misc-provider region option",
+    "value": "Auto (try both)"
+  },
+  "settings.misc.region.chinaMainland": {
+    "comment": "Alibaba region option",
+    "value": "China mainland (cn-beijing)"
+  },
+  "settings.misc.region.international": {
+    "comment": "Alibaba region option; the region id is never translated",
+    "value": "International (ap-southeast-1)"
+  },
+  "settings.misc.region.minimaxChina": {
+    "comment": "MiniMax region option",
+    "value": "China mainland (minimaxi.com)"
+  },
+  "settings.misc.region.minimaxGlobal": {
+    "comment": "MiniMax region option",
+    "value": "Global (minimax.io)"
+  },
+  "settings.misc.region.zaiChina": {
+    "comment": "Z.ai region option",
+    "value": "China mainland (open.bigmodel.cn)"
+  },
+  "settings.misc.region.zaiGlobal": {
+    "comment": "Z.ai region option; the host is never translated",
+    "value": "Global (api.z.ai)"
+  },
   "settings.misc.removeAkSk": {
     "comment": "Tooltip on the button that clears a stored AK/SK pair",
     "value": "Remove stored {provider} AK/SK"
@@ -2068,6 +2296,30 @@
   "settings.planBadgeDetail": {
     "comment": "Caption under the plan badge field",
     "value": "Leave blank to use the detected account plan."
+  },
+  "settings.popoverDensity.compact": {
+    "comment": "Popover density option",
+    "value": "Compact"
+  },
+  "settings.popoverDensity.compactDetail": {
+    "comment": "Caption under the Compact density",
+    "value": "Tightest spacing, narrowest popover."
+  },
+  "settings.popoverDensity.regular": {
+    "comment": "Popover density option",
+    "value": "Regular"
+  },
+  "settings.popoverDensity.regularDetail": {
+    "comment": "Caption under the Regular density",
+    "value": "Balanced spacing — default."
+  },
+  "settings.popoverDensity.spacious": {
+    "comment": "Popover density option",
+    "value": "Spacious"
+  },
+  "settings.popoverDensity.spaciousDetail": {
+    "comment": "Caption under the Spacious density",
+    "value": "Roomy spacing for big displays."
   },
   "settings.pricing.addOverride": {
     "comment": "Button that appends a blank rate card",
@@ -2340,6 +2592,86 @@
     "comment": "Button label",
     "value": "Rescan cost logs"
   },
+  "settings.route.antigravityLocal": {
+    "comment": "Connection-health row: the local AntiGravity probe or agy CLI",
+    "value": "Local Antigravity / agy"
+  },
+  "settings.route.browserCookies": {
+    "comment": "Connection-health row: cookies imported from a browser",
+    "value": "Chrome/Safari cookies"
+  },
+  "settings.route.cli": {
+    "comment": "Connection-health row: the local CLI credential path",
+    "value": "CLI"
+  },
+  "settings.route.grokAuthFile": {
+    "comment": "Connection-health row: the Grok CLI's credential file. A path, never translated.",
+    "value": "~/.grok/auth.json"
+  },
+  "settings.route.oauth": {
+    "comment": "Connection-health row: the OAuth credential path",
+    "value": "OAuth"
+  },
+  "settings.route.webViewCookies": {
+    "comment": "Connection-health row: cookies from the in-app login window",
+    "value": "WebView cookies"
+  },
+  "settings.routeHealth.agyAvailable": {
+    "comment": "Connection-health detail: the agy CLI is installed",
+    "value": "agy CLI available"
+  },
+  "settings.routeHealth.authFileExpired": {
+    "comment": "Connection-health detail; the filename is never translated",
+    "value": "auth.json expired"
+  },
+  "settings.routeHealth.authFileUnreadable": {
+    "comment": "Connection-health detail",
+    "value": "Could not read auth.json"
+  },
+  "settings.routeHealth.cachedOnly": {
+    "comment": "Connection-health detail",
+    "value": "Cached data only; live quota unavailable"
+  },
+  "settings.routeHealth.credentialUnreadable": {
+    "comment": "Connection-health detail",
+    "value": "Could not read credential"
+  },
+  "settings.routeHealth.credentialsAvailable": {
+    "comment": "Connection-health detail: a usable credential was found",
+    "value": "Credentials available"
+  },
+  "settings.routeHealth.invalidCookie": {
+    "comment": "Connection-health detail",
+    "value": "Invalid cookie data"
+  },
+  "settings.routeHealth.keychainLocked": {
+    "comment": "Connection-health detail",
+    "value": "Keychain locked"
+  },
+  "settings.routeHealth.lspRunning": {
+    "comment": "Connection-health detail: the AntiGravity language server is up",
+    "value": "Local LSP running"
+  },
+  "settings.routeHealth.noAntigravityData": {
+    "comment": "Connection-health detail",
+    "value": "No local Antigravity data"
+  },
+  "settings.routeHealth.noAuthFile": {
+    "comment": "Connection-health detail",
+    "value": "No auth.json"
+  },
+  "settings.routeHealth.noCredential": {
+    "comment": "Connection-health detail",
+    "value": "No credential found"
+  },
+  "settings.routeHealth.noSavedCookie": {
+    "comment": "Connection-health detail",
+    "value": "No saved cookie"
+  },
+  "settings.routeHealth.savedInKeychain": {
+    "comment": "Connection-health detail: a cookie is stored",
+    "value": "Saved in Keychain"
+  },
   "settings.search": {
     "comment": "Placeholder in the settings sidebar's search field",
     "value": "Search settings"
@@ -2355,6 +2687,10 @@
   "settings.section.layout": {
     "comment": "Settings section heading for page layout",
     "value": "Layout"
+  },
+  "settings.section.menuBar": {
+    "comment": "Settings sidebar destination and section heading",
+    "value": "Menu Bar"
   },
   "settings.section.menuBarHealth": {
     "comment": "Settings section heading for the status-item watchdog",
@@ -2375,6 +2711,10 @@
   "settings.section.refreshing": {
     "comment": "Settings section heading for refresh intervals. Distinct from status.overview.refreshing, which says a fetch is in flight.",
     "value": "Refreshing"
+  },
+  "settings.section.remoteProbes": {
+    "comment": "Settings sidebar destination for remote machine sync",
+    "value": "Remote Probes"
   },
   "settings.section.system": {
     "comment": "Settings section heading for login items and the setup assistant. Distinct from settings.language.system, which is a language-picker option meaning 'follow macOS'.",
@@ -2416,13 +2756,165 @@
     "comment": "Explanation on the SpaceXAI settings page",
     "value": "The SpaceXAI page combines Grok with Cursor. Grok reads `~/.grok/auth.json` or grok.com cookies; Cursor reads Cursor.app first, then cursor.com cookie slots. Grok Bot contributes quota, plus read-only sessions from its local cache — its cloud runs still add no token/cost rows."
   },
+  "settings.terminal.copyOnly": {
+    "comment": "Terminal preference: copy the resume command instead of running it. Terminal and iTerm2 are product names and stay as spelled.",
+    "value": "Copy to clipboard"
+  },
   "settings.updateChannel": {
     "comment": "Picker label",
     "value": "Update channel"
   },
+  "settings.updateChannel.dev": {
+    "comment": "Update channel option",
+    "value": "Dev"
+  },
+  "settings.updateChannel.devDetail": {
+    "comment": "Caption under the Dev channel option",
+    "value": "Preview releases plus all Main releases."
+  },
+  "settings.updateChannel.main": {
+    "comment": "Update channel option",
+    "value": "Main"
+  },
+  "settings.updateChannel.mainDetail": {
+    "comment": "Caption under the Main channel option",
+    "value": "Stable releases only."
+  },
   "settings.updateCheckDetail": {
     "comment": "Caption under the update controls",
     "value": "Checks the selected channel once a day and asks before installing."
+  },
+  "settings.usageMode.antigravity.autoDetail": {
+    "comment": "Caption under an AntiGravity usage-source option",
+    "value": "Use the Antigravity app first, then the installed agy CLI; fall back to imported cookies when the web source is available."
+  },
+  "settings.usageMode.antigravity.localFirstDetail": {
+    "comment": "Caption under an AntiGravity usage-source option",
+    "value": "Use the Antigravity app or agy CLI first; fall back to imported cookies."
+  },
+  "settings.usageMode.antigravity.localOnly": {
+    "comment": "AntiGravity usage-source option",
+    "value": "Local sources only"
+  },
+  "settings.usageMode.antigravity.localOnlyDetail": {
+    "comment": "Caption under an AntiGravity usage-source option",
+    "value": "Only use the Antigravity app or installed agy CLI."
+  },
+  "settings.usageMode.antigravity.localThenWeb": {
+    "comment": "AntiGravity usage-source option",
+    "value": "Local sources, then Web"
+  },
+  "settings.usageMode.antigravity.webFirstDetail": {
+    "comment": "Caption under an AntiGravity usage-source option",
+    "value": "Use imported cookies first; fall back to the Antigravity app or agy CLI."
+  },
+  "settings.usageMode.antigravity.webOnly": {
+    "comment": "AntiGravity usage-source option",
+    "value": "Web only"
+  },
+  "settings.usageMode.antigravity.webOnlyDetail": {
+    "comment": "Caption under an AntiGravity usage-source option",
+    "value": "Only use imported cookies. Falls back to the local probe until the Antigravity Cloud endpoint ships."
+  },
+  "settings.usageMode.antigravity.webThenLocal": {
+    "comment": "AntiGravity usage-source option",
+    "value": "Web, then Local sources"
+  },
+  "settings.usageMode.auto": {
+    "comment": "Usage-source option: let Vibe Bar choose the order",
+    "value": "Auto"
+  },
+  "settings.usageMode.claude.autoDetail": {
+    "comment": "Caption under a Claude usage-source option",
+    "value": "Use saved claude.ai cookies first; fall back to Claude OAuth and Claude Code."
+  },
+  "settings.usageMode.claude.codeFirstDetail": {
+    "comment": "Caption under a Claude usage-source option",
+    "value": "Use Claude Code first; fall back to saved claude.ai cookies."
+  },
+  "settings.usageMode.claude.codeOnly": {
+    "comment": "Claude usage-source option",
+    "value": "Claude Code only"
+  },
+  "settings.usageMode.claude.codeOnlyDetail": {
+    "comment": "Caption under a Claude usage-source option",
+    "value": "Use only local Claude Code OAuth credentials."
+  },
+  "settings.usageMode.claude.codeThenWeb": {
+    "comment": "Claude usage-source option",
+    "value": "Claude Code, then Web"
+  },
+  "settings.usageMode.claude.oauthCodeWeb": {
+    "comment": "Claude usage-source option",
+    "value": "OAuth, then Claude Code, then Web"
+  },
+  "settings.usageMode.claude.oauthFirstDetail": {
+    "comment": "Caption under a Claude usage-source option",
+    "value": "Use Claude OAuth first; fall back to Claude Code and saved claude.ai cookies."
+  },
+  "settings.usageMode.claude.oauthOnly": {
+    "comment": "Claude usage-source option",
+    "value": "OAuth only"
+  },
+  "settings.usageMode.claude.oauthOnlyDetail": {
+    "comment": "Caption under a Claude usage-source option",
+    "value": "Use only Claude OAuth credentials."
+  },
+  "settings.usageMode.claude.webFirstDetail": {
+    "comment": "Caption under a Claude usage-source option",
+    "value": "Use saved claude.ai cookies first; fall back to Claude Code and OAuth."
+  },
+  "settings.usageMode.claude.webOnly": {
+    "comment": "Claude usage-source option",
+    "value": "Claude Web only"
+  },
+  "settings.usageMode.claude.webOnlyDetail": {
+    "comment": "Caption under a Claude usage-source option",
+    "value": "Use only saved claude.ai cookies."
+  },
+  "settings.usageMode.claude.webThenCode": {
+    "comment": "Claude usage-source option",
+    "value": "Claude Web, then Claude Code"
+  },
+  "settings.usageMode.codex.autoDetail": {
+    "comment": "Caption under a Codex usage-source option",
+    "value": "Use local Codex CLI credentials first; fall back to Codex OAuth and saved OpenAI web cookies."
+  },
+  "settings.usageMode.codex.cliOnly": {
+    "comment": "Codex usage-source option",
+    "value": "CLI only"
+  },
+  "settings.usageMode.codex.cliOnlyDetail": {
+    "comment": "Caption under a Codex usage-source option",
+    "value": "Use only local Codex CLI credentials."
+  },
+  "settings.usageMode.codex.cliThenOauth": {
+    "comment": "Codex usage-source option",
+    "value": "CLI, then OAuth"
+  },
+  "settings.usageMode.codex.oauthFirstDetail": {
+    "comment": "Caption under a Codex usage-source option",
+    "value": "Use Codex OAuth first; fall back to local Codex CLI credentials and saved OpenAI web cookies."
+  },
+  "settings.usageMode.codex.oauthOnly": {
+    "comment": "Codex usage-source option",
+    "value": "OAuth only"
+  },
+  "settings.usageMode.codex.oauthOnlyDetail": {
+    "comment": "Caption under a Codex usage-source option",
+    "value": "Use only Codex OAuth credentials from auth.json."
+  },
+  "settings.usageMode.codex.oauthThenCli": {
+    "comment": "Codex usage-source option",
+    "value": "OAuth, then CLI"
+  },
+  "settings.usageMode.gemini.webOnly": {
+    "comment": "Gemini usage-source option",
+    "value": "Gemini Web only"
+  },
+  "settings.usageMode.gemini.webOnlyDetail": {
+    "comment": "Caption under the Gemini usage-source option",
+    "value": "Only fetch imported gemini.google.com cookies."
   },
   "settings.usageSource": {
     "comment": "Picker label choosing where a provider's quota is read from",

--- a/Resources/i18n/en.json
+++ b/Resources/i18n/en.json
@@ -957,6 +957,46 @@
     "comment": "Subtitle under the Overview page header",
     "value": "All providers · quota & cost"
   },
+  "popover.machines.checking": {
+    "comment": "Empty-state title while a sync is in flight",
+    "value": "Checking the Relay…"
+  },
+  "popover.machines.includeInTotals": {
+    "comment": "Toggle on a remote machine card",
+    "value": "Include in totals"
+  },
+  "popover.machines.includeInTotalsHelp": {
+    "comment": "Tooltip on the include-in-totals toggle",
+    "value": "Add this machine's decrypted usage to Overview and provider cost pages on this Core"
+  },
+  "popover.machines.labelWithStatus": {
+    "comment": "A source label followed by its status; both halves arrive already localized",
+    "value": "{label} · {status}"
+  },
+  "popover.machines.noData": {
+    "comment": "Empty-state title when the Relay is connected but nothing has arrived",
+    "value": "No remote machine data yet"
+  },
+  "popover.machines.noDataDetail": {
+    "comment": "Empty-state body on the Machines page",
+    "value": "The Relay is connected. A Probe will appear after its first encrypted batch is decrypted and imported."
+  },
+  "popover.machines.notConfigured": {
+    "comment": "Empty-state title on the Machines page",
+    "value": "Remote Core is not configured"
+  },
+  "popover.machines.notConfiguredDetail": {
+    "comment": "Empty-state body on the Machines page",
+    "value": "Create a Core descriptor, provision a workspace-scoped Relay credential, then import the signed provisioning file. No inbound port is required on this Mac."
+  },
+  "popover.machines.sequence": {
+    "comment": "The last imported batch's sequence number on a machine card; the number is raw",
+    "value": "seq {value}"
+  },
+  "popover.machines.thirtyDayCost": {
+    "comment": "Metric label on a remote machine card",
+    "value": "30-day cost"
+  },
   "popover.refreshGoogleAI": {
     "comment": "Tooltip on the Google AI page's refresh button; the SubProvider names are never translated",
     "value": "Refresh Gemini Web + AntiGravity"
@@ -2575,6 +2615,78 @@
   "settings.remote.statusWithCode": {
     "comment": "Sync status line: a translated title and the raw status code",
     "value": "{title} · {code}"
+  },
+  "settings.remote.sync.busy": {
+    "comment": "Remote sync status title for HTTP 429/503",
+    "value": "Relay is temporarily busy"
+  },
+  "settings.remote.sync.connectionFailed": {
+    "comment": "Remote sync status title",
+    "value": "Relay connection was interrupted"
+  },
+  "settings.remote.sync.hostLookupFailed": {
+    "comment": "Remote sync status title",
+    "value": "Relay host could not be resolved"
+  },
+  "settings.remote.sync.invalidResponse": {
+    "comment": "Remote sync status title",
+    "value": "Relay returned an unexpected response"
+  },
+  "settings.remote.sync.networkDetail": {
+    "comment": "Remote sync status detail for an offline or DNS failure",
+    "value": "Check this Mac's network or proxy path; existing machine data is still available."
+  },
+  "settings.remote.sync.offline": {
+    "comment": "Remote sync status title. The error code beside it is a machine-readable identifier and stays English.",
+    "value": "This Mac is offline"
+  },
+  "settings.remote.sync.rejected": {
+    "comment": "Remote sync status title for HTTP 401/403",
+    "value": "Relay access was rejected"
+  },
+  "settings.remote.sync.rejectedDetail": {
+    "comment": "Remote sync status detail for HTTP 401/403",
+    "value": "The workspace credential may have been revoked. Reconnect this Core in Settings."
+  },
+  "settings.remote.sync.retryDetail": {
+    "comment": "Remote sync status detail for a transient transport failure",
+    "value": "Existing machine data is still available. Vibe Bar will retry automatically."
+  },
+  "settings.remote.sync.secureConnectionFailed": {
+    "comment": "Remote sync status title",
+    "value": "Secure Relay connection failed"
+  },
+  "settings.remote.sync.sequenceGap": {
+    "comment": "Remote sync status title",
+    "value": "Probe history has a sequence gap"
+  },
+  "settings.remote.sync.sequenceGapDetail": {
+    "comment": "Remote sync status detail",
+    "value": "A Probe batch is missing from the Relay stream, so later batches were not imported."
+  },
+  "settings.remote.sync.timeout": {
+    "comment": "Remote sync status title",
+    "value": "Relay connection timed out"
+  },
+  "settings.remote.sync.transportFailed": {
+    "comment": "Remote sync status title",
+    "value": "Relay transport failed"
+  },
+  "settings.remote.sync.unknown": {
+    "comment": "Remote sync status title for a code this build does not recognize. A new Relay error code must still render a sentence.",
+    "value": "Remote sync needs attention"
+  },
+  "settings.remote.sync.unknownDetail": {
+    "comment": "Remote sync status detail for an unrecognized code",
+    "value": "No local usage was deleted. Retry now or inspect Remote Core settings for the error code."
+  },
+  "settings.remote.sync.unverifiedProbe": {
+    "comment": "Remote sync status title for an invalid signature or unauthorized producer",
+    "value": "A Probe could not be verified"
+  },
+  "settings.remote.sync.unverifiedProbeDetail": {
+    "comment": "Remote sync status detail",
+    "value": "The current workspace roster does not authorize one of the received batches."
   },
   "settings.remote.syncNow": {
     "comment": "Button that pulls remote batches immediately",

--- a/Resources/i18n/zh-Hans.json
+++ b/Resources/i18n/zh-Hans.json
@@ -668,6 +668,36 @@
   "popover.header.overviewSubtitle": {
     "value": "全部厂商 · 额度与花费"
   },
+  "popover.machines.checking": {
+    "value": "正在检查 Relay…"
+  },
+  "popover.machines.includeInTotals": {
+    "value": "计入总计"
+  },
+  "popover.machines.includeInTotalsHelp": {
+    "value": "把这台机器解密后的用量计入本 Core 的总览与厂商花费页"
+  },
+  "popover.machines.labelWithStatus": {
+    "value": "{label} · {status}"
+  },
+  "popover.machines.noData": {
+    "value": "暂无远程机器数据"
+  },
+  "popover.machines.noDataDetail": {
+    "value": "Relay 已连接。探针会在其首个加密批次被解密并导入后出现。"
+  },
+  "popover.machines.notConfigured": {
+    "value": "尚未配置远程 Core"
+  },
+  "popover.machines.notConfiguredDetail": {
+    "value": "先创建 Core 描述文件，再签发工作区范围的 Relay 凭据，然后导入已签名的配置文件。本机无需开放任何入站端口。"
+  },
+  "popover.machines.sequence": {
+    "value": "序号 {value}"
+  },
+  "popover.machines.thirtyDayCost": {
+    "value": "近 30 天花费"
+  },
   "popover.refreshGoogleAI": {
     "value": "刷新 Gemini Web + AntiGravity"
   },
@@ -1795,6 +1825,60 @@
   },
   "settings.remote.statusWithCode": {
     "value": "{title} · {code}"
+  },
+  "settings.remote.sync.busy": {
+    "value": "Relay 暂时繁忙"
+  },
+  "settings.remote.sync.connectionFailed": {
+    "value": "Relay 连接中断"
+  },
+  "settings.remote.sync.hostLookupFailed": {
+    "value": "无法解析 Relay 主机"
+  },
+  "settings.remote.sync.invalidResponse": {
+    "value": "Relay 返回了预期之外的响应"
+  },
+  "settings.remote.sync.networkDetail": {
+    "value": "请检查本机的网络或代理设置；已有的机器数据仍然可用。"
+  },
+  "settings.remote.sync.offline": {
+    "value": "本机当前离线"
+  },
+  "settings.remote.sync.rejected": {
+    "value": "Relay 拒绝了访问"
+  },
+  "settings.remote.sync.rejectedDetail": {
+    "value": "工作区凭据可能已被吊销，请在设置中重新连接本 Core。"
+  },
+  "settings.remote.sync.retryDetail": {
+    "value": "已有的机器数据仍然可用，Vibe Bar 会自动重试。"
+  },
+  "settings.remote.sync.secureConnectionFailed": {
+    "value": "Relay 安全连接失败"
+  },
+  "settings.remote.sync.sequenceGap": {
+    "value": "探针历史存在序号缺口"
+  },
+  "settings.remote.sync.sequenceGapDetail": {
+    "value": "Relay 流中缺少一个探针批次，因此后续批次未被导入。"
+  },
+  "settings.remote.sync.timeout": {
+    "value": "Relay 连接超时"
+  },
+  "settings.remote.sync.transportFailed": {
+    "value": "Relay 传输失败"
+  },
+  "settings.remote.sync.unknown": {
+    "value": "远程同步需要处理"
+  },
+  "settings.remote.sync.unknownDetail": {
+    "value": "本地用量未被删除。可立即重试，或在「远程 Core」设置中查看错误码。"
+  },
+  "settings.remote.sync.unverifiedProbe": {
+    "value": "有探针无法通过校验"
+  },
+  "settings.remote.sync.unverifiedProbeDetail": {
+    "value": "当前工作区名单未授权收到的某个批次。"
   },
   "settings.remote.syncNow": {
     "value": "立即同步"

--- a/Resources/i18n/zh-Hans.json
+++ b/Resources/i18n/zh-Hans.json
@@ -590,6 +590,75 @@
   "platform.macos.launchAtLogin.toggle": {
     "value": "登录时启动 Vibe Bar"
   },
+  "platform.macos.menuBar.color.actual": {
+    "value": "实际"
+  },
+  "platform.macos.menuBar.color.actualDetail": {
+    "value": "仅按显示的百分比着色，忽略预测。"
+  },
+  "platform.macos.menuBar.color.forecast": {
+    "value": "预测"
+  },
+  "platform.macos.menuBar.color.forecastDetail": {
+    "value": "绿色表示预计够用 · 蓝色表示预计会有较多闲置 · 橙色表示可能不足 · 红色表示预计会用尽。当某项额度历史过少、无法预测时，回退为按百分比着色。"
+  },
+  "platform.macos.menuBar.displayDensity": {
+    "value": "显示密度"
+  },
+  "platform.macos.menuBar.fieldStyle.label": {
+    "value": "名称"
+  },
+  "platform.macos.menuBar.fieldStyle.labelDetail": {
+    "value": "名称与百分比并列。"
+  },
+  "platform.macos.menuBar.fieldStyle.logo": {
+    "value": "图标"
+  },
+  "platform.macos.menuBar.fieldStyle.logoAndLabel": {
+    "value": "图标与名称"
+  },
+  "platform.macos.menuBar.fieldStyle.logoAndLabelDetail": {
+    "value": "图标、名称与百分比。"
+  },
+  "platform.macos.menuBar.fieldStyle.logoDetail": {
+    "value": "厂商图标与百分比并列 — 不显示文字。"
+  },
+  "platform.macos.menuBar.fields": {
+    "value": "字段"
+  },
+  "platform.macos.menuBar.layout": {
+    "value": "排布"
+  },
+  "platform.macos.menuBar.layout.compact": {
+    "value": "紧凑"
+  },
+  "platform.macos.menuBar.layout.iconOnly": {
+    "value": "仅图标"
+  },
+  "platform.macos.menuBar.layout.singleLine": {
+    "value": "单行"
+  },
+  "platform.macos.menuBar.layout.twoRows": {
+    "value": "双行"
+  },
+  "platform.macos.menuBar.mergeGroupWindows": {
+    "value": "合并同组的窗口"
+  },
+  "platform.macos.menuBar.mergeGroupWindowsDetail": {
+    "value": "把 5 小时与每周显示为 5%/100%，而不是两条独立条目。"
+  },
+  "platform.macos.menuBar.overview": {
+    "value": "总览"
+  },
+  "platform.macos.menuBar.percentColor": {
+    "value": "百分比配色"
+  },
+  "platform.macos.menuBar.showInMenuBar": {
+    "value": "在菜单栏中显示"
+  },
+  "platform.macos.menuBar.showTitleText": {
+    "value": "显示标题文字"
+  },
   "popover.header.machinesSubtitle": {
     "value": "端到端加密的远程用量"
   },
@@ -1064,6 +1133,21 @@
   "settings.couldNotDeleteGrokCookies": {
     "value": "无法删除已保存的 Grok cookies。"
   },
+  "settings.credentialSource.apiOnly": {
+    "value": "仅 API / OAuth"
+  },
+  "settings.credentialSource.auto": {
+    "value": "自动"
+  },
+  "settings.credentialSource.browserOnly": {
+    "value": "仅浏览器"
+  },
+  "settings.credentialSource.manualOnly": {
+    "value": "仅手动"
+  },
+  "settings.credentialSource.off": {
+    "value": "关闭"
+  },
   "settings.cursorNoSession": {
     "value": "没有可用的 Cursor.app 会话 — 请在下方导入 cursor.com 的 cookies。"
   },
@@ -1084,6 +1168,12 @@
   },
   "settings.deleteGrokCookies": {
     "value": "删除 Grok 的 cookies"
+  },
+  "settings.displayMode.remaining": {
+    "value": "剩余"
+  },
+  "settings.displayMode.used": {
+    "value": "已用"
   },
   "settings.externalChange.title": {
     "value": "另一个 Vibe Bar 覆盖了此处的修改"
@@ -1211,6 +1301,24 @@
   "settings.miniWindow.allBucketsIncluded": {
     "value": "已知的 bucket 都已在此窗口中。"
   },
+  "settings.miniWindow.density.narrow": {
+    "value": "紧凑"
+  },
+  "settings.miniWindow.density.narrowDetail": {
+    "value": "菜单栏的紧凑样式：同样的单元，尺寸更小。"
+  },
+  "settings.miniWindow.density.roomy": {
+    "value": "宽松"
+  },
+  "settings.miniWindow.density.roomyDetail": {
+    "value": "菜单栏的单行样式：显示全部 bucket，名称与数字并列。"
+  },
+  "settings.miniWindow.density.twoLines": {
+    "value": "双行"
+  },
+  "settings.miniWindow.density.twoLinesDetail": {
+    "value": "菜单栏样式：bucket 两两成列堆叠，每个数字旁附名称。"
+  },
   "settings.miniWindow.dismissBuiltIn": {
     "value": "在厂商未返回该内置 bucket 期间将其隐藏。厂商一旦恢复返回，它便会重新出现。"
   },
@@ -1222,6 +1330,48 @@
   },
   "settings.miniWindow.lastCannotBeRemoved": {
     "value": "最后一个迷你窗口无法移除。"
+  },
+  "settings.miniWindow.mode.compact": {
+    "value": "紧凑"
+  },
+  "settings.miniWindow.mode.compactDetail": {
+    "value": "同样的三层结构，改为竖条，适合放在屏幕角落。"
+  },
+  "settings.miniWindow.mode.focus": {
+    "value": "聚焦"
+  },
+  "settings.miniWindow.mode.focusDetail": {
+    "value": "一次只显示一个选定 bucket，尺寸更大 — 点击按设定顺序切换。"
+  },
+  "settings.miniWindow.mode.ledger": {
+    "value": "清单"
+  },
+  "settings.miniWindow.mode.ledgerDetail": {
+    "value": "每个额度 bucket 一行 — 宽度固定，向下延伸。"
+  },
+  "settings.miniWindow.mode.rail": {
+    "value": "时间轴"
+  },
+  "settings.miniWindow.mode.railDetail": {
+    "value": "把未来 7 天画成一条补额轴，并列出即将到来的重置。"
+  },
+  "settings.miniWindow.mode.regular": {
+    "value": "标准"
+  },
+  "settings.miniWindow.mode.regularDetail": {
+    "value": "环形仪表，按 company → SubProvider → 额度组分组。"
+  },
+  "settings.miniWindow.mode.strip": {
+    "value": "条带"
+  },
+  "settings.miniWindow.mode.stripDetail": {
+    "value": "与菜单栏样式一致的细长条 — 每个 bucket 一格。"
+  },
+  "settings.miniWindow.mode.tiles": {
+    "value": "磁贴"
+  },
+  "settings.miniWindow.mode.tilesDetail": {
+    "value": "磁贴网格，含大号数字与状态色条。"
   },
   "settings.miniWindow.namesAllWindows": {
     "value": "名称：全部窗口"
@@ -1343,6 +1493,27 @@
   "settings.misc.region": {
     "value": "区域"
   },
+  "settings.misc.region.auto": {
+    "value": "自动（两者都试）"
+  },
+  "settings.misc.region.chinaMainland": {
+    "value": "中国大陆（cn-beijing）"
+  },
+  "settings.misc.region.international": {
+    "value": "国际站（ap-southeast-1）"
+  },
+  "settings.misc.region.minimaxChina": {
+    "value": "中国大陆（minimaxi.com）"
+  },
+  "settings.misc.region.minimaxGlobal": {
+    "value": "全球站（minimax.io）"
+  },
+  "settings.misc.region.zaiChina": {
+    "value": "中国大陆（open.bigmodel.cn）"
+  },
+  "settings.misc.region.zaiGlobal": {
+    "value": "全球站（api.z.ai）"
+  },
   "settings.misc.removeAkSk": {
     "value": "移除已保存的 {provider} AK/SK"
   },
@@ -1417,6 +1588,24 @@
   },
   "settings.planBadgeDetail": {
     "value": "留空则使用自动检测到的账号套餐。"
+  },
+  "settings.popoverDensity.compact": {
+    "value": "紧凑"
+  },
+  "settings.popoverDensity.compactDetail": {
+    "value": "间距最紧，面板最窄。"
+  },
+  "settings.popoverDensity.regular": {
+    "value": "标准"
+  },
+  "settings.popoverDensity.regularDetail": {
+    "value": "间距均衡 — 默认。"
+  },
+  "settings.popoverDensity.spacious": {
+    "value": "宽松"
+  },
+  "settings.popoverDensity.spaciousDetail": {
+    "value": "间距宽裕，适合大屏。"
   },
   "settings.pricing.addOverride": {
     "value": "添加模型覆盖值"
@@ -1619,6 +1808,66 @@
   "settings.rescanCostLogs": {
     "value": "重新扫描花费日志"
   },
+  "settings.route.antigravityLocal": {
+    "value": "本地 Antigravity / agy"
+  },
+  "settings.route.browserCookies": {
+    "value": "Chrome/Safari cookies"
+  },
+  "settings.route.cli": {
+    "value": "CLI"
+  },
+  "settings.route.grokAuthFile": {
+    "value": "~/.grok/auth.json"
+  },
+  "settings.route.oauth": {
+    "value": "OAuth"
+  },
+  "settings.route.webViewCookies": {
+    "value": "WebView cookies"
+  },
+  "settings.routeHealth.agyAvailable": {
+    "value": "agy CLI 可用"
+  },
+  "settings.routeHealth.authFileExpired": {
+    "value": "auth.json 已过期"
+  },
+  "settings.routeHealth.authFileUnreadable": {
+    "value": "无法读取 auth.json"
+  },
+  "settings.routeHealth.cachedOnly": {
+    "value": "仅有缓存数据；无法获取实时额度"
+  },
+  "settings.routeHealth.credentialUnreadable": {
+    "value": "无法读取凭据"
+  },
+  "settings.routeHealth.credentialsAvailable": {
+    "value": "凭据可用"
+  },
+  "settings.routeHealth.invalidCookie": {
+    "value": "cookie 数据无效"
+  },
+  "settings.routeHealth.keychainLocked": {
+    "value": "Keychain 已锁定"
+  },
+  "settings.routeHealth.lspRunning": {
+    "value": "本地 LSP 正在运行"
+  },
+  "settings.routeHealth.noAntigravityData": {
+    "value": "没有本地 Antigravity 数据"
+  },
+  "settings.routeHealth.noAuthFile": {
+    "value": "没有 auth.json"
+  },
+  "settings.routeHealth.noCredential": {
+    "value": "未找到凭据"
+  },
+  "settings.routeHealth.noSavedCookie": {
+    "value": "没有已保存的 cookie"
+  },
+  "settings.routeHealth.savedInKeychain": {
+    "value": "已保存到 Keychain"
+  },
   "settings.search": {
     "value": "搜索设置"
   },
@@ -1630,6 +1879,9 @@
   },
   "settings.section.layout": {
     "value": "布局"
+  },
+  "settings.section.menuBar": {
+    "value": "菜单栏"
   },
   "settings.section.menuBarHealth": {
     "value": "菜单栏健康"
@@ -1645,6 +1897,9 @@
   },
   "settings.section.refreshing": {
     "value": "刷新"
+  },
+  "settings.section.remoteProbes": {
+    "value": "远程探针"
   },
   "settings.section.system": {
     "value": "系统"
@@ -1676,11 +1931,125 @@
   "settings.spaceXAIIntro": {
     "value": "SpaceXAI 页面同时包含 Grok 与 Cursor。Grok 读取 `~/.grok/auth.json` 或 grok.com 的 cookies；Cursor 先读 Cursor.app，再读 cursor.com 的 cookie 槽位。Grok Bot 提供额度，以及来自本地缓存的只读会话 — 其云端运行仍不产生 token 或花费记录。"
   },
+  "settings.terminal.copyOnly": {
+    "value": "复制到剪贴板"
+  },
   "settings.updateChannel": {
     "value": "更新通道"
   },
+  "settings.updateChannel.dev": {
+    "value": "预览版"
+  },
+  "settings.updateChannel.devDetail": {
+    "value": "预览版本，以及全部正式版本。"
+  },
+  "settings.updateChannel.main": {
+    "value": "正式版"
+  },
+  "settings.updateChannel.mainDetail": {
+    "value": "仅稳定版本。"
+  },
   "settings.updateCheckDetail": {
     "value": "每天检查一次所选通道，安装前会先询问。"
+  },
+  "settings.usageMode.antigravity.autoDetail": {
+    "value": "优先使用 Antigravity 应用，其次是本机安装的 agy CLI；在网页来源可用时回退到已导入的 cookies。"
+  },
+  "settings.usageMode.antigravity.localFirstDetail": {
+    "value": "优先使用 Antigravity 应用或 agy CLI；其次回退到已导入的 cookies。"
+  },
+  "settings.usageMode.antigravity.localOnly": {
+    "value": "仅本地来源"
+  },
+  "settings.usageMode.antigravity.localOnlyDetail": {
+    "value": "仅使用 Antigravity 应用或本机安装的 agy CLI。"
+  },
+  "settings.usageMode.antigravity.localThenWeb": {
+    "value": "先本地来源，后网页"
+  },
+  "settings.usageMode.antigravity.webFirstDetail": {
+    "value": "优先使用已导入的 cookies；其次回退到 Antigravity 应用或 agy CLI。"
+  },
+  "settings.usageMode.antigravity.webOnly": {
+    "value": "仅网页"
+  },
+  "settings.usageMode.antigravity.webOnlyDetail": {
+    "value": "仅使用已导入的 cookies。在 Antigravity Cloud 端点上线前会回退到本地探测。"
+  },
+  "settings.usageMode.antigravity.webThenLocal": {
+    "value": "先网页，后本地来源"
+  },
+  "settings.usageMode.auto": {
+    "value": "自动"
+  },
+  "settings.usageMode.claude.autoDetail": {
+    "value": "优先使用已保存的 claude.ai cookies；其次回退到 Claude OAuth 与 Claude Code。"
+  },
+  "settings.usageMode.claude.codeFirstDetail": {
+    "value": "优先使用 Claude Code；其次回退到已保存的 claude.ai cookies。"
+  },
+  "settings.usageMode.claude.codeOnly": {
+    "value": "仅 Claude Code"
+  },
+  "settings.usageMode.claude.codeOnlyDetail": {
+    "value": "仅使用本地 Claude Code 的 OAuth 凭据。"
+  },
+  "settings.usageMode.claude.codeThenWeb": {
+    "value": "先 Claude Code，后网页"
+  },
+  "settings.usageMode.claude.oauthCodeWeb": {
+    "value": "依次使用 OAuth、Claude Code、网页"
+  },
+  "settings.usageMode.claude.oauthFirstDetail": {
+    "value": "优先使用 Claude OAuth；其次回退到 Claude Code 与已保存的 claude.ai cookies。"
+  },
+  "settings.usageMode.claude.oauthOnly": {
+    "value": "仅 OAuth"
+  },
+  "settings.usageMode.claude.oauthOnlyDetail": {
+    "value": "仅使用 Claude OAuth 凭据。"
+  },
+  "settings.usageMode.claude.webFirstDetail": {
+    "value": "优先使用已保存的 claude.ai cookies；其次回退到 Claude Code 与 OAuth。"
+  },
+  "settings.usageMode.claude.webOnly": {
+    "value": "仅 Claude 网页"
+  },
+  "settings.usageMode.claude.webOnlyDetail": {
+    "value": "仅使用已保存的 claude.ai cookies。"
+  },
+  "settings.usageMode.claude.webThenCode": {
+    "value": "先 Claude 网页，后 Claude Code"
+  },
+  "settings.usageMode.codex.autoDetail": {
+    "value": "优先使用本地 Codex CLI 凭据；其次回退到 Codex OAuth 与已保存的 OpenAI 网页 cookies。"
+  },
+  "settings.usageMode.codex.cliOnly": {
+    "value": "仅 CLI"
+  },
+  "settings.usageMode.codex.cliOnlyDetail": {
+    "value": "仅使用本地 Codex CLI 凭据。"
+  },
+  "settings.usageMode.codex.cliThenOauth": {
+    "value": "先 CLI，后 OAuth"
+  },
+  "settings.usageMode.codex.oauthFirstDetail": {
+    "value": "优先使用 Codex OAuth；其次回退到本地 Codex CLI 凭据与已保存的 OpenAI 网页 cookies。"
+  },
+  "settings.usageMode.codex.oauthOnly": {
+    "value": "仅 OAuth"
+  },
+  "settings.usageMode.codex.oauthOnlyDetail": {
+    "value": "仅使用 auth.json 中的 Codex OAuth 凭据。"
+  },
+  "settings.usageMode.codex.oauthThenCli": {
+    "value": "先 OAuth，后 CLI"
+  },
+  "settings.usageMode.gemini.webOnly": {
+    "value": "仅 Gemini Web"
+  },
+  "settings.usageMode.gemini.webOnlyDetail": {
+    "value": "仅读取已导入的 gemini.google.com cookies。"
   },
   "settings.usageSource": {
     "value": "用量来源"

--- a/Resources/i18n/zh-Hans.json
+++ b/Resources/i18n/zh-Hans.json
@@ -150,7 +150,7 @@
     "value": "{title} — 完整图表"
   },
   "cost.gemini.emptyDetail": {
-    "value": "Vibe Bar 会优先从 AntiGravity 桌面端读取实时额度，其次回退到本机安装的 agy CLI。两个本地来源都刷新不了时，缓存值会标记为已过期。"
+    "value": "Vibe Bar 会优先从 AntiGravity 桌面端读取实时额度，其次回退到本机安装的 agy CLI。两个本地来源均无法刷新时，缓存值将标记为已过期。"
   },
   "cost.gemini.emptyTitle": {
     "value": "暂未发现 Gemini 或 AntiGravity 的用量。"
@@ -183,10 +183,10 @@
     "value": "近 30 天 token"
   },
   "cost.metric.today": {
-    "value": "今天"
+    "value": "今日"
   },
   "cost.metric.todayTokens": {
-    "value": "今天 token"
+    "value": "今日 token"
   },
   "cost.metric.totalCost": {
     "value": "总花费"
@@ -195,10 +195,10 @@
     "value": "总 token"
   },
   "cost.metric.yesterday": {
-    "value": "昨天"
+    "value": "昨日"
   },
   "cost.metric.yesterdayTokens": {
-    "value": "昨天 token"
+    "value": "昨日 token"
   },
   "cost.modelRanking.allProvidersAllTime": {
     "value": "全部厂商 · 全部时间"
@@ -249,7 +249,7 @@
     "value": "30 天"
   },
   "cost.timeframe.today": {
-    "value": "今天"
+    "value": "今日"
   },
   "cost.timeframe.week": {
     "value": "7 天"
@@ -258,7 +258,7 @@
     "value": "7 天"
   },
   "cost.timeframe.yesterday": {
-    "value": "昨天"
+    "value": "昨日"
   },
   "cost.title": {
     "value": "花费"
@@ -306,7 +306,7 @@
     "value": "收起"
   },
   "onboarding.apiKeys.intro": {
-    "value": "这些套餐靠 API key 或控制台 cookie 跟踪，而不是 CLI 登录。勾选你有的那些 — 勾选后会在「其他厂商」页得到一张卡片 — 展开某一行即可现在填写凭据。密钥和 cookies 都会存进你的登录 Keychain。"
+    "value": "这些套餐通过 API key 或控制台 cookie 跟踪，而非 CLI 登录。勾选已持有的项 — 勾选后将在「其他厂商」页生成一张卡片 — 展开对应行即可填写凭据。密钥与 cookies 均存入登录 Keychain。"
   },
   "onboarding.apiKeys.setUp": {
     "value": "设置"
@@ -321,7 +321,7 @@
     "value": "下一步"
   },
   "onboarding.cookies.batchScope": {
-    "value": "这个按钮只覆盖上面四个套餐。下一步的控制台 cookie 套餐有各自的一键批量导入，在「设置 → 浏览器 Cookies」里。"
+    "value": "此按钮仅覆盖上述四个套餐。下一步的控制台 cookie 套餐另有一键批量导入，位于「设置 → 浏览器 Cookies」。"
   },
   "onboarding.cookies.importAll": {
     "value": "立即从所有浏览器导入"
@@ -339,7 +339,7 @@
     "value": "正在导入…"
   },
   "onboarding.cookies.intro": {
-    "value": "网页端额度 — 也就是厂商在自己网站上显示的那份 — 来自浏览器里已有的登录会话。Vibe Bar 会读取这台 Mac 上各浏览器（Chrome 及其他 Chromium 浏览器、Safari、Firefox）的 cookie 存储，只保留每个厂商真正需要的那几条，并存进你的登录 Keychain，绝不写入明文文件。首次读取浏览器的 cookie 密钥时，macOS 可能会要求授权一次。"
+    "value": "网页端额度 — 即厂商在其自有网站上展示的部分 — 来自浏览器中已有的登录会话。Vibe Bar 会读取本机各浏览器（Chrome 及其他 Chromium 浏览器、Safari、Firefox）的 cookie 存储，仅保留各厂商所需的少量 cookie，并存入登录 Keychain，不写入明文文件。首次读取浏览器 cookie 密钥时，macOS 可能要求授权一次。"
   },
   "onboarding.cookies.notImported": {
     "value": "尚未导入"
@@ -351,7 +351,7 @@
     "value": "cookies 已保存。"
   },
   "onboarding.cookies.signInFirst": {
-    "value": "请先在浏览器里登录 chatgpt.com、claude.ai、gemini.google.com 或 grok.com — 导入只能找到已经存在的会话。没登录过的厂商不会有任何结果。"
+    "value": "请先在浏览器中登录 chatgpt.com、claude.ai、gemini.google.com 或 grok.com — 导入只能找到已存在的会话；未登录的厂商不会返回任何结果。"
   },
   "onboarding.done.apiKeyProviders": {
     "value": "API key 厂商"
@@ -363,16 +363,16 @@
     "value": "已保存 {saved}/{total} 个厂商"
   },
   "onboarding.done.footer": {
-    "value": "这里的每一项在设置里都能改，向导本身也在「设置 → 系统」里一键可达。"
+    "value": "此处各项均可在设置中修改，向导亦可在「设置 → 系统」中一键打开。"
   },
   "onboarding.done.intro": {
-    "value": "菜单栏需要的都齐了。点「完成」会打开面板并显示当前已能读到的额度，其余的会在第一次刷新时补上。"
+    "value": "菜单栏所需配置已齐备。点击「完成」将打开面板并显示当前可读取的额度，其余部分在首次刷新时补全。"
   },
   "onboarding.done.launchAtLogin": {
     "value": "开机启动"
   },
   "onboarding.done.miscCount": {
-    "value": "「其他厂商」页有 {count} 个"
+    "value": "「其他厂商」页 {count} 个"
   },
   "onboarding.done.modelPricing": {
     "value": "模型价格"
@@ -399,7 +399,7 @@
     "value": "正在获取…"
   },
   "onboarding.pricing.footer": {
-    "value": "价格单位是每百万 token 的美元数。本地覆盖值在「设置 → 模型价格」里。"
+    "value": "价格单位为每百万 token 的美元数。本地覆盖值位于「设置 → 模型价格」。"
   },
   "onboarding.pricing.interval.hour": {
     "value": "小时"
@@ -408,7 +408,7 @@
     "value": "{hours} 小时"
   },
   "onboarding.pricing.intro": {
-    "value": "Token 花费完全在这台 Mac 上按 agent 的会话日志计算，价格来自若干公开价目表合并后的目录 — 同一个模型出现在多处时优先级高的胜出，你自己的覆盖值优先于全部，内置表是离线兜底。目录每 {interval}在后台刷新一次；现在抓一次能让第一批费用数字用上当前价格。"
+    "value": "Token 花费完全在本机依据 agent 的会话日志计算，价格取自若干公开价目表合并后的目录 — 同一模型出现在多个目录时以优先级高者为准，自定义覆盖值优先于全部，内置表为离线兜底。目录每 {interval}在后台刷新一次；此刻获取可使首批费用数字采用当前价格。"
   },
   "onboarding.pricing.merged": {
     "value": "{when}合并 · {count} 个模型"
@@ -444,25 +444,25 @@
     "value": "浏览器 cookies"
   },
   "onboarding.step.done.subtitle": {
-    "value": "这里的每一项在设置里也能改。"
+    "value": "此处各项均可在设置中修改。"
   },
   "onboarding.step.done.title": {
     "value": "完成"
   },
   "onboarding.step.pricing.subtitle": {
-    "value": "费用数字背后的 token 单价从哪来。"
+    "value": "费用数字背后的 token 单价来源。"
   },
   "onboarding.step.pricing.title": {
     "value": "模型价格"
   },
   "onboarding.step.subscriptions.subtitle": {
-    "value": "打开你付费的套餐。"
+    "value": "启用已订阅的套餐。"
   },
   "onboarding.step.subscriptions.title": {
     "value": "订阅"
   },
   "onboarding.step.welcome.subtitle": {
-    "value": "一段话讲清 Vibe Bar 能做什么。"
+    "value": "用一段话说明 Vibe Bar 的功能。"
   },
   "onboarding.step.welcome.title": {
     "value": "欢迎"
@@ -486,16 +486,16 @@
     "value": "已保存 ChatGPT 网页 cookies — 额度将从这里读取。"
   },
   "onboarding.subscriptions.gemini.hint": {
-    "value": "Gemini 的额度只能从 gemini.google.com 的 cookies 读取，没有 CLI 登录或 WebView 途径。AntiGravity 在运行时会被本地探测。"
+    "value": "Gemini 的额度只能从 gemini.google.com 的 cookies 读取，无 CLI 登录或 WebView 途径。AntiGravity 在运行时会被本地探测。"
   },
   "onboarding.subscriptions.grok.detected": {
     "value": "已检测到 ~/.grok/auth.json — 额度将从这里读取。"
   },
   "onboarding.subscriptions.grok.missing": {
-    "value": "还没有 ~/.grok/auth.json。运行 `grok login`，或在下方从浏览器导入 grok.com 的 cookies。"
+    "value": "尚未找到 ~/.grok/auth.json。运行 `grok login`，或在下方从浏览器导入 grok.com 的 cookies。"
   },
   "onboarding.subscriptions.intro": {
-    "value": "打开你在用的订阅。关掉的厂商不会出现在总览和菜单栏里；之后再关掉也不会丢失凭据和历史。"
+    "value": "启用正在使用的订阅。已关闭的厂商不会出现在总览与菜单栏；之后关闭亦不会删除其凭据与历史。"
   },
   "onboarding.subscriptions.productLine.claude": {
     "value": "Claude Code · claude.ai 网页"
@@ -522,31 +522,31 @@
     "value": "Token 花费"
   },
   "onboarding.welcome.footer": {
-    "value": "整个过程约两分钟。这里的每个选择之后都能在设置里改，向导本身也在「设置 → 系统」里一键可达。"
+    "value": "全程约两分钟。此处的每项选择均可稍后在设置中修改，向导亦可在「设置 → 系统」中一键打开。"
   },
   "onboarding.welcome.intro": {
-    "value": "Vibe Bar 常驻菜单栏，一眼就能看到每个 AI 订阅还剩多少、编码 agent 花了多少钱，以及这台 Mac 上有哪些会话和 skills。它读取 Codex、Claude Code、Gemini、Grok 这些 CLI 本就保存在本机的凭据，在你允许时再从浏览器 cookies 补上网页端额度，并且只会把这些数据发回它们各自的厂商。"
+    "value": "Vibe Bar 常驻菜单栏，可一览各 AI 订阅的剩余量、编码 agent 的支出，以及本机存有哪些会话与 skills。它读取 Codex、Claude Code、Gemini、Grok 等 CLI 已保存在本机的凭据，并在获得授权后从浏览器 cookies 补充网页端额度；所有数据仅发送至其来源厂商。"
   },
   "onboarding.welcome.mcp.detail": {
-    "value": "你的 agent 可以通过 home 目录下的 Unix socket 向 Vibe Bar 查询额度和花费。"
+    "value": "agent 可通过 home 目录下的 Unix socket 向 Vibe Bar 查询额度与花费。"
   },
   "onboarding.welcome.mcp.title": {
     "value": "本地 MCP 服务"
   },
   "onboarding.welcome.quotas.detail": {
-    "value": "Codex、Claude Code、Gemini、Grok，以及一排 API key 套餐，每个都带重置倒计时。"
+    "value": "Codex、Claude Code、Gemini、Grok，以及一系列 API key 套餐，均附带重置倒计时。"
   },
   "onboarding.welcome.quotas.title": {
     "value": "订阅额度"
   },
   "onboarding.welcome.sessions.detail": {
-    "value": "在 Workbench 里浏览、搜索和整理 agent 会话与共享 skills。"
+    "value": "在 Workbench 中浏览、搜索并整理 agent 会话与共享 skills。"
   },
   "onboarding.welcome.sessions.title": {
     "value": "会话与 skills"
   },
   "platform.macos.launchAtLogin.detail": {
-    "value": "Vibe Bar 是没有 Dock 图标的菜单栏应用。开机启动能让额度读数和本地 MCP 服务在你登录后立刻可用；首次启用时 macOS 可能会要求你在「系统设置」中批准这个登录项。"
+    "value": "Vibe Bar 是无 Dock 图标的菜单栏应用。开机启动可使额度读数与本地 MCP 服务在登录后即刻可用；首次启用时 macOS 可能要求在「系统设置」中批准该登录项。"
   },
   "platform.macos.launchAtLogin.enabled": {
     "value": "已在 macOS 登录项中启用。"
@@ -555,7 +555,7 @@
     "value": "已关闭。"
   },
   "platform.macos.launchAtLogin.subtitle": {
-    "value": "登录 Mac 后菜单栏立刻显示读数。"
+    "value": "登录 Mac 后菜单栏即刻显示读数。"
   },
   "platform.macos.launchAtLogin.title": {
     "value": "开机启动"
@@ -600,7 +600,7 @@
     "value": "距重置 {when}"
   },
   "quota.empty.needsLogin.detail": {
-    "value": "在终端里运行 `{command} login`，然后刷新。"
+    "value": "在终端中运行 `{command} login`，然后刷新。"
   },
   "quota.empty.needsLogin.headline": {
     "value": "需重新登录"
@@ -624,7 +624,7 @@
     "value": "响应格式已变化"
   },
   "quota.empty.rateLimited.detail": {
-    "value": "官方 API 要求稍候，请过一会儿再试。"
+    "value": "官方 API 要求稍候，请稍后重试。"
   },
   "quota.empty.rateLimited.headline": {
     "value": "请求过于频繁"
@@ -639,19 +639,19 @@
     "value": "中等置信度"
   },
   "quota.forecast.guidance.atRisk": {
-    "value": "放慢节奏，或把工作转到别的额度上"
+    "value": "降低使用速度，或将任务转移至其他额度"
   },
   "quota.forecast.guidance.available": {
     "value": "目标保留 {target}% · 约有 {unused}% 可用"
   },
   "quota.forecast.guidance.surplus": {
-    "value": "预计有约 {unused}% 会闲置，超出 {target}% 的安全余量"
+    "value": "预计约 {unused}% 将闲置，超出 {target}% 的安全余量"
   },
   "quota.forecast.guidance.usedAvailable": {
     "value": "目标用到 {target}% · 约有 {unused}% 额度可用"
   },
   "quota.forecast.guidance.usedSurplus": {
-    "value": "预计有约 {unused}% 的额度会剩下，超出 {target}% 的使用目标"
+    "value": "预计约 {unused}% 的额度将剩余，超出 {target}% 的使用目标"
   },
   "quota.forecast.guidance.usedWithinTarget": {
     "value": "仍在 {target}% 的使用目标之内"
@@ -663,22 +663,22 @@
     "value": "仍在 {target}% 的安全余量之内"
   },
   "quota.forecast.reset.atRisk": {
-    "value": "大概率在重置前用尽"
+    "value": "很可能在重置前耗尽"
   },
   "quota.forecast.reset.enough": {
     "value": "预计重置时剩余 {remaining}%"
   },
   "quota.forecast.reset.learning": {
-    "value": "正在学习你的使用规律 · 约剩余 {remaining}%"
+    "value": "正在学习使用规律 · 约剩余 {remaining}%"
   },
   "quota.forecast.reset.surplus": {
-    "value": "大概率有盈余 · 预计剩余 {remaining}%"
+    "value": "预计将有盈余 · 重置时剩余 {remaining}%"
   },
   "quota.forecast.reset.watch": {
-    "value": "可能不够用 · 预计剩余 {remaining}%"
+    "value": "可能不足 · 预计剩余 {remaining}%"
   },
   "quota.forecast.status.atRisk": {
-    "value": "有风险 · 大概率在重置前用尽"
+    "value": "有风险 · 很可能在重置前耗尽"
   },
   "quota.forecast.status.enough": {
     "value": "充足 · 预计重置时{value}"
@@ -693,19 +693,19 @@
     "value": "需关注 · 预计重置时{value}"
   },
   "quota.forecast.useUp.beforeReset": {
-    "value": "预计会在重置前用尽"
+    "value": "预计将在重置前耗尽"
   },
   "quota.forecast.useUp.couldRunOut": {
-    "value": "可能在 {countdown}后用尽"
+    "value": "可能在 {countdown}后耗尽"
   },
   "quota.forecast.useUp.estimated": {
-    "value": "预计 {countdown}后用尽"
+    "value": "预计 {countdown}后耗尽"
   },
   "quota.forecast.useUp.lastsUntilReset": {
     "value": "预计可用到重置"
   },
   "quota.forecast.useUp.uncertain": {
-    "value": "用尽时间不确定 · 可能在重置前不够用"
+    "value": "耗尽时间不确定 · 可能在重置前不足"
   },
   "quota.forecast.value.left": {
     "value": "剩余 {percent}%"
@@ -741,7 +741,7 @@
     "value": "{seconds} 秒"
   },
   "quota.freshness.dataAge": {
-    "value": "数据已 {age}"
+    "value": "数据已有 {age}"
   },
   "quota.freshness.defaultHelp": {
     "value": "实时额度未在预期间隔内刷新。"
@@ -777,7 +777,7 @@
     "value": "每月"
   },
   "quota.group.noUtilization": {
-    "value": "暂无使用数据 — 试试刷新。"
+    "value": "暂无使用数据 — 可尝试刷新"
   },
   "quota.group.other": {
     "value": "其他"
@@ -816,7 +816,7 @@
     "value": "可用到重置"
   },
   "quota.pace.runsOutIn": {
-    "value": "{countdown}后用尽"
+    "value": "{countdown}后耗尽"
   },
   "quota.perModelLimits": {
     "value": "{count, plural, other {# 个}}按模型的限额 · 打开 {provider} 查看详情"
@@ -894,7 +894,7 @@
     "value": "提前补额，下次重置时间不变"
   },
   "quota.resetHistory.reset.earlyUnclear": {
-    "value": "提前补额，切换到了别的节奏"
+    "value": "提前补额，重置节奏已改变"
   },
   "quota.resetHistory.spoken.allCycles": {
     "value": "全部已记录周期"
@@ -927,25 +927,25 @@
     "value": "已用 {used}% · 浪费 {wasted}% · {count, plural, other {# 个周期}}"
   },
   "quota.resetHistory.totals.none": {
-    "value": "该区间内没有完整周期"
+    "value": "该区间内无完整周期"
   },
   "quota.resetHistory.truncation": {
     "value": "仅显示最近 {shown} 个周期，共 {total} 个"
   },
   "quota.resetHistory.verdict.clean": {
-    "value": "没有明显浪费 — 补回的额度用掉了 {percent}%。"
+    "value": "无明显浪费 — 补回的额度已使用 {percent}%。"
   },
   "quota.resetHistory.verdict.leaky": {
-    "value": "{label} 在 {count, plural, other {# 个周期}}里平均有 {percent}% 没用掉。"
+    "value": "{label} 在 {count, plural, other {# 个周期}}中平均有 {percent}% 未使用。"
   },
   "quota.resetHistory.verdict.noCycles": {
     "value": "尚无完整周期 — 额度补满时才会记录一个周期。"
   },
   "quota.resetHistory.verdict.noQuota": {
-    "value": "目前还没有跟踪任何按周或更长周期的额度。"
+    "value": "尚未跟踪任何按周或更长周期的额度。"
   },
   "quota.resetHistory.verdict.wasteful": {
-    "value": "{label} 有 {count, plural, other {# 次}}补额时超过一半没用掉。"
+    "value": "{label} 有 {count, plural, other {# 次}}补额后超过一半未使用。"
   },
   "quota.resetHistory.window.all": {
     "value": "全部"
@@ -966,7 +966,7 @@
     "value": "+{hours} 小时"
   },
   "quota.upcoming.empty": {
-    "value": "未来 7 天内没有额度会补满。"
+    "value": "未来 7 天内无额度补满。"
   },
   "quota.upcoming.forecastAtReset": {
     "value": "预计重置时剩余 {percent}%"
@@ -1092,7 +1092,7 @@
     "value": "维护中"
   },
   "status.overview.needsAttention": {
-    "value": "需要处理"
+    "value": "需处理"
   },
   "status.overview.operational": {
     "value": "运行正常"
@@ -1206,13 +1206,13 @@
     "value": "{seconds} 秒"
   },
   "usage.harnessMix.activeCount": {
-    "value": "所选范围内有 {count, plural, other {# 个}} harness 在使用"
+    "value": "所选范围内 {count, plural, other {# 个}} harness 活跃"
   },
   "usage.harnessMix.byRealTokens": {
     "value": "按实际 token 计"
   },
   "usage.harnessMix.empty": {
-    "value": "所选范围内没有 harness 流量"
+    "value": "所选范围内无 harness 流量"
   },
   "usage.harnessMix.title": {
     "value": "Harness 分布"
@@ -1251,7 +1251,7 @@
     "value": "{count} 条未计价"
   },
   "usage.hero.unpricedHelp": {
-    "value": "{count, plural, other {# 条请求}}没有可用价格，计入 $0。"
+    "value": "{count, plural, other {# 条请求}}无可用价格，计入 $0。"
   },
   "usage.ledgerUnavailable.detail": {
     "value": "无法打开 ~/.vibebar 下的逐请求账本，本次会话只能显示实时费用卡片。"
@@ -1311,7 +1311,7 @@
     "value": "Token 流向"
   },
   "usage.noHarnessSelected.detail": {
-    "value": "「全部 harness」是一个开关：再点一次即可把所有 harness 放回查询。"
+    "value": "「全部 harness」是一个开关：再次点击即可将全部 harness 重新纳入查询。"
   },
   "usage.noHarnessSelected.title": {
     "value": "未选择任何 harness — 请在上方选择"
@@ -1518,13 +1518,13 @@
     "value": "Token 用量随时间变化"
   },
   "usage.whenYouUse.everything": {
-    "value": "你什么时候在用"
+    "value": "整体使用时段"
   },
   "usage.whenYouUse.googleAI": {
-    "value": "你什么时候用 Google AI"
+    "value": "Google AI 使用时段"
   },
   "usage.whenYouUse.spaceXAI": {
-    "value": "你什么时候用 SpaceXAI"
+    "value": "SpaceXAI 使用时段"
   },
   "workbench.appearance.useDark": {
     "value": "使用深色外观"

--- a/Resources/i18n/zh-Hans.json
+++ b/Resources/i18n/zh-Hans.json
@@ -1,12 +1,21 @@
 {
+  "common.add": {
+    "value": "添加"
+  },
   "common.all": {
     "value": "全部"
+  },
+  "common.auto": {
+    "value": "自动"
   },
   "common.cancel": {
     "value": "取消"
   },
   "common.clear": {
     "value": "清除"
+  },
+  "common.copied": {
+    "value": "已复制"
   },
   "common.copy": {
     "value": "复制"
@@ -62,6 +71,9 @@
   "common.done": {
     "value": "完成"
   },
+  "common.dragToReorder": {
+    "value": "拖动可重新排序"
+  },
   "common.duration.days": {
     "value": "{days} 天"
   },
@@ -83,6 +95,9 @@
   "common.duration.now": {
     "value": "现在"
   },
+  "common.name": {
+    "value": "名称"
+  },
   "common.off": {
     "value": "已关闭"
   },
@@ -98,14 +113,26 @@
   "common.percent": {
     "value": "{value}%"
   },
+  "common.provider": {
+    "value": "厂商"
+  },
   "common.refresh": {
     "value": "刷新"
   },
   "common.refreshSection": {
     "value": "刷新此区块"
   },
+  "common.remove": {
+    "value": "移除"
+  },
   "common.retry": {
     "value": "重试"
+  },
+  "common.retryNow": {
+    "value": "立即重试"
+  },
+  "common.save": {
+    "value": "保存"
   },
   "common.updated.daysAgo": {
     "value": "{days, plural, other {# 天}}前更新"
@@ -992,6 +1019,99 @@
   "quota.update.failed": {
     "value": "更新失败：{reason}"
   },
+  "settings.antigravityCookieEnabled": {
+    "value": "Antigravity 的 cookie 导入已启用 — 请先在 antigravity.google 登录。"
+  },
+  "settings.antigravityLocalOnly": {
+    "value": "Antigravity 读取本机运行的语言服务。cookie 导入将等到 Antigravity Cloud 端点上线后再启用。"
+  },
+  "settings.antigravitySource": {
+    "value": "Antigravity 来源"
+  },
+  "settings.appVersion": {
+    "value": "Vibe Bar {version}"
+  },
+  "settings.bundled": {
+    "value": "内置"
+  },
+  "settings.checkConnections": {
+    "value": "检查 {company} 连接"
+  },
+  "settings.checkForUpdates": {
+    "value": "检查更新…"
+  },
+  "settings.checkKitUpdates": {
+    "value": "检查组件更新"
+  },
+  "settings.checkingGitHub": {
+    "value": "正在向 github.com 查询最新版本…"
+  },
+  "settings.clearCostData": {
+    "value": "清除花费数据"
+  },
+  "settings.connectionHealth": {
+    "value": "连接状态"
+  },
+  "settings.costDataIntro": {
+    "value": "花费根据 ~/.codex/sessions 与 ~/.claude/projects 下的本地 CLI 会话 JSONL 日志计算。网页端与桌面端用量不计入。"
+  },
+  "settings.couldNotDeleteCookies": {
+    "value": "无法删除已保存的 cookies。"
+  },
+  "settings.couldNotDeleteGeminiCookies": {
+    "value": "无法删除已保存的 Gemini cookies。"
+  },
+  "settings.couldNotDeleteGrokCookies": {
+    "value": "无法删除已保存的 Grok cookies。"
+  },
+  "settings.cursorNoSession": {
+    "value": "没有可用的 Cursor.app 会话 — 请在下方导入 cursor.com 的 cookies。"
+  },
+  "settings.cursorSessionDetected": {
+    "value": "已检测到 Cursor.app 的登录会话"
+  },
+  "settings.cursorSource": {
+    "value": "Cursor 来源"
+  },
+  "settings.cursorSourceValue": {
+    "value": "Cursor.app → 网页"
+  },
+  "settings.deleteCookies": {
+    "value": "删除 cookies"
+  },
+  "settings.deleteGeminiCookies": {
+    "value": "删除 Gemini 的 cookies"
+  },
+  "settings.deleteGrokCookies": {
+    "value": "删除 Grok 的 cookies"
+  },
+  "settings.externalChange.title": {
+    "value": "另一个 Vibe Bar 覆盖了此处的修改"
+  },
+  "settings.geminiCookiesSaved": {
+    "value": "Gemini 的 cookies 已保存。"
+  },
+  "settings.geminiShared": {
+    "value": "Gemini 与 Antigravity 共用同一份 Google AI 订阅额度。网页端仅支持 cookie 导入，没有 WebView 登录途径。"
+  },
+  "settings.geminiSource": {
+    "value": "Gemini 来源"
+  },
+  "settings.grokAuthDetected": {
+    "value": "已检测到 ~/.grok/auth.json"
+  },
+  "settings.grokCookiesSaved": {
+    "value": "Grok 的 cookies 已保存。"
+  },
+  "settings.keepHistory": {
+    "value": "保留历史"
+  },
+  "settings.keepHistoryDetail": {
+    "value": "适用于花费历史与订阅填充历史。"
+  },
+  "settings.kitDetail": {
+    "value": "会话发现、harness 命名与 MCP 传输。独立仓库，固定到确切 tag 并编译进本次构建。"
+  },
   "settings.language.caption": {
     "value": "Vibe Bar 默认跟随 macOS 语言，也可以在此单独指定。厂商、模型与 harness 名称保持原始拼写。"
   },
@@ -1000,6 +1120,576 @@
   },
   "settings.language.title": {
     "value": "语言"
+  },
+  "settings.mcp.allowRefresh": {
+    "value": "允许 agent 刷新额度"
+  },
+  "settings.mcp.allowRefreshDetail": {
+    "value": "开启后，agent 可以让 Vibe Bar 重新向厂商拉取额度。强制刷新限流为每 {seconds} 秒一次。关闭后只读工具照常可用，quota.refresh 会报告刷新已禁用。"
+  },
+  "settings.mcp.allowSkills": {
+    "value": "允许 agent 安装 skills"
+  },
+  "settings.mcp.allowSkillsDetail": {
+    "value": "开启后，agent 可以调用 skills.install，从 GitHub 仓库或本地文件夹添加 skill。它走的是与 Workbench → Skills 相同的管理流程，因此只写入 ~/.agents/skills 以及 Vibe Bar 管理的 agent skills 目录 — 绝不覆盖已被其他 skill 占用的文件夹。关闭后该工具会报告安装已禁用。"
+  },
+  "settings.mcp.appendCodexConfig": {
+    "value": "追加到 ~/.codex/config.toml。"
+  },
+  "settings.mcp.connectAgent": {
+    "value": "接入一个 agent"
+  },
+  "settings.mcp.connectedClients": {
+    "value": "已连接客户端"
+  },
+  "settings.mcp.enable": {
+    "value": "启用本地 MCP 服务"
+  },
+  "settings.mcp.intro": {
+    "value": "Vibe Bar 可通过 MCP 向编码 agent 提供本机的额度、用量、花费与本地会话。服务监听 home 目录下的 Unix domain socket — 不开放网络端口，也不创建 token：socket 的文件权限即访问控制。"
+  },
+  "settings.mcp.lastActivity": {
+    "value": "最近一次客户端活动"
+  },
+  "settings.mcp.listening": {
+    "value": "监听中"
+  },
+  "settings.mcp.manualIntro": {
+    "value": "也可手动配置客户端。所有客户端运行同一条命令 — Vibe Bar 自身的可执行文件加 {flag}，它把 stdin/stdout 桥接到上面的 socket。"
+  },
+  "settings.mcp.mergeCursorConfig": {
+    "value": "合并到 ~/.cursor/mcp.json。"
+  },
+  "settings.mcp.movePrompt": {
+    "value": "Vibe Bar 正从 {path} 运行。保存客户端配置前请先移动到 /Applications，否则下次重新构建后配置会失效。"
+  },
+  "settings.mcp.notListening": {
+    "value": "未监听"
+  },
+  "settings.mcp.otherStdioClient": {
+    "value": "其他 stdio 客户端"
+  },
+  "settings.mcp.otherStdioDetail": {
+    "value": "给客户端自己的 mcpServers 映射加一条。"
+  },
+  "settings.mcp.quickestPath": {
+    "value": "最快的方式：把这段粘贴给任意 agent，让它自行完成配置、安装配套 skill 并验证连接。"
+  },
+  "settings.mcp.readOnlyDetail": {
+    "value": "agent 能访问的其余内容均为只读：额度、token 用量、花费、厂商状态、生效模型价格，以及本地会话索引（标题、项目，以及在开启会话正文索引时的消息摘录）。凭据、cookies 与组织 id 从不暴露，邮箱地址会被掩码。"
+  },
+  "settings.mcp.runInTerminal": {
+    "value": "在终端中运行。"
+  },
+  "settings.mcp.setupPrompt": {
+    "value": "Agent 配置提示词"
+  },
+  "settings.mcp.setupPromptDetail": {
+    "value": "一行内容，适用于任何能抓取 URL 的 agent。"
+  },
+  "settings.mcp.socket": {
+    "value": "Socket"
+  },
+  "settings.mcp.socketLifetime": {
+    "value": "socket 仅在 Vibe Bar 运行时存在。退出后，下方配置的 agent 会报告 “Vibe Bar is not running”，这是预期行为。"
+  },
+  "settings.mcp.status": {
+    "value": "状态"
+  },
+  "settings.mcp.title": {
+    "value": "MCP 服务"
+  },
+  "settings.mcp.whatAgentsMayDo": {
+    "value": "agent 的权限范围"
+  },
+  "settings.menuBarHealthUnavailable": {
+    "value": "本进程未接入菜单栏健康监控。"
+  },
+  "settings.miniWindow.add": {
+    "value": "添加迷你窗口"
+  },
+  "settings.miniWindow.allBucketsIncluded": {
+    "value": "已知的 bucket 都已在此窗口中。"
+  },
+  "settings.miniWindow.dismissBuiltIn": {
+    "value": "在厂商未返回该内置 bucket 期间将其隐藏。厂商一旦恢复返回，它便会重新出现。"
+  },
+  "settings.miniWindow.forgetDiscovered": {
+    "value": "忘记这个已发现的 bucket — 将其从列表以及所有选中它的窗口中移除。"
+  },
+  "settings.miniWindow.includeStyle": {
+    "value": "将{mode}纳入双击循环"
+  },
+  "settings.miniWindow.lastCannotBeRemoved": {
+    "value": "最后一个迷你窗口无法移除。"
+  },
+  "settings.miniWindow.namesAllWindows": {
+    "value": "名称：全部窗口"
+  },
+  "settings.miniWindow.namesThisStyle": {
+    "value": "仅此处的{mode}"
+  },
+  "settings.miniWindow.namesThisWindow": {
+    "value": "仅“{name}”"
+  },
+  "settings.miniWindow.noFieldsSelected": {
+    "value": "未选择任何字段 — 请在上方勾选。"
+  },
+  "settings.miniWindow.notInWindow": {
+    "value": "不在“{name}”中 — 勾选 bucket 即可加入。适配器在运行时发现的 bucket 会自动出现在这里；灰显的行表示已记录但不在账号当前响应中，✕ 可将其忽略，直到厂商重新返回。"
+  },
+  "settings.miniWindow.offline": {
+    "value": "离线"
+  },
+  "settings.miniWindow.openClose": {
+    "value": "打开 / 关闭"
+  },
+  "settings.miniWindow.overridesStyle": {
+    "value": "仅对此窗口的{mode}样式生效的覆盖。留空则先继承窗口名称，再继承共享名称 — 以占位文本显示。"
+  },
+  "settings.miniWindow.overridesWindow": {
+    "value": "仅对此窗口生效的名称覆盖。留空则继承共享名称 — 以占位文本显示。"
+  },
+  "settings.miniWindow.position": {
+    "value": "{position}"
+  },
+  "settings.miniWindow.removeFromWindow": {
+    "value": "从此窗口移除"
+  },
+  "settings.miniWindow.removeHelp": {
+    "value": "移除此迷你窗口"
+  },
+  "settings.miniWindow.stripDensity": {
+    "value": "条带密度"
+  },
+  "settings.miniWindow.styleCycle": {
+    "value": "双击窗口可循环切换样式。点选某个样式即将其纳入循环 — 徽标表示它在循环中的次序。未选任何样式即表示按此顺序使用全部样式。"
+  },
+  "settings.miniWindow.toggleHelp": {
+    "value": "在屏幕上显示或隐藏此迷你窗口"
+  },
+  "settings.miniWindow.treeDetail": {
+    "value": "窗口的一棵树 — 按其折叠方式分组（company → SubProvider → 额度组 → bucket）。拖动行可重新排序，✕ 可移除，任一层级均可就地重命名。第一个字段渲染在最左（或最上）。"
+  },
+  "settings.misc.accessKeyId": {
+    "value": "Access Key ID（AKLT…）"
+  },
+  "settings.misc.akSkSaved": {
+    "value": "AK/SK 已保存到 Keychain。"
+  },
+  "settings.misc.apiKeySaved": {
+    "value": "API key 已保存到 Keychain。"
+  },
+  "settings.misc.clearWorkspace": {
+    "value": "清除已保存的工作区"
+  },
+  "settings.misc.clone": {
+    "value": "复制 {provider}"
+  },
+  "settings.misc.consoleLink": {
+    "value": "{title} →"
+  },
+  "settings.misc.edition": {
+    "value": "版本"
+  },
+  "settings.misc.githubSignInHint": {
+    "value": "通过 GitHub 设备流程登录。"
+  },
+  "settings.misc.githubTokenSaved": {
+    "value": "GitHub 设备令牌已保存到 Keychain。"
+  },
+  "settings.misc.importDetail": {
+    "value": "添加或刷新找到的第一个已登录浏览器配置；已导入的配置会保留叠加，该厂商的额度取上方所有槽位的平均值。每个 Chromium 系浏览器，macOS 可能会要求输入一次登录钥匙串密码。"
+  },
+  "settings.misc.kiroHint": {
+    "value": "运行 `kiro-cli login`，之后 Vibe Bar 会探测 `kiro-cli chat --no-interactive /usage`。"
+  },
+  "settings.misc.noCookieSpec": {
+    "value": "{provider} 未注册 cookie 规格。"
+  },
+  "settings.misc.noCookiesYet": {
+    "value": "尚未导入 cookies — 可从浏览器导入或在下方粘贴。"
+  },
+  "settings.misc.probe": {
+    "value": "探测"
+  },
+  "settings.misc.prompt.copilotHost": {
+    "value": "GitHub Enterprise 主机（可选，例如 github.example.com）"
+  },
+  "settings.misc.prompt.dashscope": {
+    "value": "粘贴 DashScope API key（sk-...）— 可选"
+  },
+  "settings.misc.prompt.kilo": {
+    "value": "粘贴 Kilo API key（可选）"
+  },
+  "settings.misc.prompt.minimax": {
+    "value": "粘贴 MiniMax Token Plan API key（sk-cp-... 或 MINIMAX_CODING_API_KEY）"
+  },
+  "settings.misc.prompt.openRouter": {
+    "value": "粘贴 OpenRouter API key（sk-or-v1-...）"
+  },
+  "settings.misc.prompt.openRouterHost": {
+    "value": "OpenRouter API URL（可选，默认为 https://openrouter.ai/api/v1）"
+  },
+  "settings.misc.prompt.warp": {
+    "value": "粘贴 Warp API key（wk-...）"
+  },
+  "settings.misc.prompt.workspace": {
+    "value": "工作区 ID 或 URL（可选，wrk_... 或 /workspace/wrk_.../go）"
+  },
+  "settings.misc.prompt.zai": {
+    "value": "粘贴 Z.ai API key（zai-...）"
+  },
+  "settings.misc.region": {
+    "value": "区域"
+  },
+  "settings.misc.removeAkSk": {
+    "value": "移除已保存的 {provider} AK/SK"
+  },
+  "settings.misc.removeApiKey": {
+    "value": "移除已保存的 {provider} API key"
+  },
+  "settings.misc.removeCookieSlot": {
+    "value": "移除此 cookie 槽位"
+  },
+  "settings.misc.removeCopy": {
+    "value": "移除此 {provider} 副本"
+  },
+  "settings.misc.removeCopyButton": {
+    "value": "移除副本"
+  },
+  "settings.misc.removeCopyDetail": {
+    "value": "其保存的凭据会从 Keychain 中删除 — 包括 API key 或 AK/SK 以及全部已导入的 cookie 槽位。此操作不可撤销。"
+  },
+  "settings.misc.removeCopyTitle": {
+    "value": "是否移除此 {provider} 副本？"
+  },
+  "settings.misc.removeGithubToken": {
+    "value": "移除已保存的 GitHub 设备令牌"
+  },
+  "settings.misc.rename": {
+    "value": "重命名此副本"
+  },
+  "settings.misc.secretAccessKey": {
+    "value": "Secret Access Key"
+  },
+  "settings.misc.signIn": {
+    "value": "登录"
+  },
+  "settings.misc.signInViaWeb": {
+    "value": "通过网页登录"
+  },
+  "settings.misc.tencentTokenPlanNote": {
+    "value": "个人版 Token Plan 目前仅在中国大陆（cn-beijing）提供。复制此行即可同时跟踪团队版与个人版。"
+  },
+  "settings.misc.variant": {
+    "value": "变体"
+  },
+  "settings.misc.waiting": {
+    "value": "等待中…"
+  },
+  "settings.misc.workspaceNote": {
+    "value": "仅当账号拥有多个工作区时才需要填写 — 否则 Vibe Bar 使用找到的第一个。"
+  },
+  "settings.needsSetup": {
+    "value": "需配置"
+  },
+  "settings.notChecked": {
+    "value": "未检查"
+  },
+  "settings.notCheckedYet": {
+    "value": "尚未检查。在主动发起前不会请求任何内容。"
+  },
+  "settings.openRefreshCooldown": {
+    "value": "打开刷新的最小间隔"
+  },
+  "settings.openRefreshDetail": {
+    "value": "每个间隔周期内，打开面板最多刷新一次全部可见厂商。"
+  },
+  "settings.openStatusPage": {
+    "value": "打开 {company} 状态页"
+  },
+  "settings.percentShows": {
+    "value": "百分比显示"
+  },
+  "settings.planBadge": {
+    "value": "套餐标签"
+  },
+  "settings.planBadgeDetail": {
+    "value": "留空则使用自动检测到的账号套餐。"
+  },
+  "settings.pricing.addOverride": {
+    "value": "添加模型覆盖值"
+  },
+  "settings.pricing.advancedTiers": {
+    "value": "高级分档"
+  },
+  "settings.pricing.alwaysWins": {
+    "value": "始终优先"
+  },
+  "settings.pricing.bundledFallback": {
+    "value": "内置兜底"
+  },
+  "settings.pricing.cacheReadAbove": {
+    "value": "阈值以上缓存读取"
+  },
+  "settings.pricing.cacheWriteAbove": {
+    "value": "阈值以上缓存写入"
+  },
+  "settings.pricing.deleteOverride": {
+    "value": "删除覆盖值"
+  },
+  "settings.pricing.exactModelName": {
+    "value": "模型名称（精确匹配）"
+  },
+  "settings.pricing.fastMultiplier": {
+    "value": "快速档倍率"
+  },
+  "settings.pricing.inputAbove": {
+    "value": "阈值以上输入"
+  },
+  "settings.pricing.intro": {
+    "value": "目录在后台刷新。同一厂商与模型名出现多次时，靠前的条目优先。"
+  },
+  "settings.pricing.localOverrides": {
+    "value": "本地覆盖值"
+  },
+  "settings.pricing.localOverridesName": {
+    "value": "本地覆盖值"
+  },
+  "settings.pricing.noOverrides": {
+    "value": "暂无本地覆盖值。"
+  },
+  "settings.pricing.number": {
+    "value": "{number}"
+  },
+  "settings.pricing.offlineFloor": {
+    "value": "离线下限"
+  },
+  "settings.pricing.outputAbove": {
+    "value": "阈值以上输出"
+  },
+  "settings.pricing.overridesIntro": {
+    "value": "价格单位为每百万 token 的美元数。厂商未公布缓存价格时，相应字段留空。"
+  },
+  "settings.pricing.priorityHealth": {
+    "value": "优先级与来源状态"
+  },
+  "settings.pricing.rateInput": {
+    "value": "输入"
+  },
+  "settings.pricing.rateOutput": {
+    "value": "输出"
+  },
+  "settings.pricing.refreshNow": {
+    "value": "立即刷新"
+  },
+  "settings.pricing.refreshing": {
+    "value": "正在刷新…"
+  },
+  "settings.pricing.thresholdTokens": {
+    "value": "分档阈值 token 数"
+  },
+  "settings.pricingDataDate": {
+    "value": "价格数据：{date}"
+  },
+  "settings.privacyDetail": {
+    "value": "token 从本地 CLI 凭据读取。已保存的 OpenAI 与 Claude 网页 cookies 存放在 macOS Keychain 中，按浏览器与 WebView 来源分开。~/.vibebar/cookies 下的旧版明文 cookie 文件会迁移一次并删除。设置、额度缓存与花费汇总保留在 ~/.vibebar 下。"
+  },
+  "settings.privacyMode": {
+    "value": "隐私模式"
+  },
+  "settings.privacyModeDetail": {
+    "value": "隐私模式不将花费数据写入磁盘，并清除本地花费历史、快照与扫描缓存。"
+  },
+  "settings.ready": {
+    "value": "就绪"
+  },
+  "settings.refreshEvery": {
+    "value": "刷新间隔"
+  },
+  "settings.refreshOnPopoverOpen": {
+    "value": "打开面板时刷新"
+  },
+  "settings.releaseNotes": {
+    "value": "发行说明"
+  },
+  "settings.remote.core": {
+    "value": "远程 Core"
+  },
+  "settings.remote.costAggregation": {
+    "value": "花费汇总"
+  },
+  "settings.remote.costAggregationIntro": {
+    "value": "选择哪些远程机器计入本机的花费与 token 总计。选择与汇总均在本 Core 完成；Relay 不会看到明文用量。"
+  },
+  "settings.remote.differentControlCenter": {
+    "value": "使用其他控制台"
+  },
+  "settings.remote.discard": {
+    "value": "丢弃"
+  },
+  "settings.remote.discardPendingDetail": {
+    "value": "该配对码已失效，且工作区仍将本机视为其 Core。如需重新加入，请先在网页控制台吊销本机，再创建新的配对码。"
+  },
+  "settings.remote.discardPendingTitle": {
+    "value": "是否丢弃这次待完成的加入？"
+  },
+  "settings.remote.disconnect": {
+    "value": "断开连接"
+  },
+  "settings.remote.disconnectButton": {
+    "value": "断开与工作区的连接…"
+  },
+  "settings.remote.disconnectDetail": {
+    "value": "日后重新连接需要新的配对码或配置文件。"
+  },
+  "settings.remote.disconnectIntro": {
+    "value": "断开会从 Keychain 移除本机的 Relay 凭据及其工作区绑定。在 Relay 端吊销之前，探针仍会继续上传。已解密的用量保留在本地账本中。"
+  },
+  "settings.remote.disconnectTitle": {
+    "value": "是否断开与该工作区的连接？"
+  },
+  "settings.remote.exportIdentity": {
+    "value": "导出 Core 身份…"
+  },
+  "settings.remote.importProvisioning": {
+    "value": "导入配置文件…"
+  },
+  "settings.remote.join": {
+    "value": "加入"
+  },
+  "settings.remote.joinIntro": {
+    "value": "在 Vibe Bar 控制台创建 Core 配对码，然后粘贴到此处。本机将以“{device}”的名义加入。"
+  },
+  "settings.remote.joinWithCode": {
+    "value": "用配对码加入"
+  },
+  "settings.remote.lastSync": {
+    "value": "最近同步"
+  },
+  "settings.remote.machineDetail": {
+    "value": "{platform} · 探针 {version}"
+  },
+  "settings.remote.machinesAppearAfterImport": {
+    "value": "机器在首批加密数据导入后出现在此。"
+  },
+  "settings.remote.machinesSynced": {
+    "value": "已同步机器"
+  },
+  "settings.remote.manualPairingIntro": {
+    "value": "配对分三步：导出本机 Core 身份，在 Relay 注册以生成配置文件，然后在此导入该文件。导入会把 Relay 凭据移入 macOS Keychain — 但配置文件本身仍包含该凭据，导入成功后请删除该文件。"
+  },
+  "settings.remote.notConnected": {
+    "value": "本机尚未连接到工作区。远程探针在其他机器上采集归一化用量，用本机 Core 的密钥加密后投递到 Relay — 本机不会开放任何入站端口。"
+  },
+  "settings.remote.orPairManually": {
+    "value": "也可手动配对。"
+  },
+  "settings.remote.pendingIntro": {
+    "value": "上一次加入已被控制台接受，但在本机未完成保存。该配对码已失效，请继续保存，而不是重新申请配对码。"
+  },
+  "settings.remote.provisioning": {
+    "value": "配置接入"
+  },
+  "settings.remote.registeredProbes": {
+    "value": "已注册探针"
+  },
+  "settings.remote.relay": {
+    "value": "Relay"
+  },
+  "settings.remote.resumeSaving": {
+    "value": "继续保存"
+  },
+  "settings.remote.retrySaving": {
+    "value": "重试保存"
+  },
+  "settings.remote.statusWithCode": {
+    "value": "{title} · {code}"
+  },
+  "settings.remote.syncNow": {
+    "value": "立即同步"
+  },
+  "settings.remote.workspace": {
+    "value": "工作区"
+  },
+  "settings.repository": {
+    "value": "仓库"
+  },
+  "settings.rescanCostLogs": {
+    "value": "重新扫描花费日志"
+  },
+  "settings.search": {
+    "value": "搜索设置"
+  },
+  "settings.section.components": {
+    "value": "组件"
+  },
+  "settings.section.costData": {
+    "value": "花费数据"
+  },
+  "settings.section.layout": {
+    "value": "布局"
+  },
+  "settings.section.menuBarHealth": {
+    "value": "菜单栏健康"
+  },
+  "settings.section.miniWindows": {
+    "value": "迷你窗口"
+  },
+  "settings.section.overview": {
+    "value": "总览"
+  },
+  "settings.section.privacy": {
+    "value": "隐私"
+  },
+  "settings.section.refreshing": {
+    "value": "刷新"
+  },
+  "settings.section.system": {
+    "value": "系统"
+  },
+  "settings.section.updates": {
+    "value": "更新"
+  },
+  "settings.showAssistant": {
+    "value": "打开设置向导"
+  },
+  "settings.showAssistantDetail": {
+    "value": "重新走一遍订阅、浏览器 cookies、API key、模型价格与登录项。不会重置任何设置。"
+  },
+  "settings.sidebar.coreProviders": {
+    "value": "核心厂商"
+  },
+  "settings.sidebar.disableProvider": {
+    "value": "停用厂商"
+  },
+  "settings.sidebar.enableProvider": {
+    "value": "启用厂商"
+  },
+  "settings.sidebar.hideFromOverview": {
+    "value": "从总览中隐藏"
+  },
+  "settings.sidebar.settings": {
+    "value": "设置"
+  },
+  "settings.spaceXAIIntro": {
+    "value": "SpaceXAI 页面同时包含 Grok 与 Cursor。Grok 读取 `~/.grok/auth.json` 或 grok.com 的 cookies；Cursor 先读 Cursor.app，再读 cursor.com 的 cookie 槽位。Grok Bot 提供额度，以及来自本地缓存的只读会话 — 其云端运行仍不产生 token 或花费记录。"
+  },
+  "settings.updateChannel": {
+    "value": "更新通道"
+  },
+  "settings.updateCheckDetail": {
+    "value": "每天检查一次所选通道，安装前会先询问。"
+  },
+  "settings.usageSource": {
+    "value": "用量来源"
+  },
+  "settings.webQuota": {
+    "value": "网页端额度"
+  },
+  "settings.whatChangedIn": {
+    "value": "{version} 的更新内容"
   },
   "status.card.componentCount": {
     "value": "{count, plural, other {# 个组件}}"

--- a/Scripts/build_localizations.py
+++ b/Scripts/build_localizations.py
@@ -35,8 +35,13 @@ to `String(format:)` by mistake.
 
 Usage:
     Scripts/build_localizations.py [--check]
+    Scripts/build_localizations.py --duplicates
 
 --check writes nothing and exits non-zero when the tree is stale.
+--duplicates reports keys whose English says the same thing, using the same
+signature `vibe-bar-i18n`'s validator uses. It reports rather than fails:
+the backlog is being resolved by the extraction into that repository, and
+failing here would block the migration batches still landing.
 """
 import json
 import pathlib
@@ -581,9 +586,146 @@ def render_swift(base: dict, base_args: dict) -> str:
 # ------------------------------------------------------------------- main
 
 
+# ---------------------------------------------------------------------------
+# Reuse signature
+# ---------------------------------------------------------------------------
+
+# When two source values say the same thing. Ported from
+# `vibe-bar-i18n`'s `scripts/validate.py` (a659832), which is where the rule
+# will live once this catalogue is extracted; it is here so the two sides
+# report the same duplicates in the meantime.
+#
+# The subtlety that cost a debugging session there and a wrong count here: a
+# placeholder's *name* is not the sentence, but a plural's *branch text* is.
+# A signature that drops everything inside braces collapses
+# "{n, plural, one {# cycle} other {# cycles}}" and the same shape for files
+# onto one signature, so every plural after the first reads as a duplicate.
+# The walk below tells the two kinds of brace apart.
+
+_PLURAL_ARG = re.compile(r"\A\s*[a-z0-9_]+\s*,\s*(plural|selectordinal)\s*,(.*)\Z", re.S)
+
+
+def _matching_brace(text: str, start: int) -> int:
+    """Index of the `}` closing the `{` at `start`, or len(text) if unbalanced."""
+    depth = 0
+    for index in range(start, len(text)):
+        if text[index] == "{":
+            depth += 1
+        elif text[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return index
+    return len(text)
+
+
+def _render(text: str) -> str:
+    """Normalize placeholder arguments; keep every other character."""
+    out = []
+    index = 0
+    while index < len(text):
+        if text[index] != "{":
+            out.append(text[index])
+            index += 1
+            continue
+        close = _matching_brace(text, index)
+        body = text[index + 1:close]
+        plural = _PLURAL_ARG.match(body)
+        if plural:
+            out.append("{}")
+            out.append(plural.group(1))
+            out.append(_render_branches(plural.group(2)))
+        else:
+            out.append("{}")
+        index = close + 1
+    return "".join(out)
+
+
+def _render_branches(text: str) -> str:
+    """Keep selectors and branch text; normalize placeholders nested inside."""
+    out = []
+    index = 0
+    while index < len(text):
+        if text[index] != "{":
+            out.append(text[index])
+            index += 1
+            continue
+        close = _matching_brace(text, index)
+        out.append("{")
+        out.append(_render(text[index + 1:close]))
+        out.append("}")
+        index = close + 1
+    return "".join(out)
+
+
+def reuse_signature(text: str) -> str:
+    return " ".join(_render(text.strip().lower().rstrip(".…")).split())
+
+
+# What `reuse_signature` must and must not collapse, pinned here for the
+# same reason the upstream copy pins them: a check that silently starts
+# matching everything looks exactly like a check that is passing.
+_REUSE_CASES = [
+    ("two plurals differ by their branch text",
+     "{count, plural, one {# cycle} other {# cycles}}",
+     "{count, plural, one {# file} other {# files}}", False),
+    ("a plural's argument name is not the sentence",
+     "{count, plural, one {# cycle} other {# cycles}}",
+     "{n, plural, one {# cycle} other {# cycles}}", True),
+    ("a placeholder name is not the sentence",
+     "{provider} is offline", "{tool} is offline", True),
+    ("a placeholder nested in a branch is still a placeholder",
+     "{n, plural, other {# of {total} used}}",
+     "{m, plural, other {# of {sum} used}}", True),
+    ("but the words around it are not",
+     "{n, plural, other {# of {total} used}}",
+     "{n, plural, other {# of {total} spent}}", False),
+    ("trailing punctuation and case are presentation",
+     "Refresh", "refresh.", True),
+    ("an unbalanced brace degrades instead of raising",
+     "{count, plural, one {# cycle", "{count, plural, one {# cycle", True),
+]
+
+
+def run_reuse_self_test() -> None:
+    for name, left, right, same in _REUSE_CASES:
+        matched = reuse_signature(left) == reuse_signature(right)
+        if matched != same:
+            raise Failure(
+                "reuse signature self-test failed (%s): %r and %r %s"
+                % (name, left, right,
+                   "collapsed but should not" if matched else "differ but should not")
+            )
+
+
+def report_duplicates(entries: dict) -> int:
+    """Two keys whose English says the same thing are one key with two names.
+
+    Reported, not enforced. The catalogue has a backlog of these and they
+    are being resolved by the extraction into `vibe-bar-i18n`, whose
+    `validate.py` fails on them; failing here as well would only block the
+    migration batches that are still landing.
+    """
+    run_reuse_self_test()
+    groups = {}
+    for key, entry in sorted(entries.items()):
+        signature = reuse_signature(entry["value"])
+        if signature:
+            groups.setdefault(signature, []).append(key)
+    duplicates = {s: k for s, k in groups.items() if len(k) > 1}
+    for keys in sorted(duplicates.values()):
+        print("  %r" % entries[keys[0]]["value"])
+        for key in keys:
+            print("      %s" % key)
+    print("%d duplicate group(s) across %d keys" % (len(duplicates), len(entries)))
+    return 0
+
+
 def main() -> None:
     check_only = "--check" in sys.argv[1:]
     base = load(BASE)
+    if "--duplicates" in sys.argv[1:]:
+        check_base(base)
+        sys.exit(report_duplicates(base))
     if not base:
         raise Failure("en.json is empty")
     base_args = check_base(base)

--- a/Scripts/build_localizations.py
+++ b/Scripts/build_localizations.py
@@ -111,6 +111,49 @@ ARG_TYPES = {
     "int": {"swift": "Int", "spec": "lld", "value_type": "lld"},
 }
 
+# Register rules, per language. Vibe Bar's Chinese is written and terse —
+# the register of a spec, not of a chat message — and a catalog is exactly
+# the place that slips: one contributor writes `用不完` for "Surplus"
+# because it is what you would say out loud, and the app now has two
+# voices. These are the spoken- and internet-register words that have
+# actually turned up, plus the sentence-final mood particles and
+# exclamation marks that mark speech rather than writing.
+#
+# Substrings are only listed when they cannot appear inside a legitimate
+# written compound: `超` is absent because `超出` and `超过` are correct,
+# and `了` is absent because it is a perfectly good aspect marker — only
+# its sentence-final mood use is caught, by anchoring to the punctuation.
+REGISTER = {
+    "zh-Hans": {
+        "spoken or internet register": [
+            "用不完", "差不多", "搞定", "一会儿", "一下子", "大概率",
+            "不够用", "没用掉", "刷新不了", "试试", "咋", "干脆", "省得",
+            "别忘", "挺好", "超级", "东西", "一堆",
+        ],
+        "sentence-final mood particle": ["啦", "呀", "嘛", "吧。", "吧！", "呢。", "呢？"],
+        "exclamation": ["！"],
+        "formal-polite address": ["请您", "您"],
+    }
+}
+
+
+def check_register(language: str, entries: dict) -> None:
+    rules = REGISTER.get(language)
+    if not rules:
+        return
+    for key, entry in sorted(entries.items()):
+        for reason, words in rules.items():
+            for word in words:
+                if word in entry["value"]:
+                    raise Failure(
+                        f"{language}.json: {key} contains {word!r} — {reason}. "
+                        f"Vibe Bar's Chinese is written and terse: prefer the "
+                        f"precise term over the familiar one (盈余 not 用不完, "
+                        f"已用尽 not 没了, 约 not 差不多, 未配置 not 还没设置). "
+                        f"Value: {entry['value']}"
+                    )
+
+
 SWIFT_KEYWORDS = {
     "as", "associatedtype", "break", "case", "catch", "class", "continue",
     "default", "defer", "deinit", "do", "else", "enum", "extension", "fallthrough",
@@ -550,6 +593,7 @@ def main() -> None:
         entries = base if language == BASE else load(language)
         if language != BASE:
             check_translation(language, base, base_args, entries)
+        check_register(language, entries)
         outputs[RESOURCE_DIR / f"{language}.lproj/Localizable.strings"] = (
             render_strings(language, base, entries, base_args)
         )

--- a/Scripts/lint_localization.py
+++ b/Scripts/lint_localization.py
@@ -112,6 +112,7 @@ MIGRATED = [
     "Sources/VibeBarCore/Models/PrimaryProviderRouteHealth.swift",
     "Sources/VibeBarCore/Models/PrimaryProviderSourcePlanner.swift",
     "Sources/VibeBarCore/Models/UpdateChannel.swift",
+    "Sources/VibeBarApp/Views/RemoteMachinesPage.swift",
 ]
 
 

--- a/Scripts/lint_localization.py
+++ b/Scripts/lint_localization.py
@@ -93,6 +93,18 @@ MIGRATED = [
     "Sources/VibeBarApp/Views/Workbench/SkillDiscoverSheet.swift",
     "Sources/VibeBarApp/Views/Workbench/SkillImportSheet.swift",
     "Sources/VibeBarApp/Views/Workbench/SkillBackupsSheet.swift",
+    # Batch A: Settings and its panes. The menu-bar half (StatusItemController,
+    # MenuBarStripView, MenuBarComposerEditor, MenuBarComposition,
+    # MenuBarFieldsEditor, MenuBarHealthSettingsSection) is deliberately absent
+    # — the composer PR rewrites those files and migrating them now would be a
+    # conflict for no benefit.
+    "Sources/VibeBarApp/Views/SettingsSidebarView.swift",
+    "Sources/VibeBarApp/Views/MCPSettingsSection.swift",
+    "Sources/VibeBarApp/Views/MiniWindowsSettingsSection.swift",
+    "Sources/VibeBarApp/Views/PricingSettingsSection.swift",
+    "Sources/VibeBarApp/Views/RemoteSettingsSection.swift",
+    "Sources/VibeBarApp/Views/MiscProviderSettingsSection.swift",
+    "Sources/VibeBarApp/Views/SettingsView.swift",
 ]
 
 
@@ -398,11 +410,33 @@ def derived_helpers(files) -> set:
 LETTER = re.compile(r"[A-Za-z一-鿿]")
 
 # Per-file exceptions: a literal that reads like copy but is not, keyed by
-# the reason it is exempt. Deliberately empty — every case so far has been
-# better answered by the glossary (a name) or by `IDENTIFIER_ARGUMENTS` (an
+# the reason it is exempt. Kept short on purpose — most cases are better
+# answered by the glossary (a name) or by `IDENTIFIER_ARGUMENTS` (an
 # argument that never carries copy), and an exception that names one file is
 # the thing that quietly grows into a second, unreviewed allowlist.
-ALLOWED: dict = {}
+ALLOWED: dict = {
+    "a format mask shown as a field placeholder: it is the shape of the "
+    "value the user types, and every language types the same shape": {
+        "Views/RemoteSettingsSection.swift": {"VB-XXXXX-XXXXX"},
+    },
+    # `menuBarOverviewEditor()` is the one part of SettingsView the menu-bar
+    # composer PR rewrites. Migrating it now would be a merge conflict for no
+    # benefit, so the rest of the file is guarded and these eight strings are
+    # deferred to the menu-bar pass. Delete this entry when that pass lands —
+    # it is a promise with an owner, not a permanent exemption.
+    "owned by the in-flight menu-bar composer; migrated in the menu-bar pass": {
+        "Views/SettingsView.swift": {
+            "Show in menu bar",
+            "Show title text",
+            "Layout",
+            "Combine a group's windows",
+            "Shows 5 Hours and Weekly as 5%/100% instead of two entries.",
+            "Display density",
+            "Percent color",
+            "Fields",
+        },
+    },
+}
 
 
 def glossary_terms() -> set:
@@ -415,9 +449,16 @@ def glossary_terms() -> set:
     return terms
 
 
+URL = re.compile(r"^[a-z][a-z0-9+.-]*://\S*$|^~?/[\w./~-]*$")
+
+
 def is_allowed(text: str, terms: set, path: str) -> bool:
     stripped = text.strip()
     if not stripped or not LETTER.search(stripped):
+        return True
+    # A URL or a bare filesystem path is an address, not a sentence. No
+    # language spells `https://` differently.
+    if URL.match(stripped):
         return True
     if stripped in terms:
         return True

--- a/Scripts/lint_localization.py
+++ b/Scripts/lint_localization.py
@@ -93,11 +93,10 @@ MIGRATED = [
     "Sources/VibeBarApp/Views/Workbench/SkillDiscoverSheet.swift",
     "Sources/VibeBarApp/Views/Workbench/SkillImportSheet.swift",
     "Sources/VibeBarApp/Views/Workbench/SkillBackupsSheet.swift",
-    # Batch A: Settings and its panes. The menu-bar half (StatusItemController,
-    # MenuBarStripView, MenuBarComposerEditor, MenuBarComposition,
-    # MenuBarFieldsEditor, MenuBarHealthSettingsSection) is deliberately absent
-    # — the composer PR rewrites those files and migrating them now would be a
-    # conflict for no benefit.
+    # Settings, its panes, and the model types whose `label` / `title` /
+    # `detail` properties they render. An enum carrying a presentation string
+    # looks like a model detail and *is* UI: the picker label was localized
+    # while its choices stayed English until a reviewer caught it.
     "Sources/VibeBarApp/Views/SettingsSidebarView.swift",
     "Sources/VibeBarApp/Views/MCPSettingsSection.swift",
     "Sources/VibeBarApp/Views/MiniWindowsSettingsSection.swift",
@@ -105,6 +104,14 @@ MIGRATED = [
     "Sources/VibeBarApp/Views/RemoteSettingsSection.swift",
     "Sources/VibeBarApp/Views/MiscProviderSettingsSection.swift",
     "Sources/VibeBarApp/Views/SettingsView.swift",
+    "Sources/VibeBarCore/Models/AppSettings.swift",
+    "Sources/VibeBarCore/Models/DisplayMode.swift",
+    "Sources/VibeBarCore/Models/MenuBarSettings.swift",
+    "Sources/VibeBarCore/Models/MiscProviderSettings.swift",
+    "Sources/VibeBarCore/Models/PreferredTerminal.swift",
+    "Sources/VibeBarCore/Models/PrimaryProviderRouteHealth.swift",
+    "Sources/VibeBarCore/Models/PrimaryProviderSourcePlanner.swift",
+    "Sources/VibeBarCore/Models/UpdateChannel.swift",
 ]
 
 
@@ -418,23 +425,6 @@ ALLOWED: dict = {
     "a format mask shown as a field placeholder: it is the shape of the "
     "value the user types, and every language types the same shape": {
         "Views/RemoteSettingsSection.swift": {"VB-XXXXX-XXXXX"},
-    },
-    # `menuBarOverviewEditor()` is the one part of SettingsView the menu-bar
-    # composer PR rewrites. Migrating it now would be a merge conflict for no
-    # benefit, so the rest of the file is guarded and these eight strings are
-    # deferred to the menu-bar pass. Delete this entry when that pass lands —
-    # it is a promise with an owner, not a permanent exemption.
-    "owned by the in-flight menu-bar composer; migrated in the menu-bar pass": {
-        "Views/SettingsView.swift": {
-            "Show in menu bar",
-            "Show title text",
-            "Layout",
-            "Combine a group's windows",
-            "Shows 5 Hours and Weekly as 5%/100% instead of two entries.",
-            "Display density",
-            "Percent color",
-            "Fields",
-        },
     },
 }
 

--- a/Sources/VibeBarApp/Views/MCPSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/MCPSettingsSection.swift
@@ -27,27 +27,27 @@ struct MCPSettingsSection: View {
     // MARK: - Status
 
     private var statusSection: some View {
-        section("MCP Server") {
-            Text("Vibe Bar can expose this Mac's quota, usage, cost and local agent sessions to your coding agents over MCP. The server listens on a Unix domain socket in your home directory — no network port is opened, and no token is created: the socket's file permissions are the access control.")
+        section(L10n.Settings.mcpTitle) {
+            Text(L10n.Settings.mcpIntro)
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
-            Toggle("Enable the local MCP server", isOn: $settingsStore.settings.mcpServer.enabled)
+            Toggle(L10n.Settings.mcpEnable, isOn: $settingsStore.settings.mcpServer.enabled)
                 .toggleStyle(.switch)
                 .controlSize(.small)
 
             if settingsStore.settings.mcpServer.enabled {
-                infoRow("Status", controller.isRunning ? "Listening" : "Not listening")
-                infoRow("Socket", controller.displaySocketPath)
-                infoRow("Connected clients", "\(controller.connectionCount)")
-                infoRow("Last client activity", lastActivityText)
+                infoRow(L10n.Settings.mcpStatus, controller.isRunning ? L10n.Settings.mcpListening : L10n.Settings.mcpNotListening)
+                infoRow(L10n.Settings.mcpSocket, controller.displaySocketPath)
+                infoRow(L10n.Settings.mcpConnectedClients, AppLocale.number(controller.connectionCount))
+                infoRow(L10n.Settings.mcpLastActivity, lastActivityText)
                 if let error = controller.startupError {
                     Text(error)
                         .font(.caption2)
                         .foregroundStyle(.orange)
                         .textSelection(.enabled)
                 }
-                Text("The socket exists only while Vibe Bar is running. Agents configured below report “Vibe Bar is not running” when it is quit, which is the intended behaviour.")
+                Text(L10n.Settings.mcpSocketLifetime)
                     .font(.caption2)
                     .foregroundStyle(.tertiary)
             }
@@ -62,51 +62,51 @@ struct MCPSettingsSection: View {
     // MARK: - Setup
 
     private var setupSection: some View {
-        section("Connect an agent") {
-            Text("The quickest path: paste this into any agent and let it configure itself, install the companion skill, and verify the connection.")
+        section(L10n.Settings.mcpConnectAgent) {
+            Text(L10n.Settings.mcpQuickestPath)
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
             copyRow(
-                title: "Agent setup prompt",
-                subtitle: "One line, works in any agent that can fetch a URL.",
+                title: L10n.Settings.mcpSetupPrompt,
+                subtitle: L10n.Settings.mcpSetupPromptDetail,
                 systemImage: "sparkles",
                 value: MCPClientConfig.agentSetupPrompt
             )
 
             Divider()
 
-            Text("Or configure a client by hand. Every client runs the same command — Vibe Bar's own binary with \(MCPStdioBridge.commandLineFlag), which bridges stdin/stdout to the socket above.")
+            Text(L10n.Settings.mcpManualIntro(flag: MCPStdioBridge.commandLineFlag))
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
             copyRow(
                 title: "Claude Code",
-                subtitle: "Run in a terminal.",
+                subtitle: L10n.Settings.mcpRunInTerminal,
                 systemImage: "terminal",
                 value: MCPClientConfig.claudeCodeCommand(executablePath: executablePath)
             )
             copyRow(
                 title: "Codex CLI",
-                subtitle: "Append to ~/.codex/config.toml.",
+                subtitle: L10n.Settings.mcpAppendCodexConfig,
                 systemImage: "doc.plaintext",
                 value: MCPClientConfig.codexTOML(executablePath: executablePath)
             )
             copyRow(
                 title: "Cursor",
-                subtitle: "Merge into ~/.cursor/mcp.json.",
+                subtitle: L10n.Settings.mcpMergeCursorConfig,
                 systemImage: "curlybraces",
                 value: MCPClientConfig.cursorJSON(executablePath: executablePath)
             )
             copyRow(
-                title: "Any other stdio client",
-                subtitle: "One entry for the client's own mcpServers map.",
+                title: L10n.Settings.mcpOtherStdioClient,
+                subtitle: L10n.Settings.mcpOtherStdioDetail,
                 systemImage: "puzzlepiece.extension",
                 value: MCPClientConfig.genericJSON(executablePath: executablePath)
             )
 
             if !isInstalledInApplications {
-                Text("Vibe Bar is running from \(executablePath). Move it to /Applications before saving a client config, or the config breaks the next time you rebuild.")
+                Text(L10n.Settings.mcpMovePrompt(path: executablePath))
                     .font(.caption2)
                     .foregroundStyle(.orange)
             }
@@ -129,32 +129,34 @@ struct MCPSettingsSection: View {
     // MARK: - Behaviour
 
     private var behaviourSection: some View {
-        section("What agents may do") {
+        section(L10n.Settings.mcpWhatAgentsMayDo) {
             Toggle(
-                "Allow agents to refresh quota",
+                L10n.Settings.mcpAllowRefresh,
                 isOn: $settingsStore.settings.mcpServer.allowRefreshTools
             )
             .toggleStyle(.switch)
             .controlSize(.small)
             .disabled(!settingsStore.settings.mcpServer.enabled)
 
-            Text("With this on, an agent can ask Vibe Bar to re-fetch quota from your providers. Forced refreshes are rate-limited to one every \(Int(MCPServer.forcedRefreshMinimumInterval)) seconds. With it off the read-only tools keep working and quota.refresh reports that refreshing is disabled.")
+            Text(L10n.Settings.mcpAllowRefreshDetail(
+                seconds: Int(MCPServer.forcedRefreshMinimumInterval)
+            ))
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
             Toggle(
-                "Allow agents to install skills",
+                L10n.Settings.mcpAllowSkills,
                 isOn: $settingsStore.settings.mcpServer.allowSkillInstall
             )
             .toggleStyle(.switch)
             .controlSize(.small)
             .disabled(!settingsStore.settings.mcpServer.enabled)
 
-            Text("With this on, an agent can call skills.install to add a skill from a GitHub repository or a local folder. It goes through the same Skills manager as Workbench → Skills, so it writes only to ~/.agents/skills and the agent skills directories Vibe Bar manages — never over a folder a different skill already holds. With it off the tool reports that installing is disabled.")
+            Text(L10n.Settings.mcpAllowSkillsDetail)
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
-            Text("Everything else agents can reach is read-only: quota, token usage, cost, provider status, effective model prices, and the local session index (titles, projects, and — when session body indexing is on — message excerpts). Credentials, cookies and organization ids are never exposed, and email addresses are masked.")
+            Text(L10n.Settings.mcpReadOnlyDetail)
                 .font(.caption2)
                 .foregroundStyle(.tertiary)
         }
@@ -181,7 +183,10 @@ struct MCPSettingsSection: View {
                 Button {
                     copy(value, label: title)
                 } label: {
-                    Label(copied == title ? "Copied" : "Copy", systemImage: copied == title ? "checkmark" : systemImage)
+                    Label(
+                        copied == title ? L10n.Common.copied : L10n.Common.copy,
+                        systemImage: copied == title ? "checkmark" : systemImage
+                    )
                 }
                 .controlSize(.small)
             }

--- a/Sources/VibeBarApp/Views/MiniWindowsSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/MiniWindowsSettingsSection.swift
@@ -144,7 +144,7 @@ struct MiniWindowsSettingsSection: View {
                     .frame(width: 22, height: 22)
             }
             .buttonStyle(.vibeBar)
-            .help("Add a mini window")
+            .help(L10n.Settings.miniWindowAdd)
             Spacer(minLength: 0)
         }
         .padding(3)
@@ -172,7 +172,7 @@ struct MiniWindowsSettingsSection: View {
     private func windowDetail(_ config: MiniWindowConfig) -> some View {
         HStack(spacing: 8) {
             DebouncedSettingsTextField(
-                prompt: "Name",
+                prompt: L10n.Common.name,
                 value: Binding(
                     get: { selectedWindow?.name ?? "" },
                     set: { [configID = config.id] value in
@@ -186,23 +186,25 @@ struct MiniWindowsSettingsSection: View {
                 )
             )
             .frame(width: 140)
-            Button("Open / Close") {
+            Button(L10n.Settings.miniWindowOpenClose) {
                 NotificationCenter.default.post(
                     name: .vibeBarToggleMiniWindow,
                     object: nil,
                     userInfo: ["configID": config.id.uuidString]
                 )
             }
-            .help("Toggle this mini window on screen")
+            .help(L10n.Settings.miniWindowToggleHelp)
             Spacer(minLength: 8)
             Button(role: .destructive) {
                 removeWindow(config.id)
             } label: {
-                Label("Remove", systemImage: "trash")
+                Label(L10n.Common.remove, systemImage: "trash")
                     .font(.system(size: 11))
             }
             .disabled(windows.count <= 1)
-            .help(windows.count <= 1 ? "The last mini window cannot be removed." : "Remove this mini window")
+            .help(windows.count <= 1
+                    ? L10n.Settings.miniWindowLastCannotBeRemoved
+                    : L10n.Settings.miniWindowRemoveHelp)
         }
 
         modePicker(config)
@@ -210,7 +212,7 @@ struct MiniWindowsSettingsSection: View {
             .font(.caption)
             .foregroundStyle(.secondary)
         if config.displayMode == .strip {
-            Picker("Strip density", selection: Binding(
+            Picker(L10n.Settings.miniWindowStripDensity, selection: Binding(
                 get: { selectedWindow?.stripDensity ?? .roomy },
                 set: { value in update { $0.stripDensity = value } }
             )) {
@@ -224,39 +226,39 @@ struct MiniWindowsSettingsSection: View {
                 .foregroundStyle(.secondary)
         }
 
-        Text("Double-click on the window cycles its style. Tap a style to include it — the badge is its turn in the cycle. Nothing selected means every style, in this order.")
+        Text(L10n.Settings.miniWindowStyleCycle)
             .font(.caption)
             .foregroundStyle(.secondary)
             .fixedSize(horizontal: false, vertical: true)
         cycleEditor(config)
 
-        Text("One tree for the window — grouped exactly as it folds them (company → SubProvider → quota group → bucket). Drag a row to reorder, ✕ to remove, and rename any level in place. First field renders leftmost (or topmost).")
+        Text(L10n.Settings.miniWindowTreeDetail)
             .font(.caption)
             .foregroundStyle(.secondary)
             .fixedSize(horizontal: false, vertical: true)
         HStack(spacing: 4) {
-            namingScopeButton(.shared, label: "Names: all windows")
-            namingScopeButton(.window, label: "Only “\(config.name)”")
-            namingScopeButton(.style, label: "Only \(config.displayMode.label) here")
+            namingScopeButton(.shared, label: L10n.Settings.miniWindowNamesAllWindows)
+            namingScopeButton(.window, label: L10n.Settings.miniWindowNamesThisWindow(name: config.name))
+            namingScopeButton(.style, label: L10n.Settings.miniWindowNamesThisStyle(mode: config.displayMode.label))
             Spacer(minLength: 0)
         }
         .padding(3)
         .background(Capsule(style: .continuous).fill(Color.primary.opacity(0.045)))
         if namingScope == .window {
-            Text("Name overrides for this window only. An empty field inherits the shared name — shown as the placeholder.")
+            Text(L10n.Settings.miniWindowOverridesWindow)
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
         }
         if namingScope == .style {
-            Text("Overrides for the \(config.displayMode.label) style of this window only. An empty field inherits the window name, then the shared one — shown as the placeholder.")
+            Text(L10n.Settings.miniWindowOverridesStyle(mode: config.displayMode.label))
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
         }
         arrangementList(config)
 
-        Text("Not in “\(config.name)” — tick a bucket to add it. Buckets the adapters discover at runtime appear here automatically; a dimmed row is remembered but not in the account's current response, and ✕ dismisses it until the provider returns it.")
+        Text(L10n.Settings.miniWindowNotInWindow(name: config.name))
             .font(.caption)
             .foregroundStyle(.secondary)
             .fixedSize(horizontal: false, vertical: true)
@@ -316,7 +318,7 @@ struct MiniWindowsSettingsSection: View {
                 } label: {
                     HStack(spacing: 5) {
                         if let position {
-                            Text("\(position + 1)")
+                            Text(L10n.Settings.miniWindowPosition(position: position + 1))
                                 .font(.system(size: 8.5, weight: .bold, design: .rounded).monospacedDigit())
                                 .foregroundStyle(Color.accentColor)
                                 .frame(width: 12, height: 12)
@@ -343,7 +345,7 @@ struct MiniWindowsSettingsSection: View {
                     .contentShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
                 }
                 .buttonStyle(.vibeBar(cornerRadius: 6))
-                .help("Include \(mode.label) in the double-click cycle")
+                .help(L10n.Settings.miniWindowIncludeStyle(mode: mode.label))
             }
         }
     }
@@ -417,7 +419,7 @@ struct MiniWindowsSettingsSection: View {
         }
         return VStack(alignment: .leading, spacing: 12) {
             if sections.isEmpty {
-                Text("Every known bucket is already in this window.")
+                Text(L10n.Settings.miniWindowAllBucketsIncluded)
                     .font(.caption)
                     .foregroundStyle(.tertiary)
             }
@@ -473,8 +475,8 @@ struct MiniWindowsSettingsSection: View {
                 .buttonStyle(.vibeBar)
                 .help(
                     entry.discovered != nil
-                        ? "Forget this discovered bucket — drops it from the list and from every window that selected it."
-                        : "Dismiss this built-in bucket while the provider is not returning it. It comes back the moment the provider does."
+                        ? L10n.Settings.miniWindowForgetDiscovered
+                        : L10n.Settings.miniWindowDismissBuiltIn
                 )
             }
         }
@@ -579,7 +581,7 @@ struct MiniWindowsSettingsSection: View {
     private func arrangementList(_ config: MiniWindowConfig) -> some View {
         let rows = arrangeRows(config)
         if rows.isEmpty {
-            Text("No fields selected — tick some above.")
+            Text(L10n.Settings.miniWindowNoFieldsSelected)
                 .font(.caption)
                 .foregroundStyle(.tertiary)
         } else {
@@ -719,7 +721,7 @@ struct MiniWindowsSettingsSection: View {
                 .lineLimit(1)
                 .minimumScaleFactor(0.75)
             if !isLive {
-                Text("offline")
+                Text(L10n.Settings.miniWindowOffline)
                     .font(.system(size: 8.5, weight: .semibold, design: .rounded))
                     .foregroundStyle(.tertiary)
             }
@@ -729,7 +731,7 @@ struct MiniWindowsSettingsSection: View {
                 title: row.option.title, defaultLabel: row.option.defaultLabel
             ))
             if let percent {
-                Text("\(Int(percent.rounded()))%")
+                Text(L10n.Common.percent(value: Int(percent.rounded())))
                     .font(.system(size: 10.5, weight: .bold, design: .rounded).monospacedDigit())
                     .foregroundStyle(Theme.barColor(percent: percent, mode: settingsStore.displayMode))
             }
@@ -759,7 +761,7 @@ struct MiniWindowsSettingsSection: View {
                     .frame(width: 16, height: 16)
             }
             .buttonStyle(.vibeBar)
-            .help("Remove from this window")
+            .help(L10n.Settings.miniWindowRemoveFromWindow)
         }
         .padding(.horizontal, 8)
         .padding(.leading, 8)

--- a/Sources/VibeBarApp/Views/MiniWindowsSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/MiniWindowsSettingsSection.swift
@@ -449,7 +449,7 @@ struct MiniWindowsSettingsSection: View {
         let isLive = liveFieldIds.contains(entry.option.id)
         return HStack(spacing: 10) {
             Toggle(isOn: fieldSelectedBinding(entry.option.id)) {
-                Text(entry.option.title)
+                Text(entry.option.displayTitle)
                     .font(.system(size: 12, weight: .medium))
                     .lineLimit(2)
             }
@@ -676,7 +676,8 @@ struct MiniWindowsSettingsSection: View {
         } ?? groupKey
         let defaultLabel = MiniWindowGroupLabelCatalog.defaultLabel(for: groupKey) ?? fallback
         let resolved = settingsStore.settings.miniWindow
-            .resolvedGroupLabel(config: selectedWindow, key: groupKey) ?? defaultLabel
+            .resolvedGroupLabel(config: selectedWindow, key: groupKey)
+            ?? QuotaGroupLabelLocalizer.display(defaultLabel)
         return HStack(spacing: 8) {
             Text(resolved.uppercased())
                 .font(.system(size: 8, weight: .medium, design: .rounded))
@@ -685,7 +686,8 @@ struct MiniWindowsSettingsSection: View {
             Spacer(minLength: 8)
             nameField(NamingRow(
                 kind: .group, key: groupKey,
-                title: defaultLabel, defaultLabel: defaultLabel
+                title: QuotaGroupLabelLocalizer.display(defaultLabel),
+                defaultLabel: QuotaGroupLabelLocalizer.display(defaultLabel)
             ))
         }
         .padding(.leading, 26)
@@ -716,7 +718,7 @@ struct MiniWindowsSettingsSection: View {
             Circle()
                 .fill(Theme.providerAccent(for: row.option.tool))
                 .frame(width: 6, height: 6)
-            Text(row.option.title)
+            Text(row.option.displayTitle)
                 .font(.system(size: 11.5, weight: .medium))
                 .lineLimit(1)
                 .minimumScaleFactor(0.75)
@@ -728,7 +730,8 @@ struct MiniWindowsSettingsSection: View {
             Spacer(minLength: 6)
             nameField(NamingRow(
                 kind: .field, key: row.id,
-                title: row.option.title, defaultLabel: row.option.defaultLabel
+                title: row.option.displayTitle,
+                defaultLabel: row.option.displayDefaultLabel
             ))
             if let percent {
                 Text(L10n.Common.percent(value: Int(percent.rounded())))

--- a/Sources/VibeBarApp/Views/MiscProviderSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/MiscProviderSettingsSection.swift
@@ -28,13 +28,13 @@ struct MiscProviderSettingsSection: View {
                     .font(.system(size: 11, weight: .semibold))
                     .foregroundStyle(.tertiary)
                     .frame(width: 14)
-                    .help("Drag to reorder")
+                    .help(L10n.Common.dragToReorder)
                 Toggle(isOn: visibilityBinding) {
                     EmptyView()
                 }
                 .toggleStyle(.checkbox)
                 .labelsHidden()
-                .help("Show \(tool.menuTitle) on the Misc page")
+                .help(L10n.Onboarding.apiKeysShowOnMiscPage(provider: tool.menuTitle))
                 ToolBrandBadge(tool: tool, iconSize: 17, containerSize: 24)
                 Text(tool.menuTitle)
                     .font(.system(size: 13, weight: .semibold))
@@ -50,7 +50,7 @@ struct MiscProviderSettingsSection: View {
                 Spacer(minLength: 8)
                 BorderlessIconButton(
                     systemImage: "doc.on.doc",
-                    help: "Clone \(tool.menuTitle)",
+                    help: L10n.Settings.miscClone(provider: tool.menuTitle),
                     size: 10
                 ) {
                     _ = settingsStore.settings.cloneMiscProviderInstance(id: instanceID)
@@ -58,7 +58,7 @@ struct MiscProviderSettingsSection: View {
                 if !instance.isDefault {
                     BorderlessIconButton(
                         systemImage: "trash",
-                        help: "Remove this \(tool.menuTitle) copy",
+                        help: L10n.Settings.miscRemoveCopy(provider: tool.menuTitle),
                         size: 10
                     ) {
                         isConfirmingRemoval = true
@@ -72,14 +72,14 @@ struct MiscProviderSettingsSection: View {
         // back. A one-click trash icon next to a Clone button is too easy
         // to hit for something irreversible.
         .confirmationDialog(
-            "Remove this \(tool.menuTitle) copy?",
+            L10n.Settings.miscRemoveCopyTitle(provider: tool.menuTitle),
             isPresented: $isConfirmingRemoval,
             titleVisibility: .visible
         ) {
-            Button("Remove Copy", role: .destructive, action: removeClone)
-            Button("Cancel", role: .cancel) {}
+            Button(L10n.Settings.miscRemoveCopyButton, role: .destructive, action: removeClone)
+            Button(L10n.Common.cancel, role: .cancel) {}
         } message: {
-            Text("Its saved credentials are deleted from your Keychain — the API key or AK/SK and every imported cookie slot. This cannot be undone.")
+            Text(L10n.Settings.miscRemoveCopyDetail)
         }
     }
 
@@ -141,7 +141,7 @@ struct MiscProviderCredentialRows: View {
                 ApiKeyField(
                     tool: .zai,
                     instanceID: instanceID,
-                    prompt: "Paste Z.ai API key (zai-...)",
+                    prompt: L10n.Settings.miscPromptZai,
                     helpText: "Find it under API Keys on z.ai (Global) or open.bigmodel.cn (China mainland). Stored in macOS Keychain."
                 )
                 ZaiRegionPicker(instanceID: instanceID)
@@ -149,7 +149,7 @@ struct MiscProviderCredentialRows: View {
         case .copilot:
             VStack(alignment: .leading, spacing: 4) {
                 CopilotDeviceLoginRow(instanceID: instanceID)
-                EnterpriseHostField(tool: .copilot, instanceID: instanceID, prompt: "GitHub Enterprise host (optional, e.g. github.example.com)")
+                EnterpriseHostField(tool: .copilot, instanceID: instanceID, prompt: L10n.Settings.miscPromptCopilotHost)
             }
         case .gemini:
             EmptyView()
@@ -158,7 +158,7 @@ struct MiscProviderCredentialRows: View {
                 ApiKeyField(
                     tool: .alibaba,
                     instanceID: instanceID,
-                    prompt: "Paste DashScope API key (sk-...) — optional",
+                    prompt: L10n.Settings.miscPromptDashscope,
                     helpText: "If you have a DashScope key, paste it here. Otherwise sign in via Web below to use console cookies. Stored in macOS Keychain."
                 )
                 AlibabaRegionPicker(instanceID: instanceID)
@@ -183,7 +183,7 @@ struct MiscProviderCredentialRows: View {
                 ) == .team {
                     AlibabaRegionPicker(instanceID: instanceID)
                 } else {
-                    Text("Personal Token Plan is currently available only in China mainland (cn-beijing). Clone this row to track Team and Personal together.")
+                    Text(L10n.Settings.miscTencentTokenPlanNote)
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -203,7 +203,7 @@ struct MiscProviderCredentialRows: View {
                 ApiKeyField(
                     tool: .minimax,
                     instanceID: instanceID,
-                    prompt: "Paste MiniMax Token Plan API key (sk-cp-... or MINIMAX_CODING_API_KEY)",
+                    prompt: L10n.Settings.miscPromptMinimax,
                     helpText: "Find it under Billing → Token Plan. Stored in macOS Keychain. Env fallback: MINIMAX_CODING_API_KEY, then MINIMAX_API_KEY."
                 )
                 MiniMaxRegionPicker(instanceID: instanceID)
@@ -304,9 +304,9 @@ struct MiscProviderCredentialRows: View {
                 WorkspaceIDField(
                     tool: .openCodeGo,
                     instanceID: instanceID,
-                    prompt: "Workspace ID or URL (optional, wrk_... or /workspace/wrk_.../go)"
+                    prompt: L10n.Settings.miscPromptWorkspace
                 )
-                Text("Only needed when the account owns more than one workspace — otherwise Vibe Bar uses the first one it finds.")
+                Text(L10n.Settings.miscWorkspaceNote)
                     .font(.caption)
                     .foregroundStyle(.tertiary)
             }
@@ -314,7 +314,7 @@ struct MiscProviderCredentialRows: View {
             ApiKeyField(
                 tool: .kilo,
                 instanceID: instanceID,
-                prompt: "Paste Kilo API key (optional)",
+                prompt: L10n.Settings.miscPromptKilo,
                 helpText: "From app.kilo.ai → API Keys, and optional: Vibe Bar also reads the auth file `kilo login` writes under ~/.local/share/kilo/. Env fallback: KILO_API_KEY."
             )
         case .kiro:
@@ -330,16 +330,16 @@ struct MiscProviderCredentialRows: View {
                 ApiKeyField(
                     tool: .openRouter,
                     instanceID: instanceID,
-                    prompt: "Paste OpenRouter API key (sk-or-v1-...)",
+                    prompt: L10n.Settings.miscPromptOpenRouter,
                     helpText: "From openrouter.ai → Keys; credit-read access is enough. Stored in macOS Keychain. Env fallback: OPENROUTER_API_KEY."
                 )
-                EnterpriseHostField(tool: .openRouter, instanceID: instanceID, prompt: "OpenRouter API URL (optional, defaults to https://openrouter.ai/api/v1)")
+                EnterpriseHostField(tool: .openRouter, instanceID: instanceID, prompt: L10n.Settings.miscPromptOpenRouterHost)
             }
         case .warp:
             ApiKeyField(
                 tool: .warp,
                 instanceID: instanceID,
-                prompt: "Paste Warp API key (wk-...)",
+                prompt: L10n.Settings.miscPromptWarp,
                 helpText: "Open Warp → Settings → AI → API Keys to mint one. Stored in macOS Keychain. Env fallback: WARP_API_KEY, then WARP_TOKEN."
             )
         case .codex, .claude, .gemini, .antigravity, .grok, .cursor:
@@ -380,7 +380,7 @@ struct MiscProviderSetupNote: View {
                 // either console could be the one holding the credential.
                 ForEach(consoleLinks) { link in
                     Link(destination: link.url) {
-                        Text("\(link.title) →")
+                        Text(L10n.Settings.miscConsoleLink(title: link.title))
                             .font(.caption)
                     }
                     .buttonStyle(.plain)
@@ -457,7 +457,7 @@ struct AlibabaTokenPlanVariantPicker: View {
     @EnvironmentObject var settingsStore: SettingsStore
 
     var body: some View {
-        Picker("Edition", selection: choiceBinding) {
+        Picker(L10n.Settings.miscEdition, selection: choiceBinding) {
             ForEach(AlibabaTokenPlanVariant.allCases, id: \.rawValue) { choice in
                 Text(choice.displayLabel).tag(choice)
             }
@@ -497,7 +497,7 @@ private struct CopyNameField: View {
             .font(.caption2)
             .frame(width: 120)
             .focused($isFocused)
-            .help("Rename this copy")
+            .help(L10n.Settings.miscRename)
             .onAppear(perform: syncDraft)
             .onSubmit(save)
             .onChange(of: isFocused) { _, focused in
@@ -547,20 +547,20 @@ struct ApiKeyField: View {
                 SecureField(prompt, text: $draft)
                     .textFieldStyle(.roundedBorder)
                     .onSubmit(save)
-                Button("Save", action: save)
+                Button(L10n.Common.save, action: save)
                     .disabled(draft.isEmpty)
                 if hasStored {
                     Button(role: .destructive, action: clear) {
                         Image(systemName: "trash")
                     }
-                    .help("Remove stored \(tool.menuTitle) API key")
+                    .help(L10n.Settings.miscRemoveApiKey(provider: tool.menuTitle))
                 }
             }
             HStack(spacing: 4) {
                 Image(systemName: hasStored ? "checkmark.circle.fill" : "info.circle")
                     .foregroundStyle(hasStored ? Color.green : Color.secondary)
                     .font(.caption)
-                Text(hasStored ? "API key saved in Keychain." : helpText)
+                Text(hasStored ? L10n.Settings.miscApiKeySaved : helpText)
                     .font(.caption)
                     .foregroundStyle(hasStored ? .secondary : .tertiary)
             }
@@ -637,26 +637,26 @@ struct AkSkField: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            TextField("Access Key ID (AKLT…)", text: $akDraft)
+            TextField(L10n.Settings.miscAccessKeyId, text: $akDraft)
                 .textFieldStyle(.roundedBorder)
             HStack(spacing: 6) {
-                SecureField("Secret Access Key", text: $skDraft)
+                SecureField(L10n.Settings.miscSecretAccessKey, text: $skDraft)
                     .textFieldStyle(.roundedBorder)
                     .onSubmit(save)
-                Button("Save", action: save)
+                Button(L10n.Common.save, action: save)
                     .disabled(akDraft.isEmpty || skDraft.isEmpty)
                 if hasStored {
                     Button(role: .destructive, action: clear) {
                         Image(systemName: "trash")
                     }
-                    .help("Remove stored \(tool.menuTitle) AK/SK")
+                    .help(L10n.Settings.miscRemoveAkSk(provider: tool.menuTitle))
                 }
             }
             HStack(spacing: 4) {
                 Image(systemName: hasStored ? "checkmark.circle.fill" : "info.circle")
                     .foregroundStyle(hasStored ? Color.green : Color.secondary)
                     .font(.caption)
-                Text(hasStored ? "AK/SK saved in Keychain." : helpText)
+                Text(hasStored ? L10n.Settings.miscAkSkSaved : helpText)
                     .font(.caption)
                     .foregroundStyle(hasStored ? .secondary : .tertiary)
             }
@@ -739,7 +739,7 @@ struct CopilotDeviceLoginRow: View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 6) {
                 Label(
-                    hasStoredToken ? "GitHub device token saved in Keychain." : "Sign in with GitHub device flow.",
+                    hasStoredToken ? L10n.Settings.miscGithubTokenSaved : L10n.Settings.miscGithubSignInHint,
                     systemImage: hasStoredToken ? "checkmark.circle.fill" : "person.crop.circle.badge.key"
                 )
                 .font(.caption)
@@ -747,7 +747,7 @@ struct CopilotDeviceLoginRow: View {
 
                 Spacer(minLength: 4)
 
-                Button(isSigningIn ? "Waiting..." : "Sign in") {
+                Button(isSigningIn ? L10n.Settings.miscWaiting : L10n.Settings.miscSignIn) {
                     startLogin()
                 }
                 .buttonStyle(.bordered)
@@ -759,7 +759,7 @@ struct CopilotDeviceLoginRow: View {
                         Image(systemName: "trash")
                     }
                     .buttonStyle(.borderless)
-                    .help("Remove stored GitHub device token")
+                    .help(L10n.Settings.miscRemoveGithubToken)
                 }
             }
 
@@ -860,11 +860,11 @@ struct KiroStatusRow: View {
             Image(systemName: "terminal")
                 .foregroundStyle(.secondary)
                 .font(.caption)
-            Text("Run `kiro-cli login`, then Vibe Bar probes `kiro-cli chat --no-interactive /usage`.")
+            Text(L10n.Settings.miscKiroHint)
                 .font(.caption)
                 .foregroundStyle(.tertiary)
             Spacer(minLength: 4)
-            Button("Probe", action: probe)
+            Button(L10n.Settings.miscProbe, action: probe)
                 .buttonStyle(.bordered)
                 .controlSize(.small)
         }
@@ -927,7 +927,7 @@ struct CookieSourceControls: View {
 
     var body: some View {
         if spec == nil {
-            Text("No cookie spec is registered for \(tool.menuTitle).")
+            Text(L10n.Settings.miscNoCookieSpec(provider: tool.menuTitle))
                 .font(.caption)
                 .foregroundStyle(.orange)
         } else {
@@ -938,7 +938,7 @@ struct CookieSourceControls: View {
     private var controls: some View {
         VStack(alignment: .leading, spacing: 6) {
             if slots.isEmpty {
-                Text("No cookies imported yet — import from your browser or paste below.")
+                Text(L10n.Settings.miscNoCookiesYet)
                     .font(.caption)
                     .foregroundStyle(.tertiary)
             } else {
@@ -949,10 +949,10 @@ struct CookieSourceControls: View {
                 }
             }
             HStack(alignment: .top, spacing: 6) {
-                Button("Import from browser", action: importNow)
+                Button(L10n.Onboarding.cookiesImportFromBrowser, action: importNow)
                     .buttonStyle(.bordered)
                     .controlSize(.small)
-                Text("Adds or refreshes the first signed-in browser profile found; profiles already imported stay stacked, and this provider's quota is the average across every slot listed above. macOS may ask for your login-keychain password once per Chromium-family browser.")
+                Text(L10n.Settings.miscImportDetail)
                     .font(.caption)
                     .foregroundStyle(.tertiary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -960,7 +960,7 @@ struct CookieSourceControls: View {
             HStack(spacing: 6) {
                 SecureField(manualPrompt, text: $manualDraft)
                     .textFieldStyle(.roundedBorder)
-                Button("Add", action: saveManual)
+                Button(L10n.Common.add, action: saveManual)
                     .disabled(manualDraft.isEmpty)
             }
             if let keychainCooldown {
@@ -972,7 +972,7 @@ struct CookieSourceControls: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
-                    Button("Retry now", action: resetCooldownAndRetry)
+                    Button(L10n.Common.retryNow, action: resetCooldownAndRetry)
                         .buttonStyle(.bordered)
                         .controlSize(.small)
                 }
@@ -1176,7 +1176,7 @@ private struct CookieSlotRow: View {
                 Image(systemName: "trash")
             }
             .buttonStyle(.borderless)
-            .help("Remove this cookie slot")
+            .help(L10n.Settings.miscRemoveCookieSlot)
         }
         .padding(.vertical, 2)
         .padding(.horizontal, 6)
@@ -1244,7 +1244,7 @@ struct AlibabaRegionPicker: View {
     }
 
     var body: some View {
-        Picker("Region", selection: choiceBinding) {
+        Picker(L10n.Settings.miscRegion, selection: choiceBinding) {
             ForEach(Choice.allCases) { choice in
                 Text(choice.label).tag(choice)
             }
@@ -1278,7 +1278,7 @@ struct TencentTokenPlanVariantPicker: View {
     @EnvironmentObject var settingsStore: SettingsStore
 
     var body: some View {
-        Picker("Variant", selection: choiceBinding) {
+        Picker(L10n.Settings.miscVariant, selection: choiceBinding) {
             ForEach(TencentTokenPlanVariant.allCases, id: \.rawValue) { choice in
                 Text(choice.displayLabel).tag(choice)
             }
@@ -1325,7 +1325,7 @@ struct ZaiRegionPicker: View {
     }
 
     var body: some View {
-        Picker("Region", selection: choiceBinding) {
+        Picker(L10n.Settings.miscRegion, selection: choiceBinding) {
             ForEach(Choice.allCases) { choice in
                 Text(choice.label).tag(choice)
             }
@@ -1370,7 +1370,7 @@ struct MiniMaxRegionPicker: View {
     }
 
     var body: some View {
-        Picker("Region", selection: choiceBinding) {
+        Picker(L10n.Settings.miscRegion, selection: choiceBinding) {
             ForEach(Choice.allCases) { choice in
                 Text(choice.label).tag(choice)
             }
@@ -1409,7 +1409,7 @@ struct EnterpriseHostField: View {
         HStack(spacing: 6) {
             TextField(prompt, text: $draft, onCommit: save)
                 .textFieldStyle(.roundedBorder)
-            Button("Save", action: save)
+            Button(L10n.Common.save, action: save)
                 .disabled(draft == currentRaw)
         }
         .onAppear { draft = currentRaw }
@@ -1450,14 +1450,14 @@ struct WorkspaceIDField: View {
         HStack(spacing: 6) {
             TextField(prompt, text: $draft, onCommit: save)
                 .textFieldStyle(.roundedBorder)
-            Button("Save", action: save)
+            Button(L10n.Common.save, action: save)
                 .disabled(draft == currentRaw)
             if !currentRaw.isEmpty {
                 Button(role: .destructive, action: clear) {
                     Image(systemName: "trash")
                 }
                 .buttonStyle(.borderless)
-                .help("Clear saved workspace")
+                .help(L10n.Settings.miscClearWorkspace)
             }
         }
         .onAppear { draft = currentRaw }
@@ -1510,7 +1510,7 @@ struct MiscWebLoginRow: View {
                     .foregroundStyle(.tertiary)
                     .fixedSize(horizontal: false, vertical: true)
                 Spacer(minLength: 4)
-                Button("Sign in via Web") {
+                Button(L10n.Settings.miscSignInViaWeb) {
                     environment.openMiscWebLogin(for: tool, instanceID: instanceID)
                 }
                 .buttonStyle(.bordered)

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -2164,7 +2164,7 @@ struct ProviderQuotaCard: View {
                         .opacity(0.18)
                         .padding(.vertical, 1)
                     VStack(alignment: .leading, spacing: density.bucketRowSpacing) {
-                        Text(group.title)
+                        Text(QuotaGroupLabelLocalizer.display(group.title))
                             .font(.system(size: max(9, density.subtitleFontSize - 1), weight: .semibold))
                             .foregroundStyle(.tertiary)
                             .textCase(.uppercase)
@@ -2303,7 +2303,7 @@ private struct ProviderBucketRow: View {
         let isExpired = resetStatus?.isExpired ?? false
         VStack(alignment: .leading, spacing: density.bucketRowSpacing) {
             HStack(alignment: .firstTextBaseline) {
-                Text(bucket.title)
+                Text(QuotaGroupLabelLocalizer.display(bucket.title))
                     .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
                 if let resetStatus {
                     // Same size and scale floor as the primary bucket rows —

--- a/Sources/VibeBarApp/Views/PricingSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/PricingSettingsSection.swift
@@ -40,13 +40,13 @@ struct PricingSettingsSection: View {
     var body: some View {
         let modelPrices = cachedModelPrices()
         return VStack(alignment: .leading, spacing: density.interSectionSpacing) {
-            settingsSection("Model Pricing") {
-                Text("Catalogs refresh in the background. Higher entries win when the same provider and model name appears more than once.")
+            settingsSection(L10n.Onboarding.doneModelPricing) {
+                Text(L10n.Settings.pricingIntro)
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
                 Picker(
-                    "Refresh every",
+                    L10n.Settings.refreshEvery,
                     selection: $settingsStore.settings.pricingRefreshIntervalSeconds
                 ) {
                     ForEach(AppSettings.pricingRefreshIntervalOptions, id: \.self) { seconds in
@@ -57,19 +57,21 @@ struct PricingSettingsSection: View {
                 HStack {
                     Button(action: environment.refreshPricingNow) {
                         Label(
-                            environment.isRefreshingPricing ? "Refreshing…" : "Refresh now",
+                            environment.isRefreshingPricing ? L10n.Settings.pricingRefreshing : L10n.Settings.pricingRefreshNow,
                             systemImage: "arrow.triangle.2.circlepath"
                         )
                     }
                     .disabled(environment.isRefreshingPricing)
 
                     if let date = environment.pricingRefreshStatus.mergedAt {
-                        Text("Merged \(AppLocale.string(date, dateStyle: .medium, timeStyle: .short))")
+                        Text(L10n.Onboarding.donePricingMerged(
+                            when: AppLocale.string(date, dateStyle: .medium, timeStyle: .short)
+                        ))
                             .font(.caption2)
                             .foregroundStyle(.secondary)
                     }
                     Spacer()
-                    Text("\(modelPrices.count) models")
+                    Text(L10n.Onboarding.pricingSourceModels(count: modelPrices.count))
                         .font(.caption2.monospacedDigit())
                         .foregroundStyle(.secondary)
                 }
@@ -77,25 +79,25 @@ struct PricingSettingsSection: View {
 
             EffectivePricingCatalogView(allRows: modelPrices)
 
-            settingsSection("Priority and source health") {
-                priorityRow(number: 1, name: "Local overrides", detail: "Always wins")
+            settingsSection(L10n.Settings.pricingPriorityHealth) {
+                priorityRow(number: 1, name: L10n.Settings.pricingLocalOverridesName, detail: L10n.Settings.pricingAlwaysWins)
                 ForEach(Array(PricingSourceID.allCases.enumerated()), id: \.element) { index, source in
                     sourceRow(number: index + 2, source: source)
                 }
                 priorityRow(
                     number: PricingSourceID.allCases.count + 2,
-                    name: "Bundled fallback",
-                    detail: "Offline floor"
+                    name: L10n.Settings.pricingBundledFallback,
+                    detail: L10n.Settings.pricingOfflineFloor
                 )
             }
 
-            settingsSection("Local overrides") {
-                Text("Prices are USD per one million tokens. Leave cache fields empty when the provider does not publish them.")
+            settingsSection(L10n.Settings.pricingLocalOverrides) {
+                Text(L10n.Settings.pricingOverridesIntro)
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
                 if settingsStore.settings.modelPricingOverrides.isEmpty {
-                    Text("No local overrides.")
+                    Text(L10n.Settings.pricingNoOverrides)
                         .font(.caption)
                         .foregroundStyle(.tertiary)
                 }
@@ -112,7 +114,7 @@ struct PricingSettingsSection: View {
                 Button {
                     settingsStore.settings.modelPricingOverrides.append(ModelPricingOverride())
                 } label: {
-                    Label("Add model override", systemImage: "plus")
+                    Label(L10n.Settings.pricingAddOverride, systemImage: "plus")
                 }
             }
         }
@@ -121,7 +123,7 @@ struct PricingSettingsSection: View {
     private func sourceRow(number: Int, source: PricingSourceID) -> some View {
         let status = environment.pricingRefreshStatus.sources.first { $0.source == source }
         return HStack(spacing: 10) {
-            Text("\(number)")
+            Text(L10n.Settings.pricingNumber(number: number))
                 .font(.caption.monospacedDigit())
                 .foregroundStyle(.tertiary)
                 .frame(width: 18, alignment: .trailing)
@@ -138,7 +140,7 @@ struct PricingSettingsSection: View {
 
     private func priorityRow(number: Int, name: String, detail: String) -> some View {
         HStack(spacing: 10) {
-            Text("\(number)")
+            Text(L10n.Settings.pricingNumber(number: number))
                 .font(.caption.monospacedDigit())
                 .foregroundStyle(.tertiary)
                 .frame(width: 18, alignment: .trailing)
@@ -214,12 +216,12 @@ private struct PricingOverrideEditor: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack {
-                Picker("Provider", selection: $draft.provider) {
+                Picker(L10n.Common.provider, selection: $draft.provider) {
                     ForEach(PricingProviderFamily.allCases) { provider in
                         Text(provider.label).tag(provider)
                     }
                 }
-                TextField("Exact model name", text: $draft.model)
+                TextField(L10n.Settings.pricingExactModelName, text: $draft.model)
                     .textFieldStyle(.roundedBorder)
                 Button(role: .destructive) {
                     commitTask?.cancel()
@@ -230,27 +232,27 @@ private struct PricingOverrideEditor: View {
                     Image(systemName: "trash")
                 }
                 .buttonStyle(.borderless)
-                .help("Delete override")
+                .help(L10n.Settings.pricingDeleteOverride)
             }
 
             HStack {
-                rateField("Input", value: $draft.inputPerMillion)
-                rateField("Output", value: $draft.outputPerMillion)
-                optionalRateField("Cache read", keyPath: \.cacheReadPerMillion)
-                optionalRateField("Cache write", keyPath: \.cacheWritePerMillion)
+                rateField(L10n.Settings.pricingRateInput, value: $draft.inputPerMillion)
+                rateField(L10n.Settings.pricingRateOutput, value: $draft.outputPerMillion)
+                optionalRateField(L10n.Usage.tokensCacheRead, keyPath: \.cacheReadPerMillion)
+                optionalRateField(L10n.Usage.tokensCacheWrite, keyPath: \.cacheWritePerMillion)
             }
 
-            DisclosureGroup("Advanced tiers") {
+            DisclosureGroup(L10n.Settings.pricingAdvancedTiers) {
                 VStack(alignment: .leading, spacing: 8) {
                     HStack {
-                        optionalIntegerField("Threshold tokens", keyPath: \.thresholdTokens)
-                        optionalRateField("Input above", keyPath: \.inputAboveThresholdPerMillion)
-                        optionalRateField("Output above", keyPath: \.outputAboveThresholdPerMillion)
+                        optionalIntegerField(L10n.Settings.pricingThresholdTokens, keyPath: \.thresholdTokens)
+                        optionalRateField(L10n.Settings.pricingInputAbove, keyPath: \.inputAboveThresholdPerMillion)
+                        optionalRateField(L10n.Settings.pricingOutputAbove, keyPath: \.outputAboveThresholdPerMillion)
                     }
                     HStack {
-                        optionalRateField("Cache read above", keyPath: \.cacheReadAboveThresholdPerMillion)
-                        optionalRateField("Cache write above", keyPath: \.cacheWriteAboveThresholdPerMillion)
-                        optionalRateField("Fast multiplier", keyPath: \.fastMultiplier)
+                        optionalRateField(L10n.Settings.pricingCacheReadAbove, keyPath: \.cacheReadAboveThresholdPerMillion)
+                        optionalRateField(L10n.Settings.pricingCacheWriteAbove, keyPath: \.cacheWriteAboveThresholdPerMillion)
+                        optionalRateField(L10n.Settings.pricingFastMultiplier, keyPath: \.fastMultiplier)
                     }
                 }
                 .padding(.top, 6)

--- a/Sources/VibeBarApp/Views/QuotaBucketView.swift
+++ b/Sources/VibeBarApp/Views/QuotaBucketView.swift
@@ -10,7 +10,7 @@ struct QuotaBucketView: View {
         let percent = bucket.displayPercent(mode)
         VStack(alignment: .leading, spacing: 8) {
             HStack(alignment: .firstTextBaseline) {
-                Text(bucket.title)
+                Text(QuotaGroupLabelLocalizer.display(bucket.title))
                     .font(.system(size: 15, weight: .semibold))
                     .foregroundStyle(.primary)
                 Spacer(minLength: 8)

--- a/Sources/VibeBarApp/Views/RemoteMachinesPage.swift
+++ b/Sources/VibeBarApp/Views/RemoteMachinesPage.swift
@@ -4,18 +4,18 @@ import VibeBarCore
 enum RemoteSyncStatusCopy {
     static func title(for code: String) -> String {
         switch code {
-        case "network_offline": return "This Mac is offline"
-        case "network_timeout": return "Relay connection timed out"
-        case "host_lookup_failed": return "Relay host could not be resolved"
-        case "connection_failed": return "Relay connection was interrupted"
-        case "secure_connection_failed": return "Secure Relay connection failed"
-        case "relay_http_401", "relay_http_403": return "Relay access was rejected"
-        case "relay_http_429", "relay_http_503": return "Relay is temporarily busy"
-        case "sequence_gap": return "Probe history has a sequence gap"
-        case "invalid_signature", "unauthorized_producer": return "A Probe could not be verified"
-        case "invalid_response": return "Relay returned an unexpected response"
-        case "sync_failed", "transport_failed": return "Relay transport failed"
-        default: return "Remote sync needs attention"
+        case "network_offline": return L10n.Settings.remoteSyncOffline
+        case "network_timeout": return L10n.Settings.remoteSyncTimeout
+        case "host_lookup_failed": return L10n.Settings.remoteSyncHostLookupFailed
+        case "connection_failed": return L10n.Settings.remoteSyncConnectionFailed
+        case "secure_connection_failed": return L10n.Settings.remoteSyncSecureConnectionFailed
+        case "relay_http_401", "relay_http_403": return L10n.Settings.remoteSyncRejected
+        case "relay_http_429", "relay_http_503": return L10n.Settings.remoteSyncBusy
+        case "sequence_gap": return L10n.Settings.remoteSyncSequenceGap
+        case "invalid_signature", "unauthorized_producer": return L10n.Settings.remoteSyncUnverifiedProbe
+        case "invalid_response": return L10n.Settings.remoteSyncInvalidResponse
+        case "sync_failed", "transport_failed": return L10n.Settings.remoteSyncTransportFailed
+        default: return L10n.Settings.remoteSyncUnknown
         }
     }
 
@@ -23,17 +23,17 @@ enum RemoteSyncStatusCopy {
         switch code {
         case "network_timeout", "connection_failed", "secure_connection_failed",
              "relay_http_429", "relay_http_503":
-            return "Existing machine data is still available. Vibe Bar will retry automatically."
+            return L10n.Settings.remoteSyncRetryDetail
         case "network_offline", "host_lookup_failed":
-            return "Check this Mac's network or proxy path; existing machine data is still available."
+            return L10n.Settings.remoteSyncNetworkDetail
         case "relay_http_401", "relay_http_403":
-            return "The workspace credential may have been revoked. Reconnect this Core in Settings."
+            return L10n.Settings.remoteSyncRejectedDetail
         case "sequence_gap":
-            return "A Probe batch is missing from the Relay stream, so later batches were not imported."
+            return L10n.Settings.remoteSyncSequenceGapDetail
         case "invalid_signature", "unauthorized_producer":
-            return "The current workspace roster does not authorize one of the received batches."
+            return L10n.Settings.remoteSyncUnverifiedProbeDetail
         default:
-            return "No local usage was deleted. Retry now or inspect Remote Core settings for the error code."
+            return L10n.Settings.remoteSyncUnknownDetail
         }
     }
 }
@@ -49,15 +49,15 @@ struct RemoteMachinesPage: View {
             if !service.isConfigured {
                 stateCard(
                     icon: "lock.slash",
-                    title: "Remote Core is not configured",
-                    detail: "Create a Core descriptor, provision a workspace-scoped Relay credential, then import the signed provisioning file. No inbound port is required on this Mac."
+                    title: L10n.Popover.machinesNotConfigured,
+                    detail: L10n.Popover.machinesNotConfiguredDetail
                 )
             } else if service.machines.isEmpty {
                 stateCard(
                     icon: service.isRefreshing ? "arrow.triangle.2.circlepath" : "server.rack",
-                    title: service.isRefreshing ? "Checking the Relay…" : "No remote machine data yet",
+                    title: service.isRefreshing ? L10n.Popover.machinesChecking : L10n.Popover.machinesNoData,
                     detail: service.lastErrorCode.map { RemoteSyncStatusCopy.detail(for: $0) }
-                        ?? "The Relay is connected. A Probe will appear after its first encrypted batch is decrypted and imported."
+                        ?? L10n.Popover.machinesNoDataDetail
                 )
             } else {
                 if let error = service.lastErrorCode {
@@ -112,7 +112,7 @@ struct RemoteMachinesPage: View {
                 Text(machine.alias)
                     .font(.system(size: density.titleFontSize, weight: .semibold))
                     .lineLimit(1)
-                Text("\(machine.platform) · Probe \(machine.probeVersion)")
+                Text(L10n.Settings.remoteMachineDetail(platform: machine.platform, version: machine.probeVersion))
                     .font(.system(size: max(9, density.subtitleFontSize - 1)))
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
@@ -124,13 +124,13 @@ struct RemoteMachinesPage: View {
 
     private func metrics(_ machine: RemoteMachineSummary) -> some View {
         HStack(alignment: .top, spacing: 0) {
-            metric("Today", Text(machine.todayTokens, format: .number.notation(.compactName)))
+            metric(L10n.Cost.timeframeToday, Text(machine.todayTokens, format: .number.notation(.compactName)))
             metricDivider
-            metric("7 days", Text(machine.last7DaysTokens, format: .number.notation(.compactName)))
+            metric(L10n.Cost.timeframeWeek, Text(machine.last7DaysTokens, format: .number.notation(.compactName)))
             metricDivider
-            metric("30 days", Text(machine.last30DaysTokens, format: .number.notation(.compactName)))
+            metric(L10n.Cost.timeframeMonth, Text(machine.last30DaysTokens, format: .number.notation(.compactName)))
             metricDivider
-            metric("30-day cost", Text(machine.last30DaysCostUSD, format: .currency(code: "USD")))
+            metric(L10n.Popover.machinesThirtyDayCost, Text(machine.last30DaysCostUSD, format: .currency(code: "USD")))
         }
     }
 
@@ -221,25 +221,31 @@ struct RemoteMachinesPage: View {
     private func footer(_ machine: RemoteMachineSummary) -> some View {
         HStack(alignment: .center, spacing: density.statusComponentSpacing) {
             ForEach(machine.sourceStatuses.keys.sorted(), id: \.self) { source in
-                sourceCapsule(source, status: machine.sourceStatuses[source] ?? "error")
+                sourceCapsule(source, status: machine.sourceStatuses[source] ?? Self.unknownSourceStatus)
             }
             Spacer(minLength: 8)
-            Text("seq \(machine.lastSequence)")
+            Text(L10n.Popover.machinesSequence(value: String(machine.lastSequence)))
                 .font(.caption2.monospacedDigit())
                 .foregroundStyle(.tertiary)
-            Toggle("Include in totals", isOn: includedInTotals(machine))
+            Toggle(L10n.Popover.machinesIncludeInTotals, isOn: includedInTotals(machine))
                 .toggleStyle(.switch)
                 .controlSize(.mini)
                 .font(.system(size: max(9, density.subtitleFontSize - 1)))
                 .fixedSize()
-                .help("Add this machine's decrypted usage to Overview and provider cost pages on this Core")
+                .help(L10n.Popover.machinesIncludeInTotalsHelp)
         }
     }
+
+    /// The Relay's own status vocabulary, not copy. It is compared against
+    /// `"ok"` below and shown beside the source name, so it stays English
+    /// for the same reason the error code does — a machine-readable value
+    /// inside a translated sentence.
+    private static let unknownSourceStatus = "error"
 
     private func sourceCapsule(_ source: String, status: String) -> some View {
         let isHealthy = status == "ok"
         let label = ToolType(rawValue: source)?.menuTitle ?? source.capitalized
-        return Text("\(label) · \(status)")
+        return Text(L10n.Popover.machinesLabelWithStatus(label: label, status: status))
             .font(.system(size: max(8, density.subtitleFontSize - 3), weight: .medium))
             .foregroundStyle(isHealthy ? Color.secondary : Color.orange)
             .lineLimit(1)
@@ -301,7 +307,7 @@ struct RemoteMachinesPage: View {
             Button {
                 Task { await service.refresh() }
             } label: {
-                Label("Retry", systemImage: "arrow.clockwise")
+                Label(L10n.Common.retry, systemImage: "arrow.clockwise")
                     .font(.system(size: max(9, density.segmentedFontSize - 1), weight: .semibold))
                     .padding(.horizontal, 10)
                     .frame(minHeight: 26)

--- a/Sources/VibeBarApp/Views/RemoteSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/RemoteSettingsSection.swift
@@ -51,12 +51,12 @@ struct RemoteSettingsSection: View {
     }
 
     private var aggregationSection: some View {
-        section("Cost aggregation") {
-            Text("Choose which remote machines join this Mac's local cost and token totals. Selection and aggregation stay on this Core; the Relay never sees plaintext usage.")
+        section(L10n.Settings.remoteCostAggregation) {
+            Text(L10n.Settings.remoteCostAggregationIntro)
                 .font(.caption)
                 .foregroundStyle(.secondary)
             if service.machines.isEmpty {
-                Text("Machines appear here after their first encrypted batch is imported.")
+                Text(L10n.Settings.remoteMachinesAppearAfterImport)
                     .font(.caption2)
                     .foregroundStyle(.tertiary)
             } else {
@@ -65,7 +65,7 @@ struct RemoteSettingsSection: View {
                         VStack(alignment: .leading, spacing: 2) {
                             Text(machine.alias)
                                 .font(.caption.weight(.medium))
-                            Text("\(machine.platform) · Probe \(machine.probeVersion)")
+                            Text(L10n.Settings.remoteMachineDetail(platform: machine.platform, version: machine.probeVersion))
                                 .font(.caption2)
                                 .foregroundStyle(.secondary)
                         }
@@ -80,26 +80,26 @@ struct RemoteSettingsSection: View {
     // MARK: - Status
 
     private var statusSection: some View {
-        section("Remote Core") {
+        section(L10n.Settings.remoteCore) {
             if service.isConfigured {
-                infoRow("Workspace", service.workspaceID?.uuidString.lowercased() ?? "—")
-                infoRow("Relay", service.relayURL?.absoluteString ?? "—")
-                infoRow("Registered probes", "\(service.registeredProbeCount)")
-                infoRow("Machines synced", "\(service.machines.count)")
-                infoRow("Last sync", lastSyncText)
+                infoRow(L10n.Settings.remoteWorkspace, service.workspaceID?.uuidString.lowercased() ?? "—")
+                infoRow(L10n.Settings.remoteRelay, service.relayURL?.absoluteString ?? "—")
+                infoRow(L10n.Settings.remoteRegisteredProbes, AppLocale.number(service.registeredProbeCount))
+                infoRow(L10n.Settings.remoteMachinesSynced, AppLocale.number(service.machines.count))
+                infoRow(L10n.Settings.remoteLastSync, lastSyncText)
                 if let code = service.lastErrorCode {
-                    Text("\(RemoteSyncStatusCopy.title(for: code)) · \(code)")
+                    Text(L10n.Settings.remoteStatusWithCode(title: RemoteSyncStatusCopy.title(for: code), code: code))
                         .font(.caption2)
                         .foregroundStyle(.orange)
                 }
                 Button {
                     Task { await service.refresh() }
                 } label: {
-                    Label("Sync now", systemImage: "arrow.triangle.2.circlepath")
+                    Label(L10n.Settings.remoteSyncNow, systemImage: "arrow.triangle.2.circlepath")
                 }
                 .disabled(service.isRefreshing)
             } else {
-                Text("This Mac is not connected to a workspace. Remote probes collect normalized usage on your other machines, encrypt it to this Mac's Core keys, and drop it at a Relay — no inbound port is ever opened here.")
+                Text(L10n.Settings.remoteNotConnected)
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -114,15 +114,15 @@ struct RemoteSettingsSection: View {
     // MARK: - Provisioning
 
     private var provisioningSection: some View {
-        section("Provisioning") {
+        section(L10n.Settings.remoteProvisioning) {
             if !service.isConfigured {
                 joinWithCode
                 Divider()
-                Text("Or pair manually.")
+                Text(L10n.Settings.remoteOrPairManually)
                     .font(.caption.weight(.medium))
                     .foregroundStyle(.secondary)
             }
-            Text("Pairing runs in three steps: export this Mac's Core identity, register it with your Relay to produce a provisioning file, then import that file here. Importing moves the Relay credential into the macOS Keychain — but the provisioning file itself still contains that credential, so delete the file once the import succeeds.")
+            Text(L10n.Settings.remoteManualPairingIntro)
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
@@ -130,12 +130,12 @@ struct RemoteSettingsSection: View {
                 Button {
                     exportDescriptor()
                 } label: {
-                    Label("Export Core Identity…", systemImage: "square.and.arrow.up")
+                    Label(L10n.Settings.remoteExportIdentity, systemImage: "square.and.arrow.up")
                 }
                 Button {
                     importProvisioning()
                 } label: {
-                    Label("Import Provisioning File…", systemImage: "square.and.arrow.down")
+                    Label(L10n.Settings.remoteImportProvisioning, systemImage: "square.and.arrow.down")
                 }
             }
 
@@ -167,10 +167,10 @@ struct RemoteSettingsSection: View {
     /// persisted or logged.
     private var joinWithCode: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("Join with a code")
+            Text(L10n.Settings.remoteJoinWithCode)
                 .font(.caption.weight(.medium))
                 .foregroundStyle(.secondary)
-            Text("Create a Core code in the Vibe Bar control center, then paste it here. This Mac joins as “\(deviceName)”.")
+            Text(L10n.Settings.remoteJoinIntro(device: deviceName))
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
@@ -181,7 +181,7 @@ struct RemoteSettingsSection: View {
                     .frame(width: 190)
                     .disabled(isJoining)
                     .onSubmit { join() }
-                Button("Join") { join() }
+                Button(L10n.Settings.remoteJoin) { join() }
                     .disabled(isJoining || trimmedJoinCode.isEmpty)
                 if isJoining {
                     ProgressView()
@@ -190,7 +190,7 @@ struct RemoteSettingsSection: View {
                 Spacer(minLength: 0)
             }
 
-            Toggle("Use a different control center", isOn: $showControlURLField)
+            Toggle(L10n.Settings.remoteDifferentControlCenter, isOn: $showControlURLField)
                 .toggleStyle(.checkbox)
                 .font(.caption)
                 .disabled(isJoining)
@@ -210,7 +210,7 @@ struct RemoteSettingsSection: View {
             }
             if pendingEnrollment != nil {
                 if pendingWasRestored {
-                    Text("A previous join was accepted by the control center but never finished saving on this Mac. Its pairing code is already spent, so resume the save instead of requesting a new code.")
+                    Text(L10n.Settings.remotePendingIntro)
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                 }
@@ -219,21 +219,21 @@ struct RemoteSettingsSection: View {
                         retrySavingEnrollment()
                     } label: {
                         Label(
-                            pendingWasRestored ? "Resume saving" : "Retry saving",
+                            pendingWasRestored ? L10n.Settings.remoteResumeSaving : L10n.Settings.remoteRetrySaving,
                             systemImage: "arrow.clockwise"
                         )
                     }
-                    Button("Discard") { confirmingDiscardPending = true }
+                    Button(L10n.Settings.remoteDiscard) { confirmingDiscardPending = true }
                 }
                 .confirmationDialog(
-                    "Discard this pending join?",
+                    L10n.Settings.remoteDiscardPendingTitle,
                     isPresented: $confirmingDiscardPending,
                     titleVisibility: .visible
                 ) {
-                    Button("Discard", role: .destructive) { discardPendingEnrollment() }
-                    Button("Cancel", role: .cancel) {}
+                    Button(L10n.Settings.remoteDiscard, role: .destructive) { discardPendingEnrollment() }
+                    Button(L10n.Common.cancel, role: .cancel) {}
                 } message: {
-                    Text("Its pairing code is already spent, and the workspace still counts this Mac as its Core. To join again, revoke this Mac in the web control center, then create a fresh code.")
+                    Text(L10n.Settings.remoteDiscardPendingDetail)
                 }
             }
         }
@@ -388,26 +388,26 @@ struct RemoteSettingsSection: View {
     // MARK: - Disconnect
 
     private var disconnectSection: some View {
-        section("Disconnect") {
-            Text("Disconnecting removes this Mac's Relay credential from the Keychain and its workspace binding. Probes keep uploading to the Relay until they are revoked there. Usage already decrypted stays in the local ledger.")
+        section(L10n.Settings.remoteDisconnect) {
+            Text(L10n.Settings.remoteDisconnectIntro)
                 .font(.caption)
                 .foregroundStyle(.secondary)
             Button(role: .destructive) {
                 confirmingDisconnect = true
             } label: {
-                Label("Disconnect from Workspace…", systemImage: "bolt.slash")
+                Label(L10n.Settings.remoteDisconnectButton, systemImage: "bolt.slash")
             }
             .confirmationDialog(
-                "Disconnect from this workspace?",
+                L10n.Settings.remoteDisconnectTitle,
                 isPresented: $confirmingDisconnect,
                 titleVisibility: .visible
             ) {
-                Button("Disconnect", role: .destructive) {
+                Button(L10n.Settings.remoteDisconnect, role: .destructive) {
                     disconnect()
                 }
-                Button("Cancel", role: .cancel) {}
+                Button(L10n.Common.cancel, role: .cancel) {}
             } message: {
-                Text("Reconnecting later requires a new pairing code or provisioning file.")
+                Text(L10n.Settings.remoteDisconnectDetail)
             }
         }
     }

--- a/Sources/VibeBarApp/Views/SettingsSidebarView.swift
+++ b/Sources/VibeBarApp/Views/SettingsSidebarView.swift
@@ -39,7 +39,7 @@ struct SettingsSidebarView: View {
             HStack(spacing: 7) {
                 Image(systemName: "magnifyingglass")
                     .foregroundStyle(.secondary)
-                TextField("Search settings", text: $searchText)
+                TextField(L10n.Settings.search, text: $searchText)
                     .textFieldStyle(.plain)
             }
             .padding(.horizontal, 10)
@@ -55,7 +55,7 @@ struct SettingsSidebarView: View {
             ScrollView(.vertical, showsIndicators: false) {
                 VStack(alignment: .leading, spacing: 14) {
                     if searchText.isEmpty || !filteredBasicPages.isEmpty {
-                        sidebarGroup("Settings") {
+                        sidebarGroup(L10n.Settings.sidebarSettings) {
                             ForEach(filteredBasicPages, id: \.rawValue) { page in
                                 staticRow(page)
                             }
@@ -63,7 +63,7 @@ struct SettingsSidebarView: View {
                     }
 
                     if searchText.isEmpty || !filteredCoreProviders.isEmpty {
-                        sidebarGroup("Core Providers") {
+                        sidebarGroup(L10n.Settings.sidebarCoreProviders) {
                             ForEach(filteredCoreProviders, id: \.self) { tool in
                                 coreProviderRow(tool)
                                     .onDrag {
@@ -96,7 +96,7 @@ struct SettingsSidebarView: View {
                     }
 
                     if miscLandingMatchesSearch || !filteredMiscProviders.isEmpty {
-                        sidebarGroup("Misc Providers") {
+                        sidebarGroup(L10n.Popover.tabMisc) {
                             if miscLandingMatchesSearch {
                                 miscLandingRow
                             }
@@ -215,7 +215,7 @@ struct SettingsSidebarView: View {
 
     private var miscLandingMatchesSearch: Bool {
         searchText.isEmpty
-            || "Browser Cookies".localizedCaseInsensitiveContains(searchText)
+            || L10n.Onboarding.doneBrowserCookies.localizedCaseInsensitiveContains(searchText)
             || "Misc Providers".localizedCaseInsensitiveContains(searchText)
     }
 
@@ -261,7 +261,7 @@ struct SettingsSidebarView: View {
             showsDragHandle: true
         )
         .contextMenu {
-            Button(enabled ? "Hide from Overview" : "Show in Overview") {
+            Button(enabled ? L10n.Settings.sidebarHideFromOverview : L10n.Onboarding.subscriptionsShowInOverview) {
                 settingsStore.settings.setCoreProviderVisible(!enabled, for: tool)
             }
         }
@@ -282,7 +282,7 @@ struct SettingsSidebarView: View {
             showsDragHandle: true
         )
         .contextMenu {
-            Button(enabled ? "Disable Provider" : "Enable Provider") {
+            Button(enabled ? L10n.Settings.sidebarDisableProvider : L10n.Settings.sidebarEnableProvider) {
                 settingsStore.settings.setMiscProviderInstanceVisible(!enabled, forID: instance.id)
             }
         }
@@ -291,7 +291,7 @@ struct SettingsSidebarView: View {
     private var miscLandingRow: some View {
         sidebarRow(
             destination: .page(.miscProviders),
-            title: "Browser Cookies",
+            title: L10n.Onboarding.doneBrowserCookies,
             icon: AnyView(
                 Image(systemName: "safari")
                     .font(.system(size: 14, weight: .medium))

--- a/Sources/VibeBarApp/Views/SettingsSidebarView.swift
+++ b/Sources/VibeBarApp/Views/SettingsSidebarView.swift
@@ -216,7 +216,7 @@ struct SettingsSidebarView: View {
     private var miscLandingMatchesSearch: Bool {
         searchText.isEmpty
             || L10n.Onboarding.doneBrowserCookies.localizedCaseInsensitiveContains(searchText)
-            || "Misc Providers".localizedCaseInsensitiveContains(searchText)
+            || L10n.Popover.tabMisc.localizedCaseInsensitiveContains(searchText)
     }
 
     private func sidebarGroup<Content: View>(

--- a/Sources/VibeBarApp/Views/SettingsView.swift
+++ b/Sources/VibeBarApp/Views/SettingsView.swift
@@ -142,7 +142,7 @@ struct SettingsView: View {
                 Image(systemName: "exclamationmark.arrow.triangle.2.circlepath")
                     .foregroundStyle(.orange)
                 VStack(alignment: .leading, spacing: 2) {
-                    Text("Another Vibe Bar replaced your change")
+                    Text(L10n.Settings.externalChangeTitle)
                         .font(.callout.weight(.medium))
                     Text(change.summary)
                         .font(.caption2)
@@ -150,7 +150,7 @@ struct SettingsView: View {
                         .fixedSize(horizontal: false, vertical: true)
                 }
                 Spacer(minLength: 12)
-                Button("Dismiss") { settingsStore.acknowledgeExternalChange() }
+                Button(L10n.Common.dismiss) { settingsStore.acknowledgeExternalChange() }
                     .buttonStyle(.vibeBar)
             }
             .padding(.horizontal, 12)
@@ -179,8 +179,8 @@ struct SettingsView: View {
                     externalChangeBanner
                     if selectedSection == .system {
                     LanguageSettingsSection(density: density)
-                    settingsSection("System") {
-                        Toggle("Launch at login", isOn: launchAtLoginBinding())
+                    settingsSection(L10n.Settings.sectionSystem) {
+                        Toggle(L10n.Platform.macosLaunchAtLoginTitle, isOn: launchAtLoginBinding())
                         Text(launchAtLoginStatusText)
                             .font(.caption2)
                             .foregroundStyle(.secondary)
@@ -194,68 +194,68 @@ struct SettingsView: View {
                         Button {
                             environment.showOnboarding()
                         } label: {
-                            Label("Show setup assistant", systemImage: "wand.and.stars")
+                            Label(L10n.Settings.showAssistant, systemImage: "wand.and.stars")
                         }
-                        Text("Walk through subscriptions, browser cookies, API keys, model pricing and login items again. Nothing is reset.")
+                        Text(L10n.Settings.showAssistantDetail)
                             .font(.caption2)
                             .foregroundStyle(.secondary)
                     }
                     .id(SettingsSectionID.system.rawValue)
 
-                    settingsSection("Refreshing") {
-                        Picker("Percent shows", selection: $settingsStore.settings.displayMode) {
+                    settingsSection(L10n.Settings.sectionRefreshing) {
+                        Picker(L10n.Settings.percentShows, selection: $settingsStore.settings.displayMode) {
                             ForEach(DisplayMode.allCases, id: \.self) { Text($0.label).tag($0) }
                         }
                         .pickerStyle(.segmented)
-                        Picker("Refresh every", selection: $settingsStore.settings.refreshIntervalSeconds) {
+                        Picker(L10n.Settings.refreshEvery, selection: $settingsStore.settings.refreshIntervalSeconds) {
                             ForEach(intervalOptions, id: \.self) { secs in
                                 Text(intervalLabel(secs)).tag(secs)
                             }
                         }
                         Toggle(
-                            "Refresh when the popover opens",
+                            L10n.Settings.refreshOnPopoverOpen,
                             isOn: $settingsStore.settings.refreshOnPopoverOpen
                         )
                         if settingsStore.settings.refreshOnPopoverOpen {
                             Picker(
-                                "Minimum open-refresh cooldown",
+                                L10n.Settings.openRefreshCooldown,
                                 selection: $settingsStore.settings.popoverOpenRefreshCooldownSeconds
                             ) {
                                 ForEach(popoverRefreshCooldownOptions, id: \.self) { secs in
                                     Text(intervalLabel(secs)).tag(secs)
                                 }
                             }
-                            Text("Opening the popover refreshes all visible providers at most once per cooldown period.")
+                            Text(L10n.Settings.openRefreshDetail)
                                 .font(.caption2)
                                 .foregroundStyle(.secondary)
                         }
                     }
                     .id("refreshing")
 
-                    settingsSection("Updates") {
+                    settingsSection(L10n.Settings.sectionUpdates) {
                         UpdateSettingsRow(updateController: environment.updateController)
                     }
                     .id("updates")
 
-                    settingsSection("Components") {
+                    settingsSection(L10n.Settings.sectionComponents) {
                         AgentSessionKitComponentRow()
                     }
                     .id("components")
                     }
 
                     if selectedSection == .menuBar {
-                    settingsSection("Overview") {
+                    settingsSection(L10n.Settings.sectionOverview) {
                         menuBarOverviewEditor()
                     }
                     .id(SettingsSectionID.menuBar.rawValue)
                     }
 
                     if selectedSection == .menuBarHealth {
-                    settingsSection("Menu Bar Health") {
+                    settingsSection(L10n.Settings.sectionMenuBarHealth) {
                         if let watchdog = environment.menuBarWatchdog {
                             MenuBarHealthSettingsSection(watchdog: watchdog)
                         } else {
-                            Text("The menu bar health monitor is not attached in this process.")
+                            Text(L10n.Settings.menuBarHealthUnavailable)
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                         }
@@ -264,14 +264,14 @@ struct SettingsView: View {
                     }
 
                     if selectedSection == .miniWindow {
-                    settingsSection("Mini Windows") {
+                    settingsSection(L10n.Settings.sectionMiniWindows) {
                         MiniWindowsSettingsSection()
                     }
                     .id(SettingsSectionID.miniWindow.rawValue)
                     }
 
                     if selectedSection == .layout {
-                    settingsSection("Layout") {
+                    settingsSection(L10n.Settings.sectionLayout) {
                         LayoutEditorView()
                     }
                     .id(SettingsSectionID.layout.rawValue)
@@ -286,7 +286,7 @@ struct SettingsView: View {
                         coreProviderPlanBadgeRows(for: [.codex])
                         Divider()
                             .padding(.vertical, 2)
-                        Picker("Usage source", selection: $settingsStore.settings.codexUsageMode) {
+                        Picker(L10n.Settings.usageSource, selection: $settingsStore.settings.codexUsageMode) {
                             ForEach(CodexUsageMode.allCases) { mode in
                                 Text(mode.label).tag(mode)
                             }
@@ -298,23 +298,23 @@ struct SettingsView: View {
                             Button {
                                 environment.importOpenAIBrowserCookies()
                             } label: {
-                                Label("Import from browser", systemImage: "safari")
+                                Label(L10n.Onboarding.cookiesImportFromBrowser, systemImage: "safari")
                             }
                             .disabled(environment.isImportingOpenAIBrowserCookies)
                             Button {
                                 environment.openOpenAIWebLogin()
                             } label: {
-                                Label("Open WebView login", systemImage: "person.crop.circle.badge.key")
+                                Label(L10n.Onboarding.cookiesOpenWebViewLogin, systemImage: "person.crop.circle.badge.key")
                             }
                             Button(role: .destructive) {
                                 openAICookieDeleteFailed = !environment.deleteOpenAIWebCookies()
                             } label: {
-                                Label("Delete cookies", systemImage: "trash")
+                                Label(L10n.Settings.deleteCookies, systemImage: "trash")
                             }
                             .disabled(!environment.hasOpenAIWebCookies)
                         }
                         if environment.hasOpenAIWebCookies {
-                            Text("Cookies saved.")
+                            Text(L10n.Onboarding.cookiesSaved)
                                 .font(.caption2).foregroundStyle(.green)
                         }
                         if let status = environment.openAIBrowserCookieImportStatus {
@@ -323,7 +323,7 @@ struct SettingsView: View {
                                 .foregroundStyle(status.hasPrefix("Imported") ? .green : .secondary)
                         }
                         if openAICookieDeleteFailed {
-                            Text("Could not delete saved cookies.")
+                            Text(L10n.Settings.couldNotDeleteCookies)
                                 .font(.caption2).foregroundStyle(.orange)
                         }
                         Divider()
@@ -332,7 +332,7 @@ struct SettingsView: View {
                         Button {
                             environment.recheckPrimaryRouteHealth(provider: .codex)
                         } label: {
-                            Label("Check OpenAI connections", systemImage: "checkmark.circle")
+                            Label(L10n.Settings.checkConnections(company: "OpenAI"), systemImage: "checkmark.circle")
                         }
                     }
                     .id(SettingsSectionID.openAI.id)
@@ -347,7 +347,7 @@ struct SettingsView: View {
                         coreProviderPlanBadgeRows(for: [.claude])
                         Divider()
                             .padding(.vertical, 2)
-                        Picker("Usage source", selection: $settingsStore.settings.claudeUsageMode) {
+                        Picker(L10n.Settings.usageSource, selection: $settingsStore.settings.claudeUsageMode) {
                             ForEach(ClaudeUsageMode.allCases) { mode in
                                 Text(mode.label).tag(mode)
                             }
@@ -359,23 +359,23 @@ struct SettingsView: View {
                             Button {
                                 environment.importClaudeBrowserCookies()
                             } label: {
-                                Label("Import from browser", systemImage: "safari")
+                                Label(L10n.Onboarding.cookiesImportFromBrowser, systemImage: "safari")
                             }
                             .disabled(environment.isImportingClaudeBrowserCookies)
                             Button {
                                 environment.openClaudeWebLogin()
                             } label: {
-                                Label("Open WebView login", systemImage: "person.crop.circle.badge.key")
+                                Label(L10n.Onboarding.cookiesOpenWebViewLogin, systemImage: "person.crop.circle.badge.key")
                             }
                             Button(role: .destructive) {
                                 claudeCookieDeleteFailed = !environment.deleteClaudeWebCookies()
                             } label: {
-                                Label("Delete cookies", systemImage: "trash")
+                                Label(L10n.Settings.deleteCookies, systemImage: "trash")
                             }
                             .disabled(!environment.hasClaudeWebCookies)
                         }
                         if environment.hasClaudeWebCookies {
-                            Text("Cookies saved.")
+                            Text(L10n.Onboarding.cookiesSaved)
                                 .font(.caption2).foregroundStyle(.green)
                         }
                         if let status = environment.claudeBrowserCookieImportStatus {
@@ -384,7 +384,7 @@ struct SettingsView: View {
                                 .foregroundStyle(status.hasPrefix("Imported") ? .green : .secondary)
                         }
                         if claudeCookieDeleteFailed {
-                            Text("Could not delete saved cookies.")
+                            Text(L10n.Settings.couldNotDeleteCookies)
                                 .font(.caption2).foregroundStyle(.orange)
                         }
                         Divider()
@@ -393,7 +393,7 @@ struct SettingsView: View {
                         Button {
                             environment.recheckPrimaryRouteHealth(provider: .claude)
                         } label: {
-                            Label("Check Anthropic connections", systemImage: "checkmark.circle")
+                            Label(L10n.Settings.checkConnections(company: "Anthropic"), systemImage: "checkmark.circle")
                         }
                     }
                     .id(SettingsSectionID.anthropic.id)
@@ -408,11 +408,11 @@ struct SettingsView: View {
                         coreProviderPlanBadgeRows(for: [.gemini, .antigravity])
                         Divider()
                             .padding(.vertical, 2)
-                        Text("Gemini and Antigravity share the same Google AI subscription quota. Cookie import is the only supported web path — there is no WebView login.")
+                        Text(L10n.Settings.geminiShared)
                             .font(.caption)
                             .foregroundStyle(.secondary)
 
-                        sourceSummary(label: "Gemini source", value: "Web quota")
+                        sourceSummary(label: L10n.Settings.geminiSource, value: L10n.Settings.webQuota)
                         Text(GeminiUsageMode.webOnly.detail)
                             .font(.caption)
                             .foregroundStyle(.secondary)
@@ -420,18 +420,18 @@ struct SettingsView: View {
                             Button {
                                 environment.importGeminiBrowserCookies()
                             } label: {
-                                Label("Import Gemini cookies from browser", systemImage: "safari")
+                                Label(L10n.Onboarding.cookiesImportGemini, systemImage: "safari")
                             }
                             .disabled(environment.isImportingGeminiBrowserCookies)
                             Button(role: .destructive) {
                                 geminiCookieDeleteFailed = !environment.deleteGeminiWebCookies()
                             } label: {
-                                Label("Delete Gemini cookies", systemImage: "trash")
+                                Label(L10n.Settings.deleteGeminiCookies, systemImage: "trash")
                             }
                             .disabled(!environment.hasGeminiWebCookies)
                         }
                         if environment.hasGeminiWebCookies {
-                            Text("Gemini cookies saved.")
+                            Text(L10n.Settings.geminiCookiesSaved)
                                 .font(.caption2).foregroundStyle(.green)
                         }
                         if let status = environment.geminiBrowserCookieImportStatus {
@@ -440,7 +440,7 @@ struct SettingsView: View {
                                 .foregroundStyle(status.hasPrefix("Imported") ? .green : .secondary)
                         }
                         if geminiCookieDeleteFailed {
-                            Text("Could not delete saved Gemini cookies.")
+                            Text(L10n.Settings.couldNotDeleteGeminiCookies)
                                 .font(.caption2).foregroundStyle(.orange)
                         }
                         Divider()
@@ -450,7 +450,7 @@ struct SettingsView: View {
                         Divider()
                             .padding(.vertical, 2)
 
-                        Picker("Antigravity source", selection: $settingsStore.settings.antigravityUsageMode) {
+                        Picker(L10n.Settings.antigravitySource, selection: $settingsStore.settings.antigravityUsageMode) {
                             ForEach(AntigravityUsageMode.allCases) { mode in
                                 Text(mode.label).tag(mode)
                             }
@@ -463,11 +463,11 @@ struct SettingsView: View {
                         // flag off, only the local LSP probe runs and the
                         // cookie controls would be dead UI.
                         if AntigravitySourcePlanner.antigravityWebSourceAvailable {
-                            Text("Antigravity cookie import is enabled — sign in at antigravity.google first.")
+                            Text(L10n.Settings.antigravityCookieEnabled)
                                 .font(.caption2)
                                 .foregroundStyle(.secondary)
                         } else {
-                            Text("Antigravity reads the locally running language server. Cookie import is deferred until the Antigravity Cloud endpoint ships.")
+                            Text(L10n.Settings.antigravityLocalOnly)
                                 .font(.caption2)
                                 .foregroundStyle(.tertiary)
                         }
@@ -478,7 +478,7 @@ struct SettingsView: View {
                             environment.recheckPrimaryRouteHealth(provider: .gemini)
                             environment.recheckPrimaryRouteHealth(provider: .antigravity)
                         } label: {
-                            Label("Check Google AI connections", systemImage: "checkmark.circle")
+                            Label(L10n.Settings.checkConnections(company: "Google AI"), systemImage: "checkmark.circle")
                         }
                     }
                     .id(SettingsSectionID.googleAI.id)
@@ -493,18 +493,18 @@ struct SettingsView: View {
                         coreProviderPlanBadgeRows(for: [.grok, .cursor])
                         Divider()
                             .padding(.vertical, 2)
-                        Text("The SpaceXAI page combines Grok with Cursor. Grok reads `~/.grok/auth.json` or grok.com cookies; Cursor reads Cursor.app first, then cursor.com cookie slots. Grok Bot contributes quota, plus read-only sessions from its local cache — its cloud runs still add no token/cost rows.")
+                        Text(L10n.Settings.spaceXAIIntro)
                             .font(.caption)
                             .foregroundStyle(.secondary)
 
-                        sourceSummary(label: "Usage source", value: "Auto")
+                        sourceSummary(label: L10n.Settings.usageSource, value: L10n.Common.auto)
 
                         if GrokCredentialsStore.hasCredentials() {
-                            Label("~/.grok/auth.json detected", systemImage: "checkmark.circle")
+                            Label(L10n.Settings.grokAuthDetected, systemImage: "checkmark.circle")
                                 .font(.caption2)
                                 .foregroundStyle(.green)
                         } else {
-                            Label("No ~/.grok/auth.json yet — run `grok login` to authenticate, or import cookies below.",
+                            Label(L10n.Onboarding.subscriptionsGrokMissing,
                                   systemImage: "exclamationmark.circle")
                                 .font(.caption2)
                                 .foregroundStyle(.secondary)
@@ -514,18 +514,18 @@ struct SettingsView: View {
                             Button {
                                 environment.importGrokBrowserCookies()
                             } label: {
-                                Label("Import Grok cookies from browser", systemImage: "safari")
+                                Label(L10n.Onboarding.cookiesImportGrok, systemImage: "safari")
                             }
                             .disabled(environment.isImportingGrokBrowserCookies)
                             Button(role: .destructive) {
                                 grokCookieDeleteFailed = !environment.deleteGrokWebCookies()
                             } label: {
-                                Label("Delete Grok cookies", systemImage: "trash")
+                                Label(L10n.Settings.deleteGrokCookies, systemImage: "trash")
                             }
                             .disabled(!environment.hasGrokWebCookies)
                         }
                         if environment.hasGrokWebCookies {
-                            Text("Grok cookies saved.")
+                            Text(L10n.Settings.grokCookiesSaved)
                                 .font(.caption2).foregroundStyle(.green)
                         }
                         if let status = environment.grokBrowserCookieImportStatus {
@@ -534,20 +534,20 @@ struct SettingsView: View {
                                 .foregroundStyle(status.hasPrefix("Imported") ? .green : .secondary)
                         }
                         if grokCookieDeleteFailed {
-                            Text("Could not delete saved Grok cookies.")
+                            Text(L10n.Settings.couldNotDeleteGrokCookies)
                                 .font(.caption2).foregroundStyle(.orange)
                         }
 
                         Divider()
                             .padding(.vertical, 2)
 
-                        sourceSummary(label: "Cursor source", value: "Cursor.app → Web")
+                        sourceSummary(label: L10n.Settings.cursorSource, value: L10n.Settings.cursorSourceValue)
                         if environment.account(for: .cursor)?.source == .cliDetected {
-                            Label("Cursor.app signed-in session detected", systemImage: "checkmark.circle")
+                            Label(L10n.Settings.cursorSessionDetected, systemImage: "checkmark.circle")
                                 .font(.caption2)
                                 .foregroundStyle(.green)
                         } else {
-                            Label("No usable Cursor.app session — import cursor.com cookies below.",
+                            Label(L10n.Settings.cursorNoSession,
                                   systemImage: "exclamationmark.circle")
                                 .font(.caption2)
                                 .foregroundStyle(.secondary)
@@ -564,10 +564,10 @@ struct SettingsView: View {
                         Button {
                             environment.recheckPrimaryRouteHealth(provider: .grok)
                         } label: {
-                            Label("Check SpaceXAI connections", systemImage: "checkmark.circle")
+                            Label(L10n.Settings.checkConnections(company: "SpaceXAI"), systemImage: "checkmark.circle")
                         }
 
-                        Link("Open SpaceXAI status page",
+                        Link(L10n.Settings.openStatusPage(company: "SpaceXAI"),
                              destination: ToolType.grok.statusPageURL)
                             .font(.caption2)
                     }
@@ -581,43 +581,43 @@ struct SettingsView: View {
                             MiscProviderSettingsSection(instance: instance)
                         }
                     } else {
-                        settingsSection("Browser Cookies") {
+                        settingsSection(L10n.Onboarding.doneBrowserCookies) {
                             MiscProviderLandingView()
                         }
                     }
                     }
 
                     if selectedSection == .costData {
-                    settingsSection("Cost Data") {
-                        Text("Cost is computed from local CLI session JSONL logs at ~/.codex/sessions and ~/.claude/projects. Web/desktop usage is not tracked.")
+                    settingsSection(L10n.Settings.sectionCostData) {
+                        Text(L10n.Settings.costDataIntro)
                             .font(.caption)
                             .foregroundStyle(.secondary)
-                        Picker("Keep history", selection: $settingsStore.settings.costData.retentionDays) {
+                        Picker(L10n.Settings.keepHistory, selection: $settingsStore.settings.costData.retentionDays) {
                             ForEach(costRetentionOptions, id: \.self) { days in
                                 Text(costRetentionLabel(days)).tag(days)
                             }
                         }
-                        Text("Applies to cost history and subscription fill history.")
+                        Text(L10n.Settings.keepHistoryDetail)
                             .font(.caption2)
                             .foregroundStyle(.secondary)
-                        Toggle("Privacy mode", isOn: $settingsStore.settings.costData.privacyModeEnabled)
+                        Toggle(L10n.Settings.privacyMode, isOn: $settingsStore.settings.costData.privacyModeEnabled)
                         HStack {
                             Button {
                                 environment.refreshCostUsage()
                                 costDataClearStatus = nil
                             } label: {
-                                Label("Rescan cost logs", systemImage: "arrow.triangle.2.circlepath")
+                                Label(L10n.Settings.rescanCostLogs, systemImage: "arrow.triangle.2.circlepath")
                             }
                             .disabled(settingsStore.settings.costData.privacyModeEnabled)
                             Button(role: .destructive) {
                                 environment.clearCostData()
                                 costDataClearStatus = "Cost data cleared."
                             } label: {
-                                Label("Clear cost data", systemImage: "trash")
+                                Label(L10n.Settings.clearCostData, systemImage: "trash")
                             }
                         }
                         if settingsStore.settings.costData.privacyModeEnabled {
-                            Text("Privacy mode keeps cost data off disk and clears local cost history, snapshots, and scan cache.")
+                            Text(L10n.Settings.privacyModeDetail)
                                 .font(.caption2)
                                 .foregroundStyle(.secondary)
                         }
@@ -626,7 +626,7 @@ struct SettingsView: View {
                                 .font(.caption2)
                                 .foregroundStyle(.green)
                         }
-                        Text("Pricing data: \(CostUsagePricing.pricingDataUpdatedAt)")
+                        Text(L10n.Settings.pricingDataDate(date: CostUsagePricing.pricingDataUpdatedAt))
                             .font(.caption2)
                             .foregroundStyle(.tertiary)
                     }
@@ -649,8 +649,8 @@ struct SettingsView: View {
                     }
 
                     if selectedSection == .privacy {
-                    settingsSection("Privacy") {
-                        Text("Tokens are read from local CLI credentials. Saved OpenAI and Claude Web cookies are stored in macOS Keychain, split by browser and WebView source. Legacy plaintext cookie files under ~/.vibebar/cookies are migrated once and deleted. Settings, quota cache, and cost summaries stay under ~/.vibebar.")
+                    settingsSection(L10n.Settings.sectionPrivacy) {
+                        Text(L10n.Settings.privacyDetail)
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
@@ -682,7 +682,7 @@ struct SettingsView: View {
 
     private func connectionHealthRows(provider: ToolType) -> some View {
         VStack(alignment: .leading, spacing: 6) {
-            Text("Connection health")
+            Text(L10n.Settings.connectionHealth)
                 .font(.caption)
                 .foregroundStyle(.secondary)
             ForEach(PrimaryProviderRoute.routes(for: provider)) { route in
@@ -690,7 +690,7 @@ struct SettingsView: View {
                     ?? PrimaryProviderRouteHealth(
                         route: route,
                         status: .missing,
-                        detail: "Not checked"
+                        detail: L10n.Settings.notChecked
                     )
                 HStack(spacing: 8) {
                     Circle()
@@ -735,13 +735,13 @@ struct SettingsView: View {
                     Circle()
                         .fill(ready ? Color.green : Color.red)
                         .frame(width: 7, height: 7)
-                    Text(ready ? "Ready" : "Needs setup")
+                    Text(ready ? L10n.Settings.ready : L10n.Settings.needsSetup)
                         .font(.caption2)
                         .foregroundStyle(ready ? Color.green : Color.red)
                 }
             }
             Spacer(minLength: 12)
-            Toggle("Show in Overview", isOn: coreProviderVisibilityBinding(representative))
+            Toggle(L10n.Onboarding.subscriptionsShowInOverview, isOn: coreProviderVisibilityBinding(representative))
                 .toggleStyle(.switch)
                 .controlSize(.small)
                 .font(.caption)
@@ -750,13 +750,13 @@ struct SettingsView: View {
 
     private func coreProviderPlanBadgeRows(for tools: [ToolType]) -> some View {
         VStack(alignment: .leading, spacing: 7) {
-            Text("Plan badge")
+            Text(L10n.Settings.planBadge)
                 .font(.caption)
                 .foregroundStyle(.secondary)
             ForEach(tools, id: \.self) { tool in
                 providerBadgeRow(tool)
             }
-            Text("Leave blank to use the detected account plan.")
+            Text(L10n.Settings.planBadgeDetail)
                 .font(.caption2)
                 .foregroundStyle(.tertiary)
         }
@@ -897,7 +897,7 @@ struct SettingsView: View {
             }
             Spacer(minLength: 8)
             DebouncedSettingsTextField(
-                prompt: "Auto",
+                prompt: L10n.Common.auto,
                 value: providerPlanLabelBinding(tool)
             )
             .frame(width: 130)
@@ -1109,20 +1109,20 @@ private struct AgentSessionKitComponentRow: View {
                 Button {
                     check()
                 } label: {
-                    Label("Check for kit updates", systemImage: "arrow.triangle.2.circlepath")
+                    Label(L10n.Settings.checkKitUpdates, systemImage: "arrow.triangle.2.circlepath")
                 }
                 .disabled(isChecking)
             }
 
-            Text("Session discovery, harness naming, and the MCP transport. A separate repository, pinned to an exact tag and compiled into this build.")
+            Text(L10n.Settings.kitDetail)
                 .font(.caption2)
                 .foregroundStyle(.secondary)
 
             statusLine
 
             HStack(spacing: 12) {
-                Link("Release notes", destination: AgentSessionKitInfo.bundledReleaseNotesURL)
-                Link("Repository", destination: AgentSessionKitInfo.repositoryURL)
+                Link(L10n.Settings.releaseNotes, destination: AgentSessionKitInfo.bundledReleaseNotesURL)
+                Link(L10n.Settings.repository, destination: AgentSessionKitInfo.repositoryURL)
             }
             .font(.caption2)
         }
@@ -1134,7 +1134,7 @@ private struct AgentSessionKitComponentRow: View {
     }
 
     private var bundledBadge: some View {
-        Text("bundled")
+        Text(L10n.Settings.bundled)
             .font(.system(size: 9, weight: .semibold))
             .foregroundStyle(.secondary)
             .padding(.horizontal, 7)
@@ -1147,7 +1147,7 @@ private struct AgentSessionKitComponentRow: View {
         if isChecking {
             HStack(spacing: 6) {
                 ProgressView().controlSize(.small)
-                Text("Checking github.com for the newest release…")
+                Text(L10n.Settings.checkingGitHub)
             }
             .font(.caption2)
             .foregroundStyle(.secondary)
@@ -1157,12 +1157,12 @@ private struct AgentSessionKitComponentRow: View {
                     .font(.caption2)
                     .foregroundStyle(statusColor(status))
                 if let url = status.releaseNotesURL {
-                    Link("What changed in \(url.lastPathComponent)", destination: url)
+                    Link(L10n.Settings.whatChangedIn(version: url.lastPathComponent), destination: url)
                         .font(.caption2)
                 }
             }
         } else {
-            Text("Not checked. Nothing is fetched until you ask.")
+            Text(L10n.Settings.notCheckedYet)
                 .font(.caption2)
                 .foregroundStyle(.secondary)
         }
@@ -1203,9 +1203,9 @@ private struct UpdateSettingsRow: View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(alignment: .center, spacing: 12) {
                 VStack(alignment: .leading, spacing: 3) {
-                    Text("Vibe Bar \(updateController.currentVersionDescription)")
+                    Text(L10n.Settings.appVersion(version: updateController.currentVersionDescription))
                         .font(.callout)
-                    Text("Checks the selected channel once a day and asks before installing.")
+                    Text(L10n.Settings.updateCheckDetail)
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                 }
@@ -1213,12 +1213,12 @@ private struct UpdateSettingsRow: View {
                 Button {
                     updateController.checkForUpdates()
                 } label: {
-                    Label("Check for Updates…", systemImage: "arrow.triangle.2.circlepath")
+                    Label(L10n.Settings.checkForUpdates, systemImage: "arrow.triangle.2.circlepath")
                 }
                 .disabled(!updateController.canCheckForUpdates)
             }
 
-            Picker("Update channel", selection: $settingsStore.settings.updateChannel) {
+            Picker(L10n.Settings.updateChannel, selection: $settingsStore.settings.updateChannel) {
                 ForEach(UpdateChannel.allCases) { channel in
                     Text(channel.label).tag(channel)
                 }

--- a/Sources/VibeBarApp/Views/SettingsView.swift
+++ b/Sources/VibeBarApp/Views/SettingsView.swift
@@ -22,21 +22,21 @@ enum SettingsSectionID: String {
 
     var title: String {
         switch self {
-        case .menuBar: "Menu Bar"
-        case .menuBarHealth: "Menu Bar Health"
-        case .miniWindow: "Mini Window"
-        case .layout: "Layout"
+        case .menuBar: L10n.Settings.sectionMenuBar
+        case .menuBarHealth: L10n.Settings.sectionMenuBarHealth
+        case .miniWindow: L10n.Settings.sectionMiniWindows
+        case .layout: L10n.Settings.sectionLayout
         case .openAI: "OpenAI"
         case .anthropic: "Anthropic"
         case .googleAI: "Google AI"
         case .xAI: "SpaceXAI"
-        case .miscProviders: "Misc Providers"
-        case .system: "System"
-        case .costData: "Cost Data"
-        case .pricing: "Model Pricing"
-        case .privacy: "Privacy"
-        case .remote: "Remote Probes"
-        case .mcp: "MCP Server"
+        case .miscProviders: L10n.Popover.tabMisc
+        case .system: L10n.Settings.sectionSystem
+        case .costData: L10n.Settings.sectionCostData
+        case .pricing: L10n.Onboarding.stepPricingTitle
+        case .privacy: L10n.Settings.sectionPrivacy
+        case .remote: L10n.Settings.sectionRemoteProbes
+        case .mcp: L10n.Settings.mcpTitle
         }
     }
 
@@ -790,26 +790,26 @@ struct SettingsView: View {
     private func menuBarOverviewEditor() -> some View {
         let kind = MenuBarItemKind.compact
         return VStack(alignment: .leading, spacing: 10) {
-            Toggle("Show in menu bar", isOn: menuItemVisibleBinding(kind))
-            Toggle("Show title text", isOn: menuItemTitleBinding(kind))
-            Picker("Layout", selection: menuItemLayoutBinding(kind)) {
+            Toggle(L10n.Platform.macosMenuBarShowInMenuBar, isOn: menuItemVisibleBinding(kind))
+            Toggle(L10n.Platform.macosMenuBarShowTitleText, isOn: menuItemTitleBinding(kind))
+            Picker(L10n.Platform.macosMenuBarLayout, selection: menuItemLayoutBinding(kind)) {
                 ForEach(MenuBarLayout.allCases) { layout in
                     Text(layout.label).tag(layout)
                 }
             }
             .pickerStyle(.segmented)
-            Toggle("Combine a group's windows", isOn: menuItemMergeGroupWindowsBinding(kind))
-            Text("Shows 5 Hours and Weekly as 5%/100% instead of two entries.")
+            Toggle(L10n.Platform.macosMenuBarMergeGroupWindows, isOn: menuItemMergeGroupWindowsBinding(kind))
+            Text(L10n.Platform.macosMenuBarMergeGroupWindowsDetail)
                 .font(.caption2)
                 .foregroundStyle(.tertiary)
-            Picker("Display density", selection: popoverDensityBinding()) {
+            Picker(L10n.Platform.macosMenuBarDisplayDensity, selection: popoverDensityBinding()) {
                 ForEach(PopoverDensity.allCases) { Text($0.label).tag($0) }
             }
             .pickerStyle(.segmented)
             Text(settingsStore.settings.popoverDensity.detail)
                 .font(.caption2)
                 .foregroundStyle(.tertiary)
-            Picker("Percent color", selection: menuBarColorBasisBinding()) {
+            Picker(L10n.Platform.macosMenuBarPercentColor, selection: menuBarColorBasisBinding()) {
                 ForEach(MenuBarColorBasis.allCases) { Text($0.label).tag($0) }
             }
             .pickerStyle(.segmented)
@@ -817,7 +817,7 @@ struct SettingsView: View {
                 .font(.caption2)
                 .foregroundStyle(.tertiary)
             if !MenuBarFieldCatalog.fields(for: kind).isEmpty {
-                Text("Fields")
+                Text(L10n.Platform.macosMenuBarFields)
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .padding(.top, 2)
@@ -923,7 +923,7 @@ struct SettingsView: View {
     private func fieldToggle(isOn: Binding<Bool>, field: MenuBarFieldOption) -> some View {
         Toggle(isOn: isOn) {
             VStack(alignment: .leading, spacing: 2) {
-                Text(field.title)
+                Text(field.displayTitle)
                     .font(.system(size: 12, weight: .medium))
                     .lineLimit(2)
             }
@@ -935,7 +935,7 @@ struct SettingsView: View {
     /// `DebouncedSettingsTextField`: a settings mutation fans out to every
     /// open surface, and this page alone shows two dozen of these fields.
     private func fieldLabelTextField(field: MenuBarFieldOption, label: Binding<String>) -> some View {
-        DebouncedSettingsTextField(prompt: field.defaultLabel, value: label)
+        DebouncedSettingsTextField(prompt: field.displayDefaultLabel, value: label)
             .frame(width: 110)
     }
 

--- a/Sources/VibeBarApp/Views/Workbench/ResetsPage.swift
+++ b/Sources/VibeBarApp/Views/Workbench/ResetsPage.swift
@@ -562,7 +562,7 @@ struct ResetsPage: View {
                         .fill(Theme.providerAccent(for: entry.tool))
                         .frame(width: 4.5, height: 4.5)
                     Text(L10n.Workbench.resetsCalendarDayEntry(
-                        lane: entry.shortLabel,
+                        lane: QuotaGroupLabelLocalizer.display(entry.shortLabel),
                         percent: Int(entry.gainPercent.rounded())
                     ))
                         .font(.system(size: 9, weight: .semibold, design: .rounded).monospacedDigit())

--- a/Sources/VibeBarCore/Localization/L10n+Generated.swift
+++ b/Sources/VibeBarCore/Localization/L10n+Generated.swift
@@ -12,9 +12,17 @@ import Foundation
 
 extension L10n {
     public enum Common {
+        /// `common.add` — Add
+        public static var add: String {
+            L10n.string("common.add")
+        }
         /// `common.all` — All
         public static var all: String {
             L10n.string("common.all")
+        }
+        /// `common.auto` — Auto
+        public static var auto: String {
+            L10n.string("common.auto")
         }
         /// `common.cancel` — Cancel
         public static var cancel: String {
@@ -23,6 +31,10 @@ extension L10n {
         /// `common.clear` — Clear
         public static var clear: String {
             L10n.string("common.clear")
+        }
+        /// `common.copied` — Copied
+        public static var copied: String {
+            L10n.string("common.copied")
         }
         /// `common.copy` — Copy
         public static var copy: String {
@@ -96,6 +108,10 @@ extension L10n {
         public static var done: String {
             L10n.string("common.done")
         }
+        /// `common.dragToReorder` — Drag to reorder
+        public static var dragToReorder: String {
+            L10n.string("common.dragToReorder")
+        }
         /// `common.duration.days` — {days}d
         public static func durationDays(days: Int) -> String {
             L10n.string("common.duration.days", days)
@@ -124,6 +140,10 @@ extension L10n {
         public static var durationNow: String {
             L10n.string("common.duration.now")
         }
+        /// `common.name` — Name
+        public static var name: String {
+            L10n.string("common.name")
+        }
         /// `common.off` — Off
         public static var off: String {
             L10n.string("common.off")
@@ -144,6 +164,10 @@ extension L10n {
         public static func percent(value: Int) -> String {
             L10n.string("common.percent", value)
         }
+        /// `common.provider` — Provider
+        public static var provider: String {
+            L10n.string("common.provider")
+        }
         /// `common.refresh` — Refresh
         public static var refresh: String {
             L10n.string("common.refresh")
@@ -152,9 +176,21 @@ extension L10n {
         public static var refreshSection: String {
             L10n.string("common.refreshSection")
         }
+        /// `common.remove` — Remove
+        public static var remove: String {
+            L10n.string("common.remove")
+        }
         /// `common.retry` — Retry
         public static var retry: String {
             L10n.string("common.retry")
+        }
+        /// `common.retryNow` — Retry now
+        public static var retryNow: String {
+            L10n.string("common.retryNow")
+        }
+        /// `common.save` — Save
+        public static var save: String {
+            L10n.string("common.save")
         }
         /// `common.updated.daysAgo` — Updated {days, plural, one {1 day} other {# days}} ago
         public static func updatedDaysAgo(days: Int) -> String {
@@ -1357,6 +1393,130 @@ extension L10n {
     }
 
     public enum Settings {
+        /// `settings.antigravityCookieEnabled` — Antigravity cookie import is enabled — sign in at antigravity.google first.
+        public static var antigravityCookieEnabled: String {
+            L10n.string("settings.antigravityCookieEnabled")
+        }
+        /// `settings.antigravityLocalOnly` — Antigravity reads the locally running language server. Cookie import is deferred until the Antigravity Cloud endpoint ships.
+        public static var antigravityLocalOnly: String {
+            L10n.string("settings.antigravityLocalOnly")
+        }
+        /// `settings.antigravitySource` — Antigravity source
+        public static var antigravitySource: String {
+            L10n.string("settings.antigravitySource")
+        }
+        /// `settings.appVersion` — Vibe Bar {version}
+        public static func appVersion(version: String) -> String {
+            L10n.string("settings.appVersion", version)
+        }
+        /// `settings.bundled` — bundled
+        public static var bundled: String {
+            L10n.string("settings.bundled")
+        }
+        /// `settings.checkConnections` — Check {company} connections
+        public static func checkConnections(company: String) -> String {
+            L10n.string("settings.checkConnections", company)
+        }
+        /// `settings.checkForUpdates` — Check for Updates…
+        public static var checkForUpdates: String {
+            L10n.string("settings.checkForUpdates")
+        }
+        /// `settings.checkKitUpdates` — Check for kit updates
+        public static var checkKitUpdates: String {
+            L10n.string("settings.checkKitUpdates")
+        }
+        /// `settings.checkingGitHub` — Checking github.com for the newest release…
+        public static var checkingGitHub: String {
+            L10n.string("settings.checkingGitHub")
+        }
+        /// `settings.clearCostData` — Clear cost data
+        public static var clearCostData: String {
+            L10n.string("settings.clearCostData")
+        }
+        /// `settings.connectionHealth` — Connection health
+        public static var connectionHealth: String {
+            L10n.string("settings.connectionHealth")
+        }
+        /// `settings.costDataIntro` — Cost is computed from local CLI session JSONL logs at ~/.codex/sessions and ~/.claude/projects. Web/desktop usage is not tracked.
+        public static var costDataIntro: String {
+            L10n.string("settings.costDataIntro")
+        }
+        /// `settings.couldNotDeleteCookies` — Could not delete saved cookies.
+        public static var couldNotDeleteCookies: String {
+            L10n.string("settings.couldNotDeleteCookies")
+        }
+        /// `settings.couldNotDeleteGeminiCookies` — Could not delete saved Gemini cookies.
+        public static var couldNotDeleteGeminiCookies: String {
+            L10n.string("settings.couldNotDeleteGeminiCookies")
+        }
+        /// `settings.couldNotDeleteGrokCookies` — Could not delete saved Grok cookies.
+        public static var couldNotDeleteGrokCookies: String {
+            L10n.string("settings.couldNotDeleteGrokCookies")
+        }
+        /// `settings.cursorNoSession` — No usable Cursor.app session — import cursor.com cookies below.
+        public static var cursorNoSession: String {
+            L10n.string("settings.cursorNoSession")
+        }
+        /// `settings.cursorSessionDetected` — Cursor.app signed-in session detected
+        public static var cursorSessionDetected: String {
+            L10n.string("settings.cursorSessionDetected")
+        }
+        /// `settings.cursorSource` — Cursor source
+        public static var cursorSource: String {
+            L10n.string("settings.cursorSource")
+        }
+        /// `settings.cursorSourceValue` — Cursor.app → Web
+        public static var cursorSourceValue: String {
+            L10n.string("settings.cursorSourceValue")
+        }
+        /// `settings.deleteCookies` — Delete cookies
+        public static var deleteCookies: String {
+            L10n.string("settings.deleteCookies")
+        }
+        /// `settings.deleteGeminiCookies` — Delete Gemini cookies
+        public static var deleteGeminiCookies: String {
+            L10n.string("settings.deleteGeminiCookies")
+        }
+        /// `settings.deleteGrokCookies` — Delete Grok cookies
+        public static var deleteGrokCookies: String {
+            L10n.string("settings.deleteGrokCookies")
+        }
+        /// `settings.externalChange.title` — Another Vibe Bar replaced your change
+        public static var externalChangeTitle: String {
+            L10n.string("settings.externalChange.title")
+        }
+        /// `settings.geminiCookiesSaved` — Gemini cookies saved.
+        public static var geminiCookiesSaved: String {
+            L10n.string("settings.geminiCookiesSaved")
+        }
+        /// `settings.geminiShared` — Gemini and Antigravity share the same Google AI subscription quota. Cookie import is the only supported web path — there is no WebView login.
+        public static var geminiShared: String {
+            L10n.string("settings.geminiShared")
+        }
+        /// `settings.geminiSource` — Gemini source
+        public static var geminiSource: String {
+            L10n.string("settings.geminiSource")
+        }
+        /// `settings.grokAuthDetected` — ~/.grok/auth.json detected
+        public static var grokAuthDetected: String {
+            L10n.string("settings.grokAuthDetected")
+        }
+        /// `settings.grokCookiesSaved` — Grok cookies saved.
+        public static var grokCookiesSaved: String {
+            L10n.string("settings.grokCookiesSaved")
+        }
+        /// `settings.keepHistory` — Keep history
+        public static var keepHistory: String {
+            L10n.string("settings.keepHistory")
+        }
+        /// `settings.keepHistoryDetail` — Applies to cost history and subscription fill history.
+        public static var keepHistoryDetail: String {
+            L10n.string("settings.keepHistoryDetail")
+        }
+        /// `settings.kitDetail` — Session discovery, harness naming, and the MCP transport. A separate repository, pinned to an exact tag and compiled into this build.
+        public static var kitDetail: String {
+            L10n.string("settings.kitDetail")
+        }
         /// `settings.language.caption` — Vibe Bar follows the macOS language unless you pick one here. Provider, model and harness names stay as their owners spell them.
         public static var languageCaption: String {
             L10n.string("settings.language.caption")
@@ -1368,6 +1528,766 @@ extension L10n {
         /// `settings.language.title` — Language
         public static var languageTitle: String {
             L10n.string("settings.language.title")
+        }
+        /// `settings.mcp.allowRefresh` — Allow agents to refresh quota
+        public static var mcpAllowRefresh: String {
+            L10n.string("settings.mcp.allowRefresh")
+        }
+        /// `settings.mcp.allowRefreshDetail` — With this on, an agent can ask Vibe Bar to re-fetch quota from your providers. Forced refreshes are rate-limited to one every {seconds} seconds. With it off the read-only tools keep working and quota.refresh reports that refreshing is disabled.
+        public static func mcpAllowRefreshDetail(seconds: Int) -> String {
+            L10n.string("settings.mcp.allowRefreshDetail", seconds)
+        }
+        /// `settings.mcp.allowSkills` — Allow agents to install skills
+        public static var mcpAllowSkills: String {
+            L10n.string("settings.mcp.allowSkills")
+        }
+        /// `settings.mcp.allowSkillsDetail` — With this on, an agent can call skills.install to add a skill from a GitHub repository or a local folder. It goes through the same Skills manager as Workbench → Skills, so it writes only to ~/.agents/skills and the agent skills directories Vibe Bar manages — never over a folder a different skill already holds. With it off the tool reports that installing is disabled.
+        public static var mcpAllowSkillsDetail: String {
+            L10n.string("settings.mcp.allowSkillsDetail")
+        }
+        /// `settings.mcp.appendCodexConfig` — Append to ~/.codex/config.toml.
+        public static var mcpAppendCodexConfig: String {
+            L10n.string("settings.mcp.appendCodexConfig")
+        }
+        /// `settings.mcp.connectAgent` — Connect an agent
+        public static var mcpConnectAgent: String {
+            L10n.string("settings.mcp.connectAgent")
+        }
+        /// `settings.mcp.connectedClients` — Connected clients
+        public static var mcpConnectedClients: String {
+            L10n.string("settings.mcp.connectedClients")
+        }
+        /// `settings.mcp.enable` — Enable the local MCP server
+        public static var mcpEnable: String {
+            L10n.string("settings.mcp.enable")
+        }
+        /// `settings.mcp.intro` — Vibe Bar can expose this Mac's quota, usage, cost and local agent sessions to your coding agents over MCP. The server listens on a Unix domain socket in your home directory — no network port is opened, and no token is created: the socket's file permissions are the access control.
+        public static var mcpIntro: String {
+            L10n.string("settings.mcp.intro")
+        }
+        /// `settings.mcp.lastActivity` — Last client activity
+        public static var mcpLastActivity: String {
+            L10n.string("settings.mcp.lastActivity")
+        }
+        /// `settings.mcp.listening` — Listening
+        public static var mcpListening: String {
+            L10n.string("settings.mcp.listening")
+        }
+        /// `settings.mcp.manualIntro` — Or configure a client by hand. Every client runs the same command — Vibe Bar's own binary with {flag}, which bridges stdin/stdout to the socket above.
+        public static func mcpManualIntro(flag: String) -> String {
+            L10n.string("settings.mcp.manualIntro", flag)
+        }
+        /// `settings.mcp.mergeCursorConfig` — Merge into ~/.cursor/mcp.json.
+        public static var mcpMergeCursorConfig: String {
+            L10n.string("settings.mcp.mergeCursorConfig")
+        }
+        /// `settings.mcp.movePrompt` — Vibe Bar is running from {path}. Move it to /Applications before saving a client config, or the config breaks the next time you rebuild.
+        public static func mcpMovePrompt(path: String) -> String {
+            L10n.string("settings.mcp.movePrompt", path)
+        }
+        /// `settings.mcp.notListening` — Not listening
+        public static var mcpNotListening: String {
+            L10n.string("settings.mcp.notListening")
+        }
+        /// `settings.mcp.otherStdioClient` — Any other stdio client
+        public static var mcpOtherStdioClient: String {
+            L10n.string("settings.mcp.otherStdioClient")
+        }
+        /// `settings.mcp.otherStdioDetail` — One entry for the client's own mcpServers map.
+        public static var mcpOtherStdioDetail: String {
+            L10n.string("settings.mcp.otherStdioDetail")
+        }
+        /// `settings.mcp.quickestPath` — The quickest path: paste this into any agent and let it configure itself, install the companion skill, and verify the connection.
+        public static var mcpQuickestPath: String {
+            L10n.string("settings.mcp.quickestPath")
+        }
+        /// `settings.mcp.readOnlyDetail` — Everything else agents can reach is read-only: quota, token usage, cost, provider status, effective model prices, and the local session index (titles, projects, and — when session body indexing is on — message excerpts). Credentials, cookies and organization ids are never exposed, and email addresses are masked.
+        public static var mcpReadOnlyDetail: String {
+            L10n.string("settings.mcp.readOnlyDetail")
+        }
+        /// `settings.mcp.runInTerminal` — Run in a terminal.
+        public static var mcpRunInTerminal: String {
+            L10n.string("settings.mcp.runInTerminal")
+        }
+        /// `settings.mcp.setupPrompt` — Agent setup prompt
+        public static var mcpSetupPrompt: String {
+            L10n.string("settings.mcp.setupPrompt")
+        }
+        /// `settings.mcp.setupPromptDetail` — One line, works in any agent that can fetch a URL.
+        public static var mcpSetupPromptDetail: String {
+            L10n.string("settings.mcp.setupPromptDetail")
+        }
+        /// `settings.mcp.socket` — Socket
+        public static var mcpSocket: String {
+            L10n.string("settings.mcp.socket")
+        }
+        /// `settings.mcp.socketLifetime` — The socket exists only while Vibe Bar is running. Agents configured below report “Vibe Bar is not running” when it is quit, which is the intended behaviour.
+        public static var mcpSocketLifetime: String {
+            L10n.string("settings.mcp.socketLifetime")
+        }
+        /// `settings.mcp.status` — Status
+        public static var mcpStatus: String {
+            L10n.string("settings.mcp.status")
+        }
+        /// `settings.mcp.title` — MCP Server
+        public static var mcpTitle: String {
+            L10n.string("settings.mcp.title")
+        }
+        /// `settings.mcp.whatAgentsMayDo` — What agents may do
+        public static var mcpWhatAgentsMayDo: String {
+            L10n.string("settings.mcp.whatAgentsMayDo")
+        }
+        /// `settings.menuBarHealthUnavailable` — The menu bar health monitor is not attached in this process.
+        public static var menuBarHealthUnavailable: String {
+            L10n.string("settings.menuBarHealthUnavailable")
+        }
+        /// `settings.miniWindow.add` — Add a mini window
+        public static var miniWindowAdd: String {
+            L10n.string("settings.miniWindow.add")
+        }
+        /// `settings.miniWindow.allBucketsIncluded` — Every known bucket is already in this window.
+        public static var miniWindowAllBucketsIncluded: String {
+            L10n.string("settings.miniWindow.allBucketsIncluded")
+        }
+        /// `settings.miniWindow.dismissBuiltIn` — Dismiss this built-in bucket while the provider is not returning it. It comes back the moment the provider does.
+        public static var miniWindowDismissBuiltIn: String {
+            L10n.string("settings.miniWindow.dismissBuiltIn")
+        }
+        /// `settings.miniWindow.forgetDiscovered` — Forget this discovered bucket — drops it from the list and from every window that selected it.
+        public static var miniWindowForgetDiscovered: String {
+            L10n.string("settings.miniWindow.forgetDiscovered")
+        }
+        /// `settings.miniWindow.includeStyle` — Include {mode} in the double-click cycle
+        public static func miniWindowIncludeStyle(mode: String) -> String {
+            L10n.string("settings.miniWindow.includeStyle", mode)
+        }
+        /// `settings.miniWindow.lastCannotBeRemoved` — The last mini window cannot be removed.
+        public static var miniWindowLastCannotBeRemoved: String {
+            L10n.string("settings.miniWindow.lastCannotBeRemoved")
+        }
+        /// `settings.miniWindow.namesAllWindows` — Names: all windows
+        public static var miniWindowNamesAllWindows: String {
+            L10n.string("settings.miniWindow.namesAllWindows")
+        }
+        /// `settings.miniWindow.namesThisStyle` — Only {mode} here
+        public static func miniWindowNamesThisStyle(mode: String) -> String {
+            L10n.string("settings.miniWindow.namesThisStyle", mode)
+        }
+        /// `settings.miniWindow.namesThisWindow` — Only “{name}”
+        public static func miniWindowNamesThisWindow(name: String) -> String {
+            L10n.string("settings.miniWindow.namesThisWindow", name)
+        }
+        /// `settings.miniWindow.noFieldsSelected` — No fields selected — tick some above.
+        public static var miniWindowNoFieldsSelected: String {
+            L10n.string("settings.miniWindow.noFieldsSelected")
+        }
+        /// `settings.miniWindow.notInWindow` — Not in “{name}” — tick a bucket to add it. Buckets the adapters discover at runtime appear here automatically; a dimmed row is remembered but not in the account's current response, and ✕ dismisses it until the provider returns it.
+        public static func miniWindowNotInWindow(name: String) -> String {
+            L10n.string("settings.miniWindow.notInWindow", name)
+        }
+        /// `settings.miniWindow.offline` — offline
+        public static var miniWindowOffline: String {
+            L10n.string("settings.miniWindow.offline")
+        }
+        /// `settings.miniWindow.openClose` — Open / Close
+        public static var miniWindowOpenClose: String {
+            L10n.string("settings.miniWindow.openClose")
+        }
+        /// `settings.miniWindow.overridesStyle` — Overrides for the {mode} style of this window only. An empty field inherits the window name, then the shared one — shown as the placeholder.
+        public static func miniWindowOverridesStyle(mode: String) -> String {
+            L10n.string("settings.miniWindow.overridesStyle", mode)
+        }
+        /// `settings.miniWindow.overridesWindow` — Name overrides for this window only. An empty field inherits the shared name — shown as the placeholder.
+        public static var miniWindowOverridesWindow: String {
+            L10n.string("settings.miniWindow.overridesWindow")
+        }
+        /// `settings.miniWindow.position` — {position}
+        public static func miniWindowPosition(position: Int) -> String {
+            L10n.string("settings.miniWindow.position", position)
+        }
+        /// `settings.miniWindow.removeFromWindow` — Remove from this window
+        public static var miniWindowRemoveFromWindow: String {
+            L10n.string("settings.miniWindow.removeFromWindow")
+        }
+        /// `settings.miniWindow.removeHelp` — Remove this mini window
+        public static var miniWindowRemoveHelp: String {
+            L10n.string("settings.miniWindow.removeHelp")
+        }
+        /// `settings.miniWindow.stripDensity` — Strip density
+        public static var miniWindowStripDensity: String {
+            L10n.string("settings.miniWindow.stripDensity")
+        }
+        /// `settings.miniWindow.styleCycle` — Double-click on the window cycles its style. Tap a style to include it — the badge is its turn in the cycle. Nothing selected means every style, in this order.
+        public static var miniWindowStyleCycle: String {
+            L10n.string("settings.miniWindow.styleCycle")
+        }
+        /// `settings.miniWindow.toggleHelp` — Toggle this mini window on screen
+        public static var miniWindowToggleHelp: String {
+            L10n.string("settings.miniWindow.toggleHelp")
+        }
+        /// `settings.miniWindow.treeDetail` — One tree for the window — grouped exactly as it folds them (company → SubProvider → quota group → bucket). Drag a row to reorder, ✕ to remove, and rename any level in place. First field renders leftmost (or topmost).
+        public static var miniWindowTreeDetail: String {
+            L10n.string("settings.miniWindow.treeDetail")
+        }
+        /// `settings.misc.accessKeyId` — Access Key ID (AKLT…)
+        public static var miscAccessKeyId: String {
+            L10n.string("settings.misc.accessKeyId")
+        }
+        /// `settings.misc.akSkSaved` — AK/SK saved in Keychain.
+        public static var miscAkSkSaved: String {
+            L10n.string("settings.misc.akSkSaved")
+        }
+        /// `settings.misc.apiKeySaved` — API key saved in Keychain.
+        public static var miscApiKeySaved: String {
+            L10n.string("settings.misc.apiKeySaved")
+        }
+        /// `settings.misc.clearWorkspace` — Clear saved workspace
+        public static var miscClearWorkspace: String {
+            L10n.string("settings.misc.clearWorkspace")
+        }
+        /// `settings.misc.clone` — Clone {provider}
+        public static func miscClone(provider: String) -> String {
+            L10n.string("settings.misc.clone", provider)
+        }
+        /// `settings.misc.consoleLink` — {title} →
+        public static func miscConsoleLink(title: String) -> String {
+            L10n.string("settings.misc.consoleLink", title)
+        }
+        /// `settings.misc.edition` — Edition
+        public static var miscEdition: String {
+            L10n.string("settings.misc.edition")
+        }
+        /// `settings.misc.githubSignInHint` — Sign in with GitHub device flow.
+        public static var miscGithubSignInHint: String {
+            L10n.string("settings.misc.githubSignInHint")
+        }
+        /// `settings.misc.githubTokenSaved` — GitHub device token saved in Keychain.
+        public static var miscGithubTokenSaved: String {
+            L10n.string("settings.misc.githubTokenSaved")
+        }
+        /// `settings.misc.importDetail` — Adds or refreshes the first signed-in browser profile found; profiles already imported stay stacked, and this provider's quota is the average across every slot listed above. macOS may ask for your login-keychain password once per Chromium-family browser.
+        public static var miscImportDetail: String {
+            L10n.string("settings.misc.importDetail")
+        }
+        /// `settings.misc.kiroHint` — Run `kiro-cli login`, then Vibe Bar probes `kiro-cli chat --no-interactive /usage`.
+        public static var miscKiroHint: String {
+            L10n.string("settings.misc.kiroHint")
+        }
+        /// `settings.misc.noCookieSpec` — No cookie spec is registered for {provider}.
+        public static func miscNoCookieSpec(provider: String) -> String {
+            L10n.string("settings.misc.noCookieSpec", provider)
+        }
+        /// `settings.misc.noCookiesYet` — No cookies imported yet — import from your browser or paste below.
+        public static var miscNoCookiesYet: String {
+            L10n.string("settings.misc.noCookiesYet")
+        }
+        /// `settings.misc.probe` — Probe
+        public static var miscProbe: String {
+            L10n.string("settings.misc.probe")
+        }
+        /// `settings.misc.prompt.copilotHost` — GitHub Enterprise host (optional, e.g. github.example.com)
+        public static var miscPromptCopilotHost: String {
+            L10n.string("settings.misc.prompt.copilotHost")
+        }
+        /// `settings.misc.prompt.dashscope` — Paste DashScope API key (sk-...) — optional
+        public static var miscPromptDashscope: String {
+            L10n.string("settings.misc.prompt.dashscope")
+        }
+        /// `settings.misc.prompt.kilo` — Paste Kilo API key (optional)
+        public static var miscPromptKilo: String {
+            L10n.string("settings.misc.prompt.kilo")
+        }
+        /// `settings.misc.prompt.minimax` — Paste MiniMax Token Plan API key (sk-cp-... or MINIMAX_CODING_API_KEY)
+        public static var miscPromptMinimax: String {
+            L10n.string("settings.misc.prompt.minimax")
+        }
+        /// `settings.misc.prompt.openRouter` — Paste OpenRouter API key (sk-or-v1-...)
+        public static var miscPromptOpenRouter: String {
+            L10n.string("settings.misc.prompt.openRouter")
+        }
+        /// `settings.misc.prompt.openRouterHost` — OpenRouter API URL (optional, defaults to https://openrouter.ai/api/v1)
+        public static var miscPromptOpenRouterHost: String {
+            L10n.string("settings.misc.prompt.openRouterHost")
+        }
+        /// `settings.misc.prompt.warp` — Paste Warp API key (wk-...)
+        public static var miscPromptWarp: String {
+            L10n.string("settings.misc.prompt.warp")
+        }
+        /// `settings.misc.prompt.workspace` — Workspace ID or URL (optional, wrk_... or /workspace/wrk_.../go)
+        public static var miscPromptWorkspace: String {
+            L10n.string("settings.misc.prompt.workspace")
+        }
+        /// `settings.misc.prompt.zai` — Paste Z.ai API key (zai-...)
+        public static var miscPromptZai: String {
+            L10n.string("settings.misc.prompt.zai")
+        }
+        /// `settings.misc.region` — Region
+        public static var miscRegion: String {
+            L10n.string("settings.misc.region")
+        }
+        /// `settings.misc.removeAkSk` — Remove stored {provider} AK/SK
+        public static func miscRemoveAkSk(provider: String) -> String {
+            L10n.string("settings.misc.removeAkSk", provider)
+        }
+        /// `settings.misc.removeApiKey` — Remove stored {provider} API key
+        public static func miscRemoveApiKey(provider: String) -> String {
+            L10n.string("settings.misc.removeApiKey", provider)
+        }
+        /// `settings.misc.removeCookieSlot` — Remove this cookie slot
+        public static var miscRemoveCookieSlot: String {
+            L10n.string("settings.misc.removeCookieSlot")
+        }
+        /// `settings.misc.removeCopy` — Remove this {provider} copy
+        public static func miscRemoveCopy(provider: String) -> String {
+            L10n.string("settings.misc.removeCopy", provider)
+        }
+        /// `settings.misc.removeCopyButton` — Remove Copy
+        public static var miscRemoveCopyButton: String {
+            L10n.string("settings.misc.removeCopyButton")
+        }
+        /// `settings.misc.removeCopyDetail` — Its saved credentials are deleted from your Keychain — the API key or AK/SK and every imported cookie slot. This cannot be undone.
+        public static var miscRemoveCopyDetail: String {
+            L10n.string("settings.misc.removeCopyDetail")
+        }
+        /// `settings.misc.removeCopyTitle` — Remove this {provider} copy?
+        public static func miscRemoveCopyTitle(provider: String) -> String {
+            L10n.string("settings.misc.removeCopyTitle", provider)
+        }
+        /// `settings.misc.removeGithubToken` — Remove stored GitHub device token
+        public static var miscRemoveGithubToken: String {
+            L10n.string("settings.misc.removeGithubToken")
+        }
+        /// `settings.misc.rename` — Rename this copy
+        public static var miscRename: String {
+            L10n.string("settings.misc.rename")
+        }
+        /// `settings.misc.secretAccessKey` — Secret Access Key
+        public static var miscSecretAccessKey: String {
+            L10n.string("settings.misc.secretAccessKey")
+        }
+        /// `settings.misc.signIn` — Sign in
+        public static var miscSignIn: String {
+            L10n.string("settings.misc.signIn")
+        }
+        /// `settings.misc.signInViaWeb` — Sign in via Web
+        public static var miscSignInViaWeb: String {
+            L10n.string("settings.misc.signInViaWeb")
+        }
+        /// `settings.misc.tencentTokenPlanNote` — Personal Token Plan is currently available only in China mainland (cn-beijing). Clone this row to track Team and Personal together.
+        public static var miscTencentTokenPlanNote: String {
+            L10n.string("settings.misc.tencentTokenPlanNote")
+        }
+        /// `settings.misc.variant` — Variant
+        public static var miscVariant: String {
+            L10n.string("settings.misc.variant")
+        }
+        /// `settings.misc.waiting` — Waiting...
+        public static var miscWaiting: String {
+            L10n.string("settings.misc.waiting")
+        }
+        /// `settings.misc.workspaceNote` — Only needed when the account owns more than one workspace — otherwise Vibe Bar uses the first one it finds.
+        public static var miscWorkspaceNote: String {
+            L10n.string("settings.misc.workspaceNote")
+        }
+        /// `settings.needsSetup` — Needs setup
+        public static var needsSetup: String {
+            L10n.string("settings.needsSetup")
+        }
+        /// `settings.notChecked` — Not checked
+        public static var notChecked: String {
+            L10n.string("settings.notChecked")
+        }
+        /// `settings.notCheckedYet` — Not checked. Nothing is fetched until you ask.
+        public static var notCheckedYet: String {
+            L10n.string("settings.notCheckedYet")
+        }
+        /// `settings.openRefreshCooldown` — Minimum open-refresh cooldown
+        public static var openRefreshCooldown: String {
+            L10n.string("settings.openRefreshCooldown")
+        }
+        /// `settings.openRefreshDetail` — Opening the popover refreshes all visible providers at most once per cooldown period.
+        public static var openRefreshDetail: String {
+            L10n.string("settings.openRefreshDetail")
+        }
+        /// `settings.openStatusPage` — Open {company} status page
+        public static func openStatusPage(company: String) -> String {
+            L10n.string("settings.openStatusPage", company)
+        }
+        /// `settings.percentShows` — Percent shows
+        public static var percentShows: String {
+            L10n.string("settings.percentShows")
+        }
+        /// `settings.planBadge` — Plan badge
+        public static var planBadge: String {
+            L10n.string("settings.planBadge")
+        }
+        /// `settings.planBadgeDetail` — Leave blank to use the detected account plan.
+        public static var planBadgeDetail: String {
+            L10n.string("settings.planBadgeDetail")
+        }
+        /// `settings.pricing.addOverride` — Add model override
+        public static var pricingAddOverride: String {
+            L10n.string("settings.pricing.addOverride")
+        }
+        /// `settings.pricing.advancedTiers` — Advanced tiers
+        public static var pricingAdvancedTiers: String {
+            L10n.string("settings.pricing.advancedTiers")
+        }
+        /// `settings.pricing.alwaysWins` — Always wins
+        public static var pricingAlwaysWins: String {
+            L10n.string("settings.pricing.alwaysWins")
+        }
+        /// `settings.pricing.bundledFallback` — Bundled fallback
+        public static var pricingBundledFallback: String {
+            L10n.string("settings.pricing.bundledFallback")
+        }
+        /// `settings.pricing.cacheReadAbove` — Cache read above
+        public static var pricingCacheReadAbove: String {
+            L10n.string("settings.pricing.cacheReadAbove")
+        }
+        /// `settings.pricing.cacheWriteAbove` — Cache write above
+        public static var pricingCacheWriteAbove: String {
+            L10n.string("settings.pricing.cacheWriteAbove")
+        }
+        /// `settings.pricing.deleteOverride` — Delete override
+        public static var pricingDeleteOverride: String {
+            L10n.string("settings.pricing.deleteOverride")
+        }
+        /// `settings.pricing.exactModelName` — Exact model name
+        public static var pricingExactModelName: String {
+            L10n.string("settings.pricing.exactModelName")
+        }
+        /// `settings.pricing.fastMultiplier` — Fast multiplier
+        public static var pricingFastMultiplier: String {
+            L10n.string("settings.pricing.fastMultiplier")
+        }
+        /// `settings.pricing.inputAbove` — Input above
+        public static var pricingInputAbove: String {
+            L10n.string("settings.pricing.inputAbove")
+        }
+        /// `settings.pricing.intro` — Catalogs refresh in the background. Higher entries win when the same provider and model name appears more than once.
+        public static var pricingIntro: String {
+            L10n.string("settings.pricing.intro")
+        }
+        /// `settings.pricing.localOverrides` — Local overrides
+        public static var pricingLocalOverrides: String {
+            L10n.string("settings.pricing.localOverrides")
+        }
+        /// `settings.pricing.localOverridesName` — Local overrides
+        public static var pricingLocalOverridesName: String {
+            L10n.string("settings.pricing.localOverridesName")
+        }
+        /// `settings.pricing.noOverrides` — No local overrides.
+        public static var pricingNoOverrides: String {
+            L10n.string("settings.pricing.noOverrides")
+        }
+        /// `settings.pricing.number` — {number}
+        public static func pricingNumber(number: Int) -> String {
+            L10n.string("settings.pricing.number", number)
+        }
+        /// `settings.pricing.offlineFloor` — Offline floor
+        public static var pricingOfflineFloor: String {
+            L10n.string("settings.pricing.offlineFloor")
+        }
+        /// `settings.pricing.outputAbove` — Output above
+        public static var pricingOutputAbove: String {
+            L10n.string("settings.pricing.outputAbove")
+        }
+        /// `settings.pricing.overridesIntro` — Prices are USD per one million tokens. Leave cache fields empty when the provider does not publish them.
+        public static var pricingOverridesIntro: String {
+            L10n.string("settings.pricing.overridesIntro")
+        }
+        /// `settings.pricing.priorityHealth` — Priority and source health
+        public static var pricingPriorityHealth: String {
+            L10n.string("settings.pricing.priorityHealth")
+        }
+        /// `settings.pricing.rateInput` — Input
+        public static var pricingRateInput: String {
+            L10n.string("settings.pricing.rateInput")
+        }
+        /// `settings.pricing.rateOutput` — Output
+        public static var pricingRateOutput: String {
+            L10n.string("settings.pricing.rateOutput")
+        }
+        /// `settings.pricing.refreshNow` — Refresh now
+        public static var pricingRefreshNow: String {
+            L10n.string("settings.pricing.refreshNow")
+        }
+        /// `settings.pricing.refreshing` — Refreshing…
+        public static var pricingRefreshing: String {
+            L10n.string("settings.pricing.refreshing")
+        }
+        /// `settings.pricing.thresholdTokens` — Threshold tokens
+        public static var pricingThresholdTokens: String {
+            L10n.string("settings.pricing.thresholdTokens")
+        }
+        /// `settings.pricingDataDate` — Pricing data: {date}
+        public static func pricingDataDate(date: String) -> String {
+            L10n.string("settings.pricingDataDate", date)
+        }
+        /// `settings.privacyDetail` — Tokens are read from local CLI credentials. Saved OpenAI and Claude Web cookies are stored in macOS Keychain, split by browser and WebView source. Legacy plaintext cookie files under ~/.vibebar/cookies are migrated once and deleted. Settings, quota cache, and cost summaries stay under ~/.vibebar.
+        public static var privacyDetail: String {
+            L10n.string("settings.privacyDetail")
+        }
+        /// `settings.privacyMode` — Privacy mode
+        public static var privacyMode: String {
+            L10n.string("settings.privacyMode")
+        }
+        /// `settings.privacyModeDetail` — Privacy mode keeps cost data off disk and clears local cost history, snapshots, and scan cache.
+        public static var privacyModeDetail: String {
+            L10n.string("settings.privacyModeDetail")
+        }
+        /// `settings.ready` — Ready
+        public static var ready: String {
+            L10n.string("settings.ready")
+        }
+        /// `settings.refreshEvery` — Refresh every
+        public static var refreshEvery: String {
+            L10n.string("settings.refreshEvery")
+        }
+        /// `settings.refreshOnPopoverOpen` — Refresh when the popover opens
+        public static var refreshOnPopoverOpen: String {
+            L10n.string("settings.refreshOnPopoverOpen")
+        }
+        /// `settings.releaseNotes` — Release notes
+        public static var releaseNotes: String {
+            L10n.string("settings.releaseNotes")
+        }
+        /// `settings.remote.core` — Remote Core
+        public static var remoteCore: String {
+            L10n.string("settings.remote.core")
+        }
+        /// `settings.remote.costAggregation` — Cost aggregation
+        public static var remoteCostAggregation: String {
+            L10n.string("settings.remote.costAggregation")
+        }
+        /// `settings.remote.costAggregationIntro` — Choose which remote machines join this Mac's local cost and token totals. Selection and aggregation stay on this Core; the Relay never sees plaintext usage.
+        public static var remoteCostAggregationIntro: String {
+            L10n.string("settings.remote.costAggregationIntro")
+        }
+        /// `settings.remote.differentControlCenter` — Use a different control center
+        public static var remoteDifferentControlCenter: String {
+            L10n.string("settings.remote.differentControlCenter")
+        }
+        /// `settings.remote.discard` — Discard
+        public static var remoteDiscard: String {
+            L10n.string("settings.remote.discard")
+        }
+        /// `settings.remote.discardPendingDetail` — Its pairing code is already spent, and the workspace still counts this Mac as its Core. To join again, revoke this Mac in the web control center, then create a fresh code.
+        public static var remoteDiscardPendingDetail: String {
+            L10n.string("settings.remote.discardPendingDetail")
+        }
+        /// `settings.remote.discardPendingTitle` — Discard this pending join?
+        public static var remoteDiscardPendingTitle: String {
+            L10n.string("settings.remote.discardPendingTitle")
+        }
+        /// `settings.remote.disconnect` — Disconnect
+        public static var remoteDisconnect: String {
+            L10n.string("settings.remote.disconnect")
+        }
+        /// `settings.remote.disconnectButton` — Disconnect from Workspace…
+        public static var remoteDisconnectButton: String {
+            L10n.string("settings.remote.disconnectButton")
+        }
+        /// `settings.remote.disconnectDetail` — Reconnecting later requires a new pairing code or provisioning file.
+        public static var remoteDisconnectDetail: String {
+            L10n.string("settings.remote.disconnectDetail")
+        }
+        /// `settings.remote.disconnectIntro` — Disconnecting removes this Mac's Relay credential from the Keychain and its workspace binding. Probes keep uploading to the Relay until they are revoked there. Usage already decrypted stays in the local ledger.
+        public static var remoteDisconnectIntro: String {
+            L10n.string("settings.remote.disconnectIntro")
+        }
+        /// `settings.remote.disconnectTitle` — Disconnect from this workspace?
+        public static var remoteDisconnectTitle: String {
+            L10n.string("settings.remote.disconnectTitle")
+        }
+        /// `settings.remote.exportIdentity` — Export Core Identity…
+        public static var remoteExportIdentity: String {
+            L10n.string("settings.remote.exportIdentity")
+        }
+        /// `settings.remote.importProvisioning` — Import Provisioning File…
+        public static var remoteImportProvisioning: String {
+            L10n.string("settings.remote.importProvisioning")
+        }
+        /// `settings.remote.join` — Join
+        public static var remoteJoin: String {
+            L10n.string("settings.remote.join")
+        }
+        /// `settings.remote.joinIntro` — Create a Core code in the Vibe Bar control center, then paste it here. This Mac joins as “{device}”.
+        public static func remoteJoinIntro(device: String) -> String {
+            L10n.string("settings.remote.joinIntro", device)
+        }
+        /// `settings.remote.joinWithCode` — Join with a code
+        public static var remoteJoinWithCode: String {
+            L10n.string("settings.remote.joinWithCode")
+        }
+        /// `settings.remote.lastSync` — Last sync
+        public static var remoteLastSync: String {
+            L10n.string("settings.remote.lastSync")
+        }
+        /// `settings.remote.machineDetail` — {platform} · Probe {version}
+        public static func remoteMachineDetail(platform: String, version: String) -> String {
+            L10n.string("settings.remote.machineDetail", platform, version)
+        }
+        /// `settings.remote.machinesAppearAfterImport` — Machines appear here after their first encrypted batch is imported.
+        public static var remoteMachinesAppearAfterImport: String {
+            L10n.string("settings.remote.machinesAppearAfterImport")
+        }
+        /// `settings.remote.machinesSynced` — Machines synced
+        public static var remoteMachinesSynced: String {
+            L10n.string("settings.remote.machinesSynced")
+        }
+        /// `settings.remote.manualPairingIntro` — Pairing runs in three steps: export this Mac's Core identity, register it with your Relay to produce a provisioning file, then import that file here. Importing moves the Relay credential into the macOS Keychain — but the provisioning file itself still contains that credential, so delete the file once the import succeeds.
+        public static var remoteManualPairingIntro: String {
+            L10n.string("settings.remote.manualPairingIntro")
+        }
+        /// `settings.remote.notConnected` — This Mac is not connected to a workspace. Remote probes collect normalized usage on your other machines, encrypt it to this Mac's Core keys, and drop it at a Relay — no inbound port is ever opened here.
+        public static var remoteNotConnected: String {
+            L10n.string("settings.remote.notConnected")
+        }
+        /// `settings.remote.orPairManually` — Or pair manually.
+        public static var remoteOrPairManually: String {
+            L10n.string("settings.remote.orPairManually")
+        }
+        /// `settings.remote.pendingIntro` — A previous join was accepted by the control center but never finished saving on this Mac. Its pairing code is already spent, so resume the save instead of requesting a new code.
+        public static var remotePendingIntro: String {
+            L10n.string("settings.remote.pendingIntro")
+        }
+        /// `settings.remote.provisioning` — Provisioning
+        public static var remoteProvisioning: String {
+            L10n.string("settings.remote.provisioning")
+        }
+        /// `settings.remote.registeredProbes` — Registered probes
+        public static var remoteRegisteredProbes: String {
+            L10n.string("settings.remote.registeredProbes")
+        }
+        /// `settings.remote.relay` — Relay
+        public static var remoteRelay: String {
+            L10n.string("settings.remote.relay")
+        }
+        /// `settings.remote.resumeSaving` — Resume saving
+        public static var remoteResumeSaving: String {
+            L10n.string("settings.remote.resumeSaving")
+        }
+        /// `settings.remote.retrySaving` — Retry saving
+        public static var remoteRetrySaving: String {
+            L10n.string("settings.remote.retrySaving")
+        }
+        /// `settings.remote.statusWithCode` — {title} · {code}
+        public static func remoteStatusWithCode(title: String, code: String) -> String {
+            L10n.string("settings.remote.statusWithCode", title, code)
+        }
+        /// `settings.remote.syncNow` — Sync now
+        public static var remoteSyncNow: String {
+            L10n.string("settings.remote.syncNow")
+        }
+        /// `settings.remote.workspace` — Workspace
+        public static var remoteWorkspace: String {
+            L10n.string("settings.remote.workspace")
+        }
+        /// `settings.repository` — Repository
+        public static var repository: String {
+            L10n.string("settings.repository")
+        }
+        /// `settings.rescanCostLogs` — Rescan cost logs
+        public static var rescanCostLogs: String {
+            L10n.string("settings.rescanCostLogs")
+        }
+        /// `settings.search` — Search settings
+        public static var search: String {
+            L10n.string("settings.search")
+        }
+        /// `settings.section.components` — Components
+        public static var sectionComponents: String {
+            L10n.string("settings.section.components")
+        }
+        /// `settings.section.costData` — Cost Data
+        public static var sectionCostData: String {
+            L10n.string("settings.section.costData")
+        }
+        /// `settings.section.layout` — Layout
+        public static var sectionLayout: String {
+            L10n.string("settings.section.layout")
+        }
+        /// `settings.section.menuBarHealth` — Menu Bar Health
+        public static var sectionMenuBarHealth: String {
+            L10n.string("settings.section.menuBarHealth")
+        }
+        /// `settings.section.miniWindows` — Mini Windows
+        public static var sectionMiniWindows: String {
+            L10n.string("settings.section.miniWindows")
+        }
+        /// `settings.section.overview` — Overview
+        public static var sectionOverview: String {
+            L10n.string("settings.section.overview")
+        }
+        /// `settings.section.privacy` — Privacy
+        public static var sectionPrivacy: String {
+            L10n.string("settings.section.privacy")
+        }
+        /// `settings.section.refreshing` — Refreshing
+        public static var sectionRefreshing: String {
+            L10n.string("settings.section.refreshing")
+        }
+        /// `settings.section.system` — System
+        public static var sectionSystem: String {
+            L10n.string("settings.section.system")
+        }
+        /// `settings.section.updates` — Updates
+        public static var sectionUpdates: String {
+            L10n.string("settings.section.updates")
+        }
+        /// `settings.showAssistant` — Show setup assistant
+        public static var showAssistant: String {
+            L10n.string("settings.showAssistant")
+        }
+        /// `settings.showAssistantDetail` — Walk through subscriptions, browser cookies, API keys, model pricing and login items again. Nothing is reset.
+        public static var showAssistantDetail: String {
+            L10n.string("settings.showAssistantDetail")
+        }
+        /// `settings.sidebar.coreProviders` — Core Providers
+        public static var sidebarCoreProviders: String {
+            L10n.string("settings.sidebar.coreProviders")
+        }
+        /// `settings.sidebar.disableProvider` — Disable Provider
+        public static var sidebarDisableProvider: String {
+            L10n.string("settings.sidebar.disableProvider")
+        }
+        /// `settings.sidebar.enableProvider` — Enable Provider
+        public static var sidebarEnableProvider: String {
+            L10n.string("settings.sidebar.enableProvider")
+        }
+        /// `settings.sidebar.hideFromOverview` — Hide from Overview
+        public static var sidebarHideFromOverview: String {
+            L10n.string("settings.sidebar.hideFromOverview")
+        }
+        /// `settings.sidebar.settings` — Settings
+        public static var sidebarSettings: String {
+            L10n.string("settings.sidebar.settings")
+        }
+        /// `settings.spaceXAIIntro` — The SpaceXAI page combines Grok with Cursor. Grok reads `~/.grok/auth.json` or grok.com cookies; Cursor reads Cursor.app first, then cursor.com cookie slots. Grok Bot contributes quota, plus read-only sessions from its local cache — its cloud runs still add no token/cost rows.
+        public static var spaceXAIIntro: String {
+            L10n.string("settings.spaceXAIIntro")
+        }
+        /// `settings.updateChannel` — Update channel
+        public static var updateChannel: String {
+            L10n.string("settings.updateChannel")
+        }
+        /// `settings.updateCheckDetail` — Checks the selected channel once a day and asks before installing.
+        public static var updateCheckDetail: String {
+            L10n.string("settings.updateCheckDetail")
+        }
+        /// `settings.usageSource` — Usage source
+        public static var usageSource: String {
+            L10n.string("settings.usageSource")
+        }
+        /// `settings.webQuota` — Web quota
+        public static var webQuota: String {
+            L10n.string("settings.webQuota")
+        }
+        /// `settings.whatChangedIn` — What changed in {version}
+        public static func whatChangedIn(version: String) -> String {
+            L10n.string("settings.whatChangedIn", version)
         }
     }
 
@@ -3469,9 +4389,12 @@ extension L10n {
     /// Every key the catalog defines, for the tests that assert the
     /// shipped `.strings` resolve and that no key is unreachable.
     static let allKeys: [String] = [
+        "common.add",
         "common.all",
+        "common.auto",
         "common.cancel",
         "common.clear",
+        "common.copied",
         "common.copy",
         "common.date.month.1",
         "common.date.month.10",
@@ -3490,6 +4413,7 @@ extension L10n {
         "common.delete",
         "common.dismiss",
         "common.done",
+        "common.dragToReorder",
         "common.duration.days",
         "common.duration.daysHours",
         "common.duration.hours",
@@ -3497,14 +4421,19 @@ extension L10n {
         "common.duration.lessThanMinute",
         "common.duration.minutes",
         "common.duration.now",
+        "common.name",
         "common.off",
         "common.on",
         "common.open",
         "common.openSettings",
         "common.percent",
+        "common.provider",
         "common.refresh",
         "common.refreshSection",
+        "common.remove",
         "common.retry",
+        "common.retryNow",
+        "common.save",
         "common.updated.daysAgo",
         "common.updated.hoursAgo",
         "common.updated.justNow",
@@ -3800,9 +4729,230 @@ extension L10n {
         "quota.upcoming.resetsAt",
         "quota.upcoming.title",
         "quota.update.failed",
+        "settings.antigravityCookieEnabled",
+        "settings.antigravityLocalOnly",
+        "settings.antigravitySource",
+        "settings.appVersion",
+        "settings.bundled",
+        "settings.checkConnections",
+        "settings.checkForUpdates",
+        "settings.checkKitUpdates",
+        "settings.checkingGitHub",
+        "settings.clearCostData",
+        "settings.connectionHealth",
+        "settings.costDataIntro",
+        "settings.couldNotDeleteCookies",
+        "settings.couldNotDeleteGeminiCookies",
+        "settings.couldNotDeleteGrokCookies",
+        "settings.cursorNoSession",
+        "settings.cursorSessionDetected",
+        "settings.cursorSource",
+        "settings.cursorSourceValue",
+        "settings.deleteCookies",
+        "settings.deleteGeminiCookies",
+        "settings.deleteGrokCookies",
+        "settings.externalChange.title",
+        "settings.geminiCookiesSaved",
+        "settings.geminiShared",
+        "settings.geminiSource",
+        "settings.grokAuthDetected",
+        "settings.grokCookiesSaved",
+        "settings.keepHistory",
+        "settings.keepHistoryDetail",
+        "settings.kitDetail",
         "settings.language.caption",
         "settings.language.system",
         "settings.language.title",
+        "settings.mcp.allowRefresh",
+        "settings.mcp.allowRefreshDetail",
+        "settings.mcp.allowSkills",
+        "settings.mcp.allowSkillsDetail",
+        "settings.mcp.appendCodexConfig",
+        "settings.mcp.connectAgent",
+        "settings.mcp.connectedClients",
+        "settings.mcp.enable",
+        "settings.mcp.intro",
+        "settings.mcp.lastActivity",
+        "settings.mcp.listening",
+        "settings.mcp.manualIntro",
+        "settings.mcp.mergeCursorConfig",
+        "settings.mcp.movePrompt",
+        "settings.mcp.notListening",
+        "settings.mcp.otherStdioClient",
+        "settings.mcp.otherStdioDetail",
+        "settings.mcp.quickestPath",
+        "settings.mcp.readOnlyDetail",
+        "settings.mcp.runInTerminal",
+        "settings.mcp.setupPrompt",
+        "settings.mcp.setupPromptDetail",
+        "settings.mcp.socket",
+        "settings.mcp.socketLifetime",
+        "settings.mcp.status",
+        "settings.mcp.title",
+        "settings.mcp.whatAgentsMayDo",
+        "settings.menuBarHealthUnavailable",
+        "settings.miniWindow.add",
+        "settings.miniWindow.allBucketsIncluded",
+        "settings.miniWindow.dismissBuiltIn",
+        "settings.miniWindow.forgetDiscovered",
+        "settings.miniWindow.includeStyle",
+        "settings.miniWindow.lastCannotBeRemoved",
+        "settings.miniWindow.namesAllWindows",
+        "settings.miniWindow.namesThisStyle",
+        "settings.miniWindow.namesThisWindow",
+        "settings.miniWindow.noFieldsSelected",
+        "settings.miniWindow.notInWindow",
+        "settings.miniWindow.offline",
+        "settings.miniWindow.openClose",
+        "settings.miniWindow.overridesStyle",
+        "settings.miniWindow.overridesWindow",
+        "settings.miniWindow.position",
+        "settings.miniWindow.removeFromWindow",
+        "settings.miniWindow.removeHelp",
+        "settings.miniWindow.stripDensity",
+        "settings.miniWindow.styleCycle",
+        "settings.miniWindow.toggleHelp",
+        "settings.miniWindow.treeDetail",
+        "settings.misc.accessKeyId",
+        "settings.misc.akSkSaved",
+        "settings.misc.apiKeySaved",
+        "settings.misc.clearWorkspace",
+        "settings.misc.clone",
+        "settings.misc.consoleLink",
+        "settings.misc.edition",
+        "settings.misc.githubSignInHint",
+        "settings.misc.githubTokenSaved",
+        "settings.misc.importDetail",
+        "settings.misc.kiroHint",
+        "settings.misc.noCookieSpec",
+        "settings.misc.noCookiesYet",
+        "settings.misc.probe",
+        "settings.misc.prompt.copilotHost",
+        "settings.misc.prompt.dashscope",
+        "settings.misc.prompt.kilo",
+        "settings.misc.prompt.minimax",
+        "settings.misc.prompt.openRouter",
+        "settings.misc.prompt.openRouterHost",
+        "settings.misc.prompt.warp",
+        "settings.misc.prompt.workspace",
+        "settings.misc.prompt.zai",
+        "settings.misc.region",
+        "settings.misc.removeAkSk",
+        "settings.misc.removeApiKey",
+        "settings.misc.removeCookieSlot",
+        "settings.misc.removeCopy",
+        "settings.misc.removeCopyButton",
+        "settings.misc.removeCopyDetail",
+        "settings.misc.removeCopyTitle",
+        "settings.misc.removeGithubToken",
+        "settings.misc.rename",
+        "settings.misc.secretAccessKey",
+        "settings.misc.signIn",
+        "settings.misc.signInViaWeb",
+        "settings.misc.tencentTokenPlanNote",
+        "settings.misc.variant",
+        "settings.misc.waiting",
+        "settings.misc.workspaceNote",
+        "settings.needsSetup",
+        "settings.notChecked",
+        "settings.notCheckedYet",
+        "settings.openRefreshCooldown",
+        "settings.openRefreshDetail",
+        "settings.openStatusPage",
+        "settings.percentShows",
+        "settings.planBadge",
+        "settings.planBadgeDetail",
+        "settings.pricing.addOverride",
+        "settings.pricing.advancedTiers",
+        "settings.pricing.alwaysWins",
+        "settings.pricing.bundledFallback",
+        "settings.pricing.cacheReadAbove",
+        "settings.pricing.cacheWriteAbove",
+        "settings.pricing.deleteOverride",
+        "settings.pricing.exactModelName",
+        "settings.pricing.fastMultiplier",
+        "settings.pricing.inputAbove",
+        "settings.pricing.intro",
+        "settings.pricing.localOverrides",
+        "settings.pricing.localOverridesName",
+        "settings.pricing.noOverrides",
+        "settings.pricing.number",
+        "settings.pricing.offlineFloor",
+        "settings.pricing.outputAbove",
+        "settings.pricing.overridesIntro",
+        "settings.pricing.priorityHealth",
+        "settings.pricing.rateInput",
+        "settings.pricing.rateOutput",
+        "settings.pricing.refreshNow",
+        "settings.pricing.refreshing",
+        "settings.pricing.thresholdTokens",
+        "settings.pricingDataDate",
+        "settings.privacyDetail",
+        "settings.privacyMode",
+        "settings.privacyModeDetail",
+        "settings.ready",
+        "settings.refreshEvery",
+        "settings.refreshOnPopoverOpen",
+        "settings.releaseNotes",
+        "settings.remote.core",
+        "settings.remote.costAggregation",
+        "settings.remote.costAggregationIntro",
+        "settings.remote.differentControlCenter",
+        "settings.remote.discard",
+        "settings.remote.discardPendingDetail",
+        "settings.remote.discardPendingTitle",
+        "settings.remote.disconnect",
+        "settings.remote.disconnectButton",
+        "settings.remote.disconnectDetail",
+        "settings.remote.disconnectIntro",
+        "settings.remote.disconnectTitle",
+        "settings.remote.exportIdentity",
+        "settings.remote.importProvisioning",
+        "settings.remote.join",
+        "settings.remote.joinIntro",
+        "settings.remote.joinWithCode",
+        "settings.remote.lastSync",
+        "settings.remote.machineDetail",
+        "settings.remote.machinesAppearAfterImport",
+        "settings.remote.machinesSynced",
+        "settings.remote.manualPairingIntro",
+        "settings.remote.notConnected",
+        "settings.remote.orPairManually",
+        "settings.remote.pendingIntro",
+        "settings.remote.provisioning",
+        "settings.remote.registeredProbes",
+        "settings.remote.relay",
+        "settings.remote.resumeSaving",
+        "settings.remote.retrySaving",
+        "settings.remote.statusWithCode",
+        "settings.remote.syncNow",
+        "settings.remote.workspace",
+        "settings.repository",
+        "settings.rescanCostLogs",
+        "settings.search",
+        "settings.section.components",
+        "settings.section.costData",
+        "settings.section.layout",
+        "settings.section.menuBarHealth",
+        "settings.section.miniWindows",
+        "settings.section.overview",
+        "settings.section.privacy",
+        "settings.section.refreshing",
+        "settings.section.system",
+        "settings.section.updates",
+        "settings.showAssistant",
+        "settings.showAssistantDetail",
+        "settings.sidebar.coreProviders",
+        "settings.sidebar.disableProvider",
+        "settings.sidebar.enableProvider",
+        "settings.sidebar.hideFromOverview",
+        "settings.sidebar.settings",
+        "settings.spaceXAIIntro",
+        "settings.updateChannel",
+        "settings.updateCheckDetail",
+        "settings.usageSource",
+        "settings.webQuota",
+        "settings.whatChangedIn",
         "status.card.componentCount",
         "status.card.components",
         "status.card.noIncidents",

--- a/Sources/VibeBarCore/Localization/L10n+Generated.swift
+++ b/Sources/VibeBarCore/Localization/L10n+Generated.swift
@@ -812,6 +812,98 @@ extension L10n {
         public static var macosLaunchAtLoginToggle: String {
             L10n.string("platform.macos.launchAtLogin.toggle")
         }
+        /// `platform.macos.menuBar.color.actual` — Actual
+        public static var macosMenuBarColorActual: String {
+            L10n.string("platform.macos.menuBar.color.actual")
+        }
+        /// `platform.macos.menuBar.color.actualDetail` — Colored by the displayed percentage alone, ignoring the forecast.
+        public static var macosMenuBarColorActualDetail: String {
+            L10n.string("platform.macos.menuBar.color.actualDetail")
+        }
+        /// `platform.macos.menuBar.color.forecast` — Forecast
+        public static var macosMenuBarColorForecast: String {
+            L10n.string("platform.macos.menuBar.color.forecast")
+        }
+        /// `platform.macos.menuBar.color.forecastDetail` — Green projected to last · blue a chunk will likely go unused · orange may run short · red projected to run out. Falls back to the percentage while a quota has too little history to forecast.
+        public static var macosMenuBarColorForecastDetail: String {
+            L10n.string("platform.macos.menuBar.color.forecastDetail")
+        }
+        /// `platform.macos.menuBar.displayDensity` — Display density
+        public static var macosMenuBarDisplayDensity: String {
+            L10n.string("platform.macos.menuBar.displayDensity")
+        }
+        /// `platform.macos.menuBar.fieldStyle.label` — Label
+        public static var macosMenuBarFieldStyleLabel: String {
+            L10n.string("platform.macos.menuBar.fieldStyle.label")
+        }
+        /// `platform.macos.menuBar.fieldStyle.labelDetail` — The field's name beside its percent.
+        public static var macosMenuBarFieldStyleLabelDetail: String {
+            L10n.string("platform.macos.menuBar.fieldStyle.labelDetail")
+        }
+        /// `platform.macos.menuBar.fieldStyle.logo` — Logo
+        public static var macosMenuBarFieldStyleLogo: String {
+            L10n.string("platform.macos.menuBar.fieldStyle.logo")
+        }
+        /// `platform.macos.menuBar.fieldStyle.logoAndLabel` — Logo and label
+        public static var macosMenuBarFieldStyleLogoAndLabel: String {
+            L10n.string("platform.macos.menuBar.fieldStyle.logoAndLabel")
+        }
+        /// `platform.macos.menuBar.fieldStyle.logoAndLabelDetail` — Logo, name, and percent.
+        public static var macosMenuBarFieldStyleLogoAndLabelDetail: String {
+            L10n.string("platform.macos.menuBar.fieldStyle.logoAndLabelDetail")
+        }
+        /// `platform.macos.menuBar.fieldStyle.logoDetail` — The provider's logo beside the percent — no text.
+        public static var macosMenuBarFieldStyleLogoDetail: String {
+            L10n.string("platform.macos.menuBar.fieldStyle.logoDetail")
+        }
+        /// `platform.macos.menuBar.fields` — Fields
+        public static var macosMenuBarFields: String {
+            L10n.string("platform.macos.menuBar.fields")
+        }
+        /// `platform.macos.menuBar.layout` — Layout
+        public static var macosMenuBarLayout: String {
+            L10n.string("platform.macos.menuBar.layout")
+        }
+        /// `platform.macos.menuBar.layout.compact` — Compact
+        public static var macosMenuBarLayoutCompact: String {
+            L10n.string("platform.macos.menuBar.layout.compact")
+        }
+        /// `platform.macos.menuBar.layout.iconOnly` — Icon Only
+        public static var macosMenuBarLayoutIconOnly: String {
+            L10n.string("platform.macos.menuBar.layout.iconOnly")
+        }
+        /// `platform.macos.menuBar.layout.singleLine` — Single line
+        public static var macosMenuBarLayoutSingleLine: String {
+            L10n.string("platform.macos.menuBar.layout.singleLine")
+        }
+        /// `platform.macos.menuBar.layout.twoRows` — Two rows
+        public static var macosMenuBarLayoutTwoRows: String {
+            L10n.string("platform.macos.menuBar.layout.twoRows")
+        }
+        /// `platform.macos.menuBar.mergeGroupWindows` — Combine a group's windows
+        public static var macosMenuBarMergeGroupWindows: String {
+            L10n.string("platform.macos.menuBar.mergeGroupWindows")
+        }
+        /// `platform.macos.menuBar.mergeGroupWindowsDetail` — Shows 5 Hours and Weekly as 5%/100% instead of two entries.
+        public static var macosMenuBarMergeGroupWindowsDetail: String {
+            L10n.string("platform.macos.menuBar.mergeGroupWindowsDetail")
+        }
+        /// `platform.macos.menuBar.overview` — Overview
+        public static var macosMenuBarOverview: String {
+            L10n.string("platform.macos.menuBar.overview")
+        }
+        /// `platform.macos.menuBar.percentColor` — Percent color
+        public static var macosMenuBarPercentColor: String {
+            L10n.string("platform.macos.menuBar.percentColor")
+        }
+        /// `platform.macos.menuBar.showInMenuBar` — Show in menu bar
+        public static var macosMenuBarShowInMenuBar: String {
+            L10n.string("platform.macos.menuBar.showInMenuBar")
+        }
+        /// `platform.macos.menuBar.showTitleText` — Show title text
+        public static var macosMenuBarShowTitleText: String {
+            L10n.string("platform.macos.menuBar.showTitleText")
+        }
     }
 
     public enum Popover {
@@ -1453,6 +1545,26 @@ extension L10n {
         public static var couldNotDeleteGrokCookies: String {
             L10n.string("settings.couldNotDeleteGrokCookies")
         }
+        /// `settings.credentialSource.apiOnly` — API / OAuth only
+        public static var credentialSourceApiOnly: String {
+            L10n.string("settings.credentialSource.apiOnly")
+        }
+        /// `settings.credentialSource.auto` — Auto
+        public static var credentialSourceAuto: String {
+            L10n.string("settings.credentialSource.auto")
+        }
+        /// `settings.credentialSource.browserOnly` — Browser only
+        public static var credentialSourceBrowserOnly: String {
+            L10n.string("settings.credentialSource.browserOnly")
+        }
+        /// `settings.credentialSource.manualOnly` — Manual only
+        public static var credentialSourceManualOnly: String {
+            L10n.string("settings.credentialSource.manualOnly")
+        }
+        /// `settings.credentialSource.off` — Off
+        public static var credentialSourceOff: String {
+            L10n.string("settings.credentialSource.off")
+        }
         /// `settings.cursorNoSession` — No usable Cursor.app session — import cursor.com cookies below.
         public static var cursorNoSession: String {
             L10n.string("settings.cursorNoSession")
@@ -1480,6 +1592,14 @@ extension L10n {
         /// `settings.deleteGrokCookies` — Delete Grok cookies
         public static var deleteGrokCookies: String {
             L10n.string("settings.deleteGrokCookies")
+        }
+        /// `settings.displayMode.remaining` — Remaining
+        public static var displayModeRemaining: String {
+            L10n.string("settings.displayMode.remaining")
+        }
+        /// `settings.displayMode.used` — Used
+        public static var displayModeUsed: String {
+            L10n.string("settings.displayMode.used")
         }
         /// `settings.externalChange.title` — Another Vibe Bar replaced your change
         public static var externalChangeTitle: String {
@@ -1649,6 +1769,30 @@ extension L10n {
         public static var miniWindowAllBucketsIncluded: String {
             L10n.string("settings.miniWindow.allBucketsIncluded")
         }
+        /// `settings.miniWindow.density.narrow` — Narrow
+        public static var miniWindowDensityNarrow: String {
+            L10n.string("settings.miniWindow.density.narrow")
+        }
+        /// `settings.miniWindow.density.narrowDetail` — The menu bar's compact style: the same cells at the small size.
+        public static var miniWindowDensityNarrowDetail: String {
+            L10n.string("settings.miniWindow.density.narrowDetail")
+        }
+        /// `settings.miniWindow.density.roomy` — Roomy
+        public static var miniWindowDensityRoomy: String {
+            L10n.string("settings.miniWindow.density.roomy")
+        }
+        /// `settings.miniWindow.density.roomyDetail` — The menu bar's single-line style: every bucket, full label beside its number.
+        public static var miniWindowDensityRoomyDetail: String {
+            L10n.string("settings.miniWindow.density.roomyDetail")
+        }
+        /// `settings.miniWindow.density.twoLines` — Two Lines
+        public static var miniWindowDensityTwoLines: String {
+            L10n.string("settings.miniWindow.density.twoLines")
+        }
+        /// `settings.miniWindow.density.twoLinesDetail` — Menu-bar style: buckets pair into stacked columns, label beside each number.
+        public static var miniWindowDensityTwoLinesDetail: String {
+            L10n.string("settings.miniWindow.density.twoLinesDetail")
+        }
         /// `settings.miniWindow.dismissBuiltIn` — Dismiss this built-in bucket while the provider is not returning it. It comes back the moment the provider does.
         public static var miniWindowDismissBuiltIn: String {
             L10n.string("settings.miniWindow.dismissBuiltIn")
@@ -1664,6 +1808,62 @@ extension L10n {
         /// `settings.miniWindow.lastCannotBeRemoved` — The last mini window cannot be removed.
         public static var miniWindowLastCannotBeRemoved: String {
             L10n.string("settings.miniWindow.lastCannotBeRemoved")
+        }
+        /// `settings.miniWindow.mode.compact` — Compact
+        public static var miniWindowModeCompact: String {
+            L10n.string("settings.miniWindow.mode.compact")
+        }
+        /// `settings.miniWindow.mode.compactDetail` — The same three tiers as vertical bars, sized for a corner.
+        public static var miniWindowModeCompactDetail: String {
+            L10n.string("settings.miniWindow.mode.compactDetail")
+        }
+        /// `settings.miniWindow.mode.focus` — Focus
+        public static var miniWindowModeFocus: String {
+            L10n.string("settings.miniWindow.mode.focus")
+        }
+        /// `settings.miniWindow.mode.focusDetail` — One selected bucket at a time, large — click to cycle in your order.
+        public static var miniWindowModeFocusDetail: String {
+            L10n.string("settings.miniWindow.mode.focusDetail")
+        }
+        /// `settings.miniWindow.mode.ledger` — Ledger
+        public static var miniWindowModeLedger: String {
+            L10n.string("settings.miniWindow.mode.ledger")
+        }
+        /// `settings.miniWindow.mode.ledgerDetail` — One row per quota bucket — fixed width, grows downward.
+        public static var miniWindowModeLedgerDetail: String {
+            L10n.string("settings.miniWindow.mode.ledgerDetail")
+        }
+        /// `settings.miniWindow.mode.rail` — Rail
+        public static var miniWindowModeRail: String {
+            L10n.string("settings.miniWindow.mode.rail")
+        }
+        /// `settings.miniWindow.mode.railDetail` — The next seven days as a refill lane with the coming resets listed.
+        public static var miniWindowModeRailDetail: String {
+            L10n.string("settings.miniWindow.mode.railDetail")
+        }
+        /// `settings.miniWindow.mode.regular` — Regular
+        public static var miniWindowModeRegular: String {
+            L10n.string("settings.miniWindow.mode.regular")
+        }
+        /// `settings.miniWindow.mode.regularDetail` — Ring gauges grouped company → SubProvider → quota group.
+        public static var miniWindowModeRegularDetail: String {
+            L10n.string("settings.miniWindow.mode.regularDetail")
+        }
+        /// `settings.miniWindow.mode.strip` — Strip
+        public static var miniWindowModeStrip: String {
+            L10n.string("settings.miniWindow.mode.strip")
+        }
+        /// `settings.miniWindow.mode.stripDetail` — A slim line mirroring the menu bar's styles — one cell per bucket.
+        public static var miniWindowModeStripDetail: String {
+            L10n.string("settings.miniWindow.mode.stripDetail")
+        }
+        /// `settings.miniWindow.mode.tiles` — Tiles
+        public static var miniWindowModeTiles: String {
+            L10n.string("settings.miniWindow.mode.tiles")
+        }
+        /// `settings.miniWindow.mode.tilesDetail` — A grid of tiles with a big number and a severity stripe.
+        public static var miniWindowModeTilesDetail: String {
+            L10n.string("settings.miniWindow.mode.tilesDetail")
         }
         /// `settings.miniWindow.namesAllWindows` — Names: all windows
         public static var miniWindowNamesAllWindows: String {
@@ -1825,6 +2025,34 @@ extension L10n {
         public static var miscRegion: String {
             L10n.string("settings.misc.region")
         }
+        /// `settings.misc.region.auto` — Auto (try both)
+        public static var miscRegionAuto: String {
+            L10n.string("settings.misc.region.auto")
+        }
+        /// `settings.misc.region.chinaMainland` — China mainland (cn-beijing)
+        public static var miscRegionChinaMainland: String {
+            L10n.string("settings.misc.region.chinaMainland")
+        }
+        /// `settings.misc.region.international` — International (ap-southeast-1)
+        public static var miscRegionInternational: String {
+            L10n.string("settings.misc.region.international")
+        }
+        /// `settings.misc.region.minimaxChina` — China mainland (minimaxi.com)
+        public static var miscRegionMinimaxChina: String {
+            L10n.string("settings.misc.region.minimaxChina")
+        }
+        /// `settings.misc.region.minimaxGlobal` — Global (minimax.io)
+        public static var miscRegionMinimaxGlobal: String {
+            L10n.string("settings.misc.region.minimaxGlobal")
+        }
+        /// `settings.misc.region.zaiChina` — China mainland (open.bigmodel.cn)
+        public static var miscRegionZaiChina: String {
+            L10n.string("settings.misc.region.zaiChina")
+        }
+        /// `settings.misc.region.zaiGlobal` — Global (api.z.ai)
+        public static var miscRegionZaiGlobal: String {
+            L10n.string("settings.misc.region.zaiGlobal")
+        }
         /// `settings.misc.removeAkSk` — Remove stored {provider} AK/SK
         public static func miscRemoveAkSk(provider: String) -> String {
             L10n.string("settings.misc.removeAkSk", provider)
@@ -1924,6 +2152,30 @@ extension L10n {
         /// `settings.planBadgeDetail` — Leave blank to use the detected account plan.
         public static var planBadgeDetail: String {
             L10n.string("settings.planBadgeDetail")
+        }
+        /// `settings.popoverDensity.compact` — Compact
+        public static var popoverDensityCompact: String {
+            L10n.string("settings.popoverDensity.compact")
+        }
+        /// `settings.popoverDensity.compactDetail` — Tightest spacing, narrowest popover.
+        public static var popoverDensityCompactDetail: String {
+            L10n.string("settings.popoverDensity.compactDetail")
+        }
+        /// `settings.popoverDensity.regular` — Regular
+        public static var popoverDensityRegular: String {
+            L10n.string("settings.popoverDensity.regular")
+        }
+        /// `settings.popoverDensity.regularDetail` — Balanced spacing — default.
+        public static var popoverDensityRegularDetail: String {
+            L10n.string("settings.popoverDensity.regularDetail")
+        }
+        /// `settings.popoverDensity.spacious` — Spacious
+        public static var popoverDensitySpacious: String {
+            L10n.string("settings.popoverDensity.spacious")
+        }
+        /// `settings.popoverDensity.spaciousDetail` — Roomy spacing for big displays.
+        public static var popoverDensitySpaciousDetail: String {
+            L10n.string("settings.popoverDensity.spaciousDetail")
         }
         /// `settings.pricing.addOverride` — Add model override
         public static var pricingAddOverride: String {
@@ -2193,6 +2445,86 @@ extension L10n {
         public static var rescanCostLogs: String {
             L10n.string("settings.rescanCostLogs")
         }
+        /// `settings.route.antigravityLocal` — Local Antigravity / agy
+        public static var routeAntigravityLocal: String {
+            L10n.string("settings.route.antigravityLocal")
+        }
+        /// `settings.route.browserCookies` — Chrome/Safari cookies
+        public static var routeBrowserCookies: String {
+            L10n.string("settings.route.browserCookies")
+        }
+        /// `settings.route.cli` — CLI
+        public static var routeCli: String {
+            L10n.string("settings.route.cli")
+        }
+        /// `settings.route.grokAuthFile` — ~/.grok/auth.json
+        public static var routeGrokAuthFile: String {
+            L10n.string("settings.route.grokAuthFile")
+        }
+        /// `settings.route.oauth` — OAuth
+        public static var routeOauth: String {
+            L10n.string("settings.route.oauth")
+        }
+        /// `settings.route.webViewCookies` — WebView cookies
+        public static var routeWebViewCookies: String {
+            L10n.string("settings.route.webViewCookies")
+        }
+        /// `settings.routeHealth.agyAvailable` — agy CLI available
+        public static var routeHealthAgyAvailable: String {
+            L10n.string("settings.routeHealth.agyAvailable")
+        }
+        /// `settings.routeHealth.authFileExpired` — auth.json expired
+        public static var routeHealthAuthFileExpired: String {
+            L10n.string("settings.routeHealth.authFileExpired")
+        }
+        /// `settings.routeHealth.authFileUnreadable` — Could not read auth.json
+        public static var routeHealthAuthFileUnreadable: String {
+            L10n.string("settings.routeHealth.authFileUnreadable")
+        }
+        /// `settings.routeHealth.cachedOnly` — Cached data only; live quota unavailable
+        public static var routeHealthCachedOnly: String {
+            L10n.string("settings.routeHealth.cachedOnly")
+        }
+        /// `settings.routeHealth.credentialUnreadable` — Could not read credential
+        public static var routeHealthCredentialUnreadable: String {
+            L10n.string("settings.routeHealth.credentialUnreadable")
+        }
+        /// `settings.routeHealth.credentialsAvailable` — Credentials available
+        public static var routeHealthCredentialsAvailable: String {
+            L10n.string("settings.routeHealth.credentialsAvailable")
+        }
+        /// `settings.routeHealth.invalidCookie` — Invalid cookie data
+        public static var routeHealthInvalidCookie: String {
+            L10n.string("settings.routeHealth.invalidCookie")
+        }
+        /// `settings.routeHealth.keychainLocked` — Keychain locked
+        public static var routeHealthKeychainLocked: String {
+            L10n.string("settings.routeHealth.keychainLocked")
+        }
+        /// `settings.routeHealth.lspRunning` — Local LSP running
+        public static var routeHealthLspRunning: String {
+            L10n.string("settings.routeHealth.lspRunning")
+        }
+        /// `settings.routeHealth.noAntigravityData` — No local Antigravity data
+        public static var routeHealthNoAntigravityData: String {
+            L10n.string("settings.routeHealth.noAntigravityData")
+        }
+        /// `settings.routeHealth.noAuthFile` — No auth.json
+        public static var routeHealthNoAuthFile: String {
+            L10n.string("settings.routeHealth.noAuthFile")
+        }
+        /// `settings.routeHealth.noCredential` — No credential found
+        public static var routeHealthNoCredential: String {
+            L10n.string("settings.routeHealth.noCredential")
+        }
+        /// `settings.routeHealth.noSavedCookie` — No saved cookie
+        public static var routeHealthNoSavedCookie: String {
+            L10n.string("settings.routeHealth.noSavedCookie")
+        }
+        /// `settings.routeHealth.savedInKeychain` — Saved in Keychain
+        public static var routeHealthSavedInKeychain: String {
+            L10n.string("settings.routeHealth.savedInKeychain")
+        }
         /// `settings.search` — Search settings
         public static var search: String {
             L10n.string("settings.search")
@@ -2208,6 +2540,10 @@ extension L10n {
         /// `settings.section.layout` — Layout
         public static var sectionLayout: String {
             L10n.string("settings.section.layout")
+        }
+        /// `settings.section.menuBar` — Menu Bar
+        public static var sectionMenuBar: String {
+            L10n.string("settings.section.menuBar")
         }
         /// `settings.section.menuBarHealth` — Menu Bar Health
         public static var sectionMenuBarHealth: String {
@@ -2228,6 +2564,10 @@ extension L10n {
         /// `settings.section.refreshing` — Refreshing
         public static var sectionRefreshing: String {
             L10n.string("settings.section.refreshing")
+        }
+        /// `settings.section.remoteProbes` — Remote Probes
+        public static var sectionRemoteProbes: String {
+            L10n.string("settings.section.remoteProbes")
         }
         /// `settings.section.system` — System
         public static var sectionSystem: String {
@@ -2269,13 +2609,165 @@ extension L10n {
         public static var spaceXAIIntro: String {
             L10n.string("settings.spaceXAIIntro")
         }
+        /// `settings.terminal.copyOnly` — Copy to clipboard
+        public static var terminalCopyOnly: String {
+            L10n.string("settings.terminal.copyOnly")
+        }
         /// `settings.updateChannel` — Update channel
         public static var updateChannel: String {
             L10n.string("settings.updateChannel")
         }
+        /// `settings.updateChannel.dev` — Dev
+        public static var updateChannelDev: String {
+            L10n.string("settings.updateChannel.dev")
+        }
+        /// `settings.updateChannel.devDetail` — Preview releases plus all Main releases.
+        public static var updateChannelDevDetail: String {
+            L10n.string("settings.updateChannel.devDetail")
+        }
+        /// `settings.updateChannel.main` — Main
+        public static var updateChannelMain: String {
+            L10n.string("settings.updateChannel.main")
+        }
+        /// `settings.updateChannel.mainDetail` — Stable releases only.
+        public static var updateChannelMainDetail: String {
+            L10n.string("settings.updateChannel.mainDetail")
+        }
         /// `settings.updateCheckDetail` — Checks the selected channel once a day and asks before installing.
         public static var updateCheckDetail: String {
             L10n.string("settings.updateCheckDetail")
+        }
+        /// `settings.usageMode.antigravity.autoDetail` — Use the Antigravity app first, then the installed agy CLI; fall back to imported cookies when the web source is available.
+        public static var usageModeAntigravityAutoDetail: String {
+            L10n.string("settings.usageMode.antigravity.autoDetail")
+        }
+        /// `settings.usageMode.antigravity.localFirstDetail` — Use the Antigravity app or agy CLI first; fall back to imported cookies.
+        public static var usageModeAntigravityLocalFirstDetail: String {
+            L10n.string("settings.usageMode.antigravity.localFirstDetail")
+        }
+        /// `settings.usageMode.antigravity.localOnly` — Local sources only
+        public static var usageModeAntigravityLocalOnly: String {
+            L10n.string("settings.usageMode.antigravity.localOnly")
+        }
+        /// `settings.usageMode.antigravity.localOnlyDetail` — Only use the Antigravity app or installed agy CLI.
+        public static var usageModeAntigravityLocalOnlyDetail: String {
+            L10n.string("settings.usageMode.antigravity.localOnlyDetail")
+        }
+        /// `settings.usageMode.antigravity.localThenWeb` — Local sources, then Web
+        public static var usageModeAntigravityLocalThenWeb: String {
+            L10n.string("settings.usageMode.antigravity.localThenWeb")
+        }
+        /// `settings.usageMode.antigravity.webFirstDetail` — Use imported cookies first; fall back to the Antigravity app or agy CLI.
+        public static var usageModeAntigravityWebFirstDetail: String {
+            L10n.string("settings.usageMode.antigravity.webFirstDetail")
+        }
+        /// `settings.usageMode.antigravity.webOnly` — Web only
+        public static var usageModeAntigravityWebOnly: String {
+            L10n.string("settings.usageMode.antigravity.webOnly")
+        }
+        /// `settings.usageMode.antigravity.webOnlyDetail` — Only use imported cookies. Falls back to the local probe until the Antigravity Cloud endpoint ships.
+        public static var usageModeAntigravityWebOnlyDetail: String {
+            L10n.string("settings.usageMode.antigravity.webOnlyDetail")
+        }
+        /// `settings.usageMode.antigravity.webThenLocal` — Web, then Local sources
+        public static var usageModeAntigravityWebThenLocal: String {
+            L10n.string("settings.usageMode.antigravity.webThenLocal")
+        }
+        /// `settings.usageMode.auto` — Auto
+        public static var usageModeAuto: String {
+            L10n.string("settings.usageMode.auto")
+        }
+        /// `settings.usageMode.claude.autoDetail` — Use saved claude.ai cookies first; fall back to Claude OAuth and Claude Code.
+        public static var usageModeClaudeAutoDetail: String {
+            L10n.string("settings.usageMode.claude.autoDetail")
+        }
+        /// `settings.usageMode.claude.codeFirstDetail` — Use Claude Code first; fall back to saved claude.ai cookies.
+        public static var usageModeClaudeCodeFirstDetail: String {
+            L10n.string("settings.usageMode.claude.codeFirstDetail")
+        }
+        /// `settings.usageMode.claude.codeOnly` — Claude Code only
+        public static var usageModeClaudeCodeOnly: String {
+            L10n.string("settings.usageMode.claude.codeOnly")
+        }
+        /// `settings.usageMode.claude.codeOnlyDetail` — Use only local Claude Code OAuth credentials.
+        public static var usageModeClaudeCodeOnlyDetail: String {
+            L10n.string("settings.usageMode.claude.codeOnlyDetail")
+        }
+        /// `settings.usageMode.claude.codeThenWeb` — Claude Code, then Web
+        public static var usageModeClaudeCodeThenWeb: String {
+            L10n.string("settings.usageMode.claude.codeThenWeb")
+        }
+        /// `settings.usageMode.claude.oauthCodeWeb` — OAuth, then Claude Code, then Web
+        public static var usageModeClaudeOauthCodeWeb: String {
+            L10n.string("settings.usageMode.claude.oauthCodeWeb")
+        }
+        /// `settings.usageMode.claude.oauthFirstDetail` — Use Claude OAuth first; fall back to Claude Code and saved claude.ai cookies.
+        public static var usageModeClaudeOauthFirstDetail: String {
+            L10n.string("settings.usageMode.claude.oauthFirstDetail")
+        }
+        /// `settings.usageMode.claude.oauthOnly` — OAuth only
+        public static var usageModeClaudeOauthOnly: String {
+            L10n.string("settings.usageMode.claude.oauthOnly")
+        }
+        /// `settings.usageMode.claude.oauthOnlyDetail` — Use only Claude OAuth credentials.
+        public static var usageModeClaudeOauthOnlyDetail: String {
+            L10n.string("settings.usageMode.claude.oauthOnlyDetail")
+        }
+        /// `settings.usageMode.claude.webFirstDetail` — Use saved claude.ai cookies first; fall back to Claude Code and OAuth.
+        public static var usageModeClaudeWebFirstDetail: String {
+            L10n.string("settings.usageMode.claude.webFirstDetail")
+        }
+        /// `settings.usageMode.claude.webOnly` — Claude Web only
+        public static var usageModeClaudeWebOnly: String {
+            L10n.string("settings.usageMode.claude.webOnly")
+        }
+        /// `settings.usageMode.claude.webOnlyDetail` — Use only saved claude.ai cookies.
+        public static var usageModeClaudeWebOnlyDetail: String {
+            L10n.string("settings.usageMode.claude.webOnlyDetail")
+        }
+        /// `settings.usageMode.claude.webThenCode` — Claude Web, then Claude Code
+        public static var usageModeClaudeWebThenCode: String {
+            L10n.string("settings.usageMode.claude.webThenCode")
+        }
+        /// `settings.usageMode.codex.autoDetail` — Use local Codex CLI credentials first; fall back to Codex OAuth and saved OpenAI web cookies.
+        public static var usageModeCodexAutoDetail: String {
+            L10n.string("settings.usageMode.codex.autoDetail")
+        }
+        /// `settings.usageMode.codex.cliOnly` — CLI only
+        public static var usageModeCodexCliOnly: String {
+            L10n.string("settings.usageMode.codex.cliOnly")
+        }
+        /// `settings.usageMode.codex.cliOnlyDetail` — Use only local Codex CLI credentials.
+        public static var usageModeCodexCliOnlyDetail: String {
+            L10n.string("settings.usageMode.codex.cliOnlyDetail")
+        }
+        /// `settings.usageMode.codex.cliThenOauth` — CLI, then OAuth
+        public static var usageModeCodexCliThenOauth: String {
+            L10n.string("settings.usageMode.codex.cliThenOauth")
+        }
+        /// `settings.usageMode.codex.oauthFirstDetail` — Use Codex OAuth first; fall back to local Codex CLI credentials and saved OpenAI web cookies.
+        public static var usageModeCodexOauthFirstDetail: String {
+            L10n.string("settings.usageMode.codex.oauthFirstDetail")
+        }
+        /// `settings.usageMode.codex.oauthOnly` — OAuth only
+        public static var usageModeCodexOauthOnly: String {
+            L10n.string("settings.usageMode.codex.oauthOnly")
+        }
+        /// `settings.usageMode.codex.oauthOnlyDetail` — Use only Codex OAuth credentials from auth.json.
+        public static var usageModeCodexOauthOnlyDetail: String {
+            L10n.string("settings.usageMode.codex.oauthOnlyDetail")
+        }
+        /// `settings.usageMode.codex.oauthThenCli` — OAuth, then CLI
+        public static var usageModeCodexOauthThenCli: String {
+            L10n.string("settings.usageMode.codex.oauthThenCli")
+        }
+        /// `settings.usageMode.gemini.webOnly` — Gemini Web only
+        public static var usageModeGeminiWebOnly: String {
+            L10n.string("settings.usageMode.gemini.webOnly")
+        }
+        /// `settings.usageMode.gemini.webOnlyDetail` — Only fetch imported gemini.google.com cookies.
+        public static var usageModeGeminiWebOnlyDetail: String {
+            L10n.string("settings.usageMode.gemini.webOnlyDetail")
         }
         /// `settings.usageSource` — Usage source
         public static var usageSource: String {
@@ -4586,6 +5078,29 @@ extension L10n {
         "platform.macos.launchAtLogin.subtitle",
         "platform.macos.launchAtLogin.title",
         "platform.macos.launchAtLogin.toggle",
+        "platform.macos.menuBar.color.actual",
+        "platform.macos.menuBar.color.actualDetail",
+        "platform.macos.menuBar.color.forecast",
+        "platform.macos.menuBar.color.forecastDetail",
+        "platform.macos.menuBar.displayDensity",
+        "platform.macos.menuBar.fieldStyle.label",
+        "platform.macos.menuBar.fieldStyle.labelDetail",
+        "platform.macos.menuBar.fieldStyle.logo",
+        "platform.macos.menuBar.fieldStyle.logoAndLabel",
+        "platform.macos.menuBar.fieldStyle.logoAndLabelDetail",
+        "platform.macos.menuBar.fieldStyle.logoDetail",
+        "platform.macos.menuBar.fields",
+        "platform.macos.menuBar.layout",
+        "platform.macos.menuBar.layout.compact",
+        "platform.macos.menuBar.layout.iconOnly",
+        "platform.macos.menuBar.layout.singleLine",
+        "platform.macos.menuBar.layout.twoRows",
+        "platform.macos.menuBar.mergeGroupWindows",
+        "platform.macos.menuBar.mergeGroupWindowsDetail",
+        "platform.macos.menuBar.overview",
+        "platform.macos.menuBar.percentColor",
+        "platform.macos.menuBar.showInMenuBar",
+        "platform.macos.menuBar.showTitleText",
         "popover.header.machinesSubtitle",
         "popover.header.miscSubtitle",
         "popover.header.overviewSubtitle",
@@ -4744,6 +5259,11 @@ extension L10n {
         "settings.couldNotDeleteCookies",
         "settings.couldNotDeleteGeminiCookies",
         "settings.couldNotDeleteGrokCookies",
+        "settings.credentialSource.apiOnly",
+        "settings.credentialSource.auto",
+        "settings.credentialSource.browserOnly",
+        "settings.credentialSource.manualOnly",
+        "settings.credentialSource.off",
         "settings.cursorNoSession",
         "settings.cursorSessionDetected",
         "settings.cursorSource",
@@ -4751,6 +5271,8 @@ extension L10n {
         "settings.deleteCookies",
         "settings.deleteGeminiCookies",
         "settings.deleteGrokCookies",
+        "settings.displayMode.remaining",
+        "settings.displayMode.used",
         "settings.externalChange.title",
         "settings.geminiCookiesSaved",
         "settings.geminiShared",
@@ -4793,10 +5315,30 @@ extension L10n {
         "settings.menuBarHealthUnavailable",
         "settings.miniWindow.add",
         "settings.miniWindow.allBucketsIncluded",
+        "settings.miniWindow.density.narrow",
+        "settings.miniWindow.density.narrowDetail",
+        "settings.miniWindow.density.roomy",
+        "settings.miniWindow.density.roomyDetail",
+        "settings.miniWindow.density.twoLines",
+        "settings.miniWindow.density.twoLinesDetail",
         "settings.miniWindow.dismissBuiltIn",
         "settings.miniWindow.forgetDiscovered",
         "settings.miniWindow.includeStyle",
         "settings.miniWindow.lastCannotBeRemoved",
+        "settings.miniWindow.mode.compact",
+        "settings.miniWindow.mode.compactDetail",
+        "settings.miniWindow.mode.focus",
+        "settings.miniWindow.mode.focusDetail",
+        "settings.miniWindow.mode.ledger",
+        "settings.miniWindow.mode.ledgerDetail",
+        "settings.miniWindow.mode.rail",
+        "settings.miniWindow.mode.railDetail",
+        "settings.miniWindow.mode.regular",
+        "settings.miniWindow.mode.regularDetail",
+        "settings.miniWindow.mode.strip",
+        "settings.miniWindow.mode.stripDetail",
+        "settings.miniWindow.mode.tiles",
+        "settings.miniWindow.mode.tilesDetail",
         "settings.miniWindow.namesAllWindows",
         "settings.miniWindow.namesThisStyle",
         "settings.miniWindow.namesThisWindow",
@@ -4837,6 +5379,13 @@ extension L10n {
         "settings.misc.prompt.workspace",
         "settings.misc.prompt.zai",
         "settings.misc.region",
+        "settings.misc.region.auto",
+        "settings.misc.region.chinaMainland",
+        "settings.misc.region.international",
+        "settings.misc.region.minimaxChina",
+        "settings.misc.region.minimaxGlobal",
+        "settings.misc.region.zaiChina",
+        "settings.misc.region.zaiGlobal",
         "settings.misc.removeAkSk",
         "settings.misc.removeApiKey",
         "settings.misc.removeCookieSlot",
@@ -4862,6 +5411,12 @@ extension L10n {
         "settings.percentShows",
         "settings.planBadge",
         "settings.planBadgeDetail",
+        "settings.popoverDensity.compact",
+        "settings.popoverDensity.compactDetail",
+        "settings.popoverDensity.regular",
+        "settings.popoverDensity.regularDetail",
+        "settings.popoverDensity.spacious",
+        "settings.popoverDensity.spaciousDetail",
         "settings.pricing.addOverride",
         "settings.pricing.advancedTiers",
         "settings.pricing.alwaysWins",
@@ -4929,15 +5484,37 @@ extension L10n {
         "settings.remote.workspace",
         "settings.repository",
         "settings.rescanCostLogs",
+        "settings.route.antigravityLocal",
+        "settings.route.browserCookies",
+        "settings.route.cli",
+        "settings.route.grokAuthFile",
+        "settings.route.oauth",
+        "settings.route.webViewCookies",
+        "settings.routeHealth.agyAvailable",
+        "settings.routeHealth.authFileExpired",
+        "settings.routeHealth.authFileUnreadable",
+        "settings.routeHealth.cachedOnly",
+        "settings.routeHealth.credentialUnreadable",
+        "settings.routeHealth.credentialsAvailable",
+        "settings.routeHealth.invalidCookie",
+        "settings.routeHealth.keychainLocked",
+        "settings.routeHealth.lspRunning",
+        "settings.routeHealth.noAntigravityData",
+        "settings.routeHealth.noAuthFile",
+        "settings.routeHealth.noCredential",
+        "settings.routeHealth.noSavedCookie",
+        "settings.routeHealth.savedInKeychain",
         "settings.search",
         "settings.section.components",
         "settings.section.costData",
         "settings.section.layout",
+        "settings.section.menuBar",
         "settings.section.menuBarHealth",
         "settings.section.miniWindows",
         "settings.section.overview",
         "settings.section.privacy",
         "settings.section.refreshing",
+        "settings.section.remoteProbes",
         "settings.section.system",
         "settings.section.updates",
         "settings.showAssistant",
@@ -4948,8 +5525,46 @@ extension L10n {
         "settings.sidebar.hideFromOverview",
         "settings.sidebar.settings",
         "settings.spaceXAIIntro",
+        "settings.terminal.copyOnly",
         "settings.updateChannel",
+        "settings.updateChannel.dev",
+        "settings.updateChannel.devDetail",
+        "settings.updateChannel.main",
+        "settings.updateChannel.mainDetail",
         "settings.updateCheckDetail",
+        "settings.usageMode.antigravity.autoDetail",
+        "settings.usageMode.antigravity.localFirstDetail",
+        "settings.usageMode.antigravity.localOnly",
+        "settings.usageMode.antigravity.localOnlyDetail",
+        "settings.usageMode.antigravity.localThenWeb",
+        "settings.usageMode.antigravity.webFirstDetail",
+        "settings.usageMode.antigravity.webOnly",
+        "settings.usageMode.antigravity.webOnlyDetail",
+        "settings.usageMode.antigravity.webThenLocal",
+        "settings.usageMode.auto",
+        "settings.usageMode.claude.autoDetail",
+        "settings.usageMode.claude.codeFirstDetail",
+        "settings.usageMode.claude.codeOnly",
+        "settings.usageMode.claude.codeOnlyDetail",
+        "settings.usageMode.claude.codeThenWeb",
+        "settings.usageMode.claude.oauthCodeWeb",
+        "settings.usageMode.claude.oauthFirstDetail",
+        "settings.usageMode.claude.oauthOnly",
+        "settings.usageMode.claude.oauthOnlyDetail",
+        "settings.usageMode.claude.webFirstDetail",
+        "settings.usageMode.claude.webOnly",
+        "settings.usageMode.claude.webOnlyDetail",
+        "settings.usageMode.claude.webThenCode",
+        "settings.usageMode.codex.autoDetail",
+        "settings.usageMode.codex.cliOnly",
+        "settings.usageMode.codex.cliOnlyDetail",
+        "settings.usageMode.codex.cliThenOauth",
+        "settings.usageMode.codex.oauthFirstDetail",
+        "settings.usageMode.codex.oauthOnly",
+        "settings.usageMode.codex.oauthOnlyDetail",
+        "settings.usageMode.codex.oauthThenCli",
+        "settings.usageMode.gemini.webOnly",
+        "settings.usageMode.gemini.webOnlyDetail",
         "settings.usageSource",
         "settings.webQuota",
         "settings.whatChangedIn",

--- a/Sources/VibeBarCore/Localization/L10n+Generated.swift
+++ b/Sources/VibeBarCore/Localization/L10n+Generated.swift
@@ -919,6 +919,46 @@ extension L10n {
         public static var headerOverviewSubtitle: String {
             L10n.string("popover.header.overviewSubtitle")
         }
+        /// `popover.machines.checking` — Checking the Relay…
+        public static var machinesChecking: String {
+            L10n.string("popover.machines.checking")
+        }
+        /// `popover.machines.includeInTotals` — Include in totals
+        public static var machinesIncludeInTotals: String {
+            L10n.string("popover.machines.includeInTotals")
+        }
+        /// `popover.machines.includeInTotalsHelp` — Add this machine's decrypted usage to Overview and provider cost pages on this Core
+        public static var machinesIncludeInTotalsHelp: String {
+            L10n.string("popover.machines.includeInTotalsHelp")
+        }
+        /// `popover.machines.labelWithStatus` — {label} · {status}
+        public static func machinesLabelWithStatus(label: String, status: String) -> String {
+            L10n.string("popover.machines.labelWithStatus", label, status)
+        }
+        /// `popover.machines.noData` — No remote machine data yet
+        public static var machinesNoData: String {
+            L10n.string("popover.machines.noData")
+        }
+        /// `popover.machines.noDataDetail` — The Relay is connected. A Probe will appear after its first encrypted batch is decrypted and imported.
+        public static var machinesNoDataDetail: String {
+            L10n.string("popover.machines.noDataDetail")
+        }
+        /// `popover.machines.notConfigured` — Remote Core is not configured
+        public static var machinesNotConfigured: String {
+            L10n.string("popover.machines.notConfigured")
+        }
+        /// `popover.machines.notConfiguredDetail` — Create a Core descriptor, provision a workspace-scoped Relay credential, then import the signed provisioning file. No inbound port is required on this Mac.
+        public static var machinesNotConfiguredDetail: String {
+            L10n.string("popover.machines.notConfiguredDetail")
+        }
+        /// `popover.machines.sequence` — seq {value}
+        public static func machinesSequence(value: String) -> String {
+            L10n.string("popover.machines.sequence", value)
+        }
+        /// `popover.machines.thirtyDayCost` — 30-day cost
+        public static var machinesThirtyDayCost: String {
+            L10n.string("popover.machines.thirtyDayCost")
+        }
         /// `popover.refreshGoogleAI` — Refresh Gemini Web + AntiGravity
         public static var refreshGoogleAI: String {
             L10n.string("popover.refreshGoogleAI")
@@ -2428,6 +2468,78 @@ extension L10n {
         /// `settings.remote.statusWithCode` — {title} · {code}
         public static func remoteStatusWithCode(title: String, code: String) -> String {
             L10n.string("settings.remote.statusWithCode", title, code)
+        }
+        /// `settings.remote.sync.busy` — Relay is temporarily busy
+        public static var remoteSyncBusy: String {
+            L10n.string("settings.remote.sync.busy")
+        }
+        /// `settings.remote.sync.connectionFailed` — Relay connection was interrupted
+        public static var remoteSyncConnectionFailed: String {
+            L10n.string("settings.remote.sync.connectionFailed")
+        }
+        /// `settings.remote.sync.hostLookupFailed` — Relay host could not be resolved
+        public static var remoteSyncHostLookupFailed: String {
+            L10n.string("settings.remote.sync.hostLookupFailed")
+        }
+        /// `settings.remote.sync.invalidResponse` — Relay returned an unexpected response
+        public static var remoteSyncInvalidResponse: String {
+            L10n.string("settings.remote.sync.invalidResponse")
+        }
+        /// `settings.remote.sync.networkDetail` — Check this Mac's network or proxy path; existing machine data is still available.
+        public static var remoteSyncNetworkDetail: String {
+            L10n.string("settings.remote.sync.networkDetail")
+        }
+        /// `settings.remote.sync.offline` — This Mac is offline
+        public static var remoteSyncOffline: String {
+            L10n.string("settings.remote.sync.offline")
+        }
+        /// `settings.remote.sync.rejected` — Relay access was rejected
+        public static var remoteSyncRejected: String {
+            L10n.string("settings.remote.sync.rejected")
+        }
+        /// `settings.remote.sync.rejectedDetail` — The workspace credential may have been revoked. Reconnect this Core in Settings.
+        public static var remoteSyncRejectedDetail: String {
+            L10n.string("settings.remote.sync.rejectedDetail")
+        }
+        /// `settings.remote.sync.retryDetail` — Existing machine data is still available. Vibe Bar will retry automatically.
+        public static var remoteSyncRetryDetail: String {
+            L10n.string("settings.remote.sync.retryDetail")
+        }
+        /// `settings.remote.sync.secureConnectionFailed` — Secure Relay connection failed
+        public static var remoteSyncSecureConnectionFailed: String {
+            L10n.string("settings.remote.sync.secureConnectionFailed")
+        }
+        /// `settings.remote.sync.sequenceGap` — Probe history has a sequence gap
+        public static var remoteSyncSequenceGap: String {
+            L10n.string("settings.remote.sync.sequenceGap")
+        }
+        /// `settings.remote.sync.sequenceGapDetail` — A Probe batch is missing from the Relay stream, so later batches were not imported.
+        public static var remoteSyncSequenceGapDetail: String {
+            L10n.string("settings.remote.sync.sequenceGapDetail")
+        }
+        /// `settings.remote.sync.timeout` — Relay connection timed out
+        public static var remoteSyncTimeout: String {
+            L10n.string("settings.remote.sync.timeout")
+        }
+        /// `settings.remote.sync.transportFailed` — Relay transport failed
+        public static var remoteSyncTransportFailed: String {
+            L10n.string("settings.remote.sync.transportFailed")
+        }
+        /// `settings.remote.sync.unknown` — Remote sync needs attention
+        public static var remoteSyncUnknown: String {
+            L10n.string("settings.remote.sync.unknown")
+        }
+        /// `settings.remote.sync.unknownDetail` — No local usage was deleted. Retry now or inspect Remote Core settings for the error code.
+        public static var remoteSyncUnknownDetail: String {
+            L10n.string("settings.remote.sync.unknownDetail")
+        }
+        /// `settings.remote.sync.unverifiedProbe` — A Probe could not be verified
+        public static var remoteSyncUnverifiedProbe: String {
+            L10n.string("settings.remote.sync.unverifiedProbe")
+        }
+        /// `settings.remote.sync.unverifiedProbeDetail` — The current workspace roster does not authorize one of the received batches.
+        public static var remoteSyncUnverifiedProbeDetail: String {
+            L10n.string("settings.remote.sync.unverifiedProbeDetail")
         }
         /// `settings.remote.syncNow` — Sync now
         public static var remoteSyncNow: String {
@@ -5104,6 +5216,16 @@ extension L10n {
         "popover.header.machinesSubtitle",
         "popover.header.miscSubtitle",
         "popover.header.overviewSubtitle",
+        "popover.machines.checking",
+        "popover.machines.includeInTotals",
+        "popover.machines.includeInTotalsHelp",
+        "popover.machines.labelWithStatus",
+        "popover.machines.noData",
+        "popover.machines.noDataDetail",
+        "popover.machines.notConfigured",
+        "popover.machines.notConfiguredDetail",
+        "popover.machines.sequence",
+        "popover.machines.thirtyDayCost",
         "popover.refreshGoogleAI",
         "popover.refreshSpaceXAI",
         "popover.showPage",
@@ -5480,6 +5602,24 @@ extension L10n {
         "settings.remote.resumeSaving",
         "settings.remote.retrySaving",
         "settings.remote.statusWithCode",
+        "settings.remote.sync.busy",
+        "settings.remote.sync.connectionFailed",
+        "settings.remote.sync.hostLookupFailed",
+        "settings.remote.sync.invalidResponse",
+        "settings.remote.sync.networkDetail",
+        "settings.remote.sync.offline",
+        "settings.remote.sync.rejected",
+        "settings.remote.sync.rejectedDetail",
+        "settings.remote.sync.retryDetail",
+        "settings.remote.sync.secureConnectionFailed",
+        "settings.remote.sync.sequenceGap",
+        "settings.remote.sync.sequenceGapDetail",
+        "settings.remote.sync.timeout",
+        "settings.remote.sync.transportFailed",
+        "settings.remote.sync.unknown",
+        "settings.remote.sync.unknownDetail",
+        "settings.remote.sync.unverifiedProbe",
+        "settings.remote.sync.unverifiedProbeDetail",
         "settings.remote.syncNow",
         "settings.remote.workspace",
         "settings.repository",

--- a/Sources/VibeBarCore/Models/AppSettings.swift
+++ b/Sources/VibeBarCore/Models/AppSettings.swift
@@ -1290,17 +1290,17 @@ public enum MiniStripDensity: String, Codable, CaseIterable, Identifiable, Senda
 
     public var label: String {
         switch self {
-        case .roomy:   return "Roomy"
-        case .twoLine: return "Two Lines"
-        case .narrow:  return "Narrow"
+        case .roomy:   return L10n.Settings.miniWindowDensityRoomy
+        case .twoLine: return L10n.Settings.miniWindowDensityTwoLines
+        case .narrow:  return L10n.Settings.miniWindowDensityNarrow
         }
     }
 
     public var detail: String {
         switch self {
-        case .roomy:   return "The menu bar's single-line style: every bucket, full label beside its number."
-        case .twoLine: return "Menu-bar style: buckets pair into stacked columns, label beside each number."
-        case .narrow:  return "The menu bar's compact style: the same cells at the small size."
+        case .roomy:   return L10n.Settings.miniWindowDensityRoomyDetail
+        case .twoLine: return L10n.Settings.miniWindowDensityTwoLinesDetail
+        case .narrow:  return L10n.Settings.miniWindowDensityNarrowDetail
         }
     }
 }
@@ -1518,25 +1518,25 @@ public enum MiniWindowDisplayMode: String, Codable, CaseIterable, Identifiable, 
 
     public var label: String {
         switch self {
-        case .regular: return "Regular"
-        case .compact: return "Compact"
-        case .ledger:  return "Ledger"
-        case .strip:   return "Strip"
-        case .tile:    return "Tiles"
-        case .focus:   return "Focus"
-        case .rail:    return "Rail"
+        case .regular: return L10n.Settings.miniWindowModeRegular
+        case .compact: return L10n.Settings.miniWindowModeCompact
+        case .ledger:  return L10n.Settings.miniWindowModeLedger
+        case .strip:   return L10n.Settings.miniWindowModeStrip
+        case .tile:    return L10n.Settings.miniWindowModeTiles
+        case .focus:   return L10n.Settings.miniWindowModeFocus
+        case .rail:    return L10n.Settings.miniWindowModeRail
         }
     }
 
     public var detail: String {
         switch self {
-        case .regular: return "Ring gauges grouped company → SubProvider → quota group."
-        case .compact: return "The same three tiers as vertical bars, sized for a corner."
-        case .ledger:  return "One row per quota bucket — fixed width, grows downward."
-        case .strip:   return "A slim line mirroring the menu bar's styles — one cell per bucket."
-        case .tile:    return "A grid of tiles with a big number and a severity stripe."
-        case .focus:   return "One selected bucket at a time, large — click to cycle in your order."
-        case .rail:    return "The next seven days as a refill lane with the coming resets listed."
+        case .regular: return L10n.Settings.miniWindowModeRegularDetail
+        case .compact: return L10n.Settings.miniWindowModeCompactDetail
+        case .ledger:  return L10n.Settings.miniWindowModeLedgerDetail
+        case .strip:   return L10n.Settings.miniWindowModeStripDetail
+        case .tile:    return L10n.Settings.miniWindowModeTilesDetail
+        case .focus:   return L10n.Settings.miniWindowModeFocusDetail
+        case .rail:    return L10n.Settings.miniWindowModeRailDetail
         }
     }
 
@@ -1557,17 +1557,17 @@ public enum PopoverDensity: String, Codable, CaseIterable, Identifiable, Sendabl
 
     public var label: String {
         switch self {
-        case .compact:  return "Compact"
-        case .regular:  return "Regular"
-        case .spacious: return "Spacious"
+        case .compact:  return L10n.Settings.popoverDensityCompact
+        case .regular:  return L10n.Settings.popoverDensityRegular
+        case .spacious: return L10n.Settings.popoverDensitySpacious
         }
     }
 
     public var detail: String {
         switch self {
-        case .compact:  return "Tightest spacing, narrowest popover."
-        case .regular:  return "Balanced spacing — default."
-        case .spacious: return "Roomy spacing for big displays."
+        case .compact:  return L10n.Settings.popoverDensityCompactDetail
+        case .regular:  return L10n.Settings.popoverDensityRegularDetail
+        case .spacious: return L10n.Settings.popoverDensitySpaciousDetail
         }
     }
 }
@@ -1585,25 +1585,25 @@ public enum ClaudeUsageMode: String, Codable, CaseIterable, Identifiable, Sendab
 
     public var label: String {
         switch self {
-        case .auto: return "Auto"
-        case .oauthThenCliThenWeb: return "OAuth, then Claude Code, then Web"
-        case .cliThenWeb: return "Claude Code, then Web"
-        case .webThenCli: return "Claude Web, then Claude Code"
-        case .oauthOnly: return "OAuth only"
-        case .cliOnly: return "Claude Code only"
-        case .webOnly: return "Claude Web only"
+        case .auto: return L10n.Settings.usageModeAuto
+        case .oauthThenCliThenWeb: return L10n.Settings.usageModeClaudeOauthCodeWeb
+        case .cliThenWeb: return L10n.Settings.usageModeClaudeCodeThenWeb
+        case .webThenCli: return L10n.Settings.usageModeClaudeWebThenCode
+        case .oauthOnly: return L10n.Settings.usageModeClaudeOauthOnly
+        case .cliOnly: return L10n.Settings.usageModeClaudeCodeOnly
+        case .webOnly: return L10n.Settings.usageModeClaudeWebOnly
         }
     }
 
     public var detail: String {
         switch self {
-        case .auto: return "Use saved claude.ai cookies first; fall back to Claude OAuth and Claude Code."
-        case .oauthThenCliThenWeb: return "Use Claude OAuth first; fall back to Claude Code and saved claude.ai cookies."
-        case .cliThenWeb: return "Use Claude Code first; fall back to saved claude.ai cookies."
-        case .webThenCli: return "Use saved claude.ai cookies first; fall back to Claude Code and OAuth."
-        case .oauthOnly: return "Use only Claude OAuth credentials."
-        case .cliOnly: return "Use only local Claude Code OAuth credentials."
-        case .webOnly: return "Use only saved claude.ai cookies."
+        case .auto: return L10n.Settings.usageModeClaudeAutoDetail
+        case .oauthThenCliThenWeb: return L10n.Settings.usageModeClaudeOauthFirstDetail
+        case .cliThenWeb: return L10n.Settings.usageModeClaudeCodeFirstDetail
+        case .webThenCli: return L10n.Settings.usageModeClaudeWebFirstDetail
+        case .oauthOnly: return L10n.Settings.usageModeClaudeOauthOnlyDetail
+        case .cliOnly: return L10n.Settings.usageModeClaudeCodeOnlyDetail
+        case .webOnly: return L10n.Settings.usageModeClaudeWebOnlyDetail
         }
     }
 }
@@ -1619,13 +1619,13 @@ public enum GeminiUsageMode: String, Codable, CaseIterable, Identifiable, Sendab
 
     public var label: String {
         switch self {
-        case .webOnly: return "Gemini Web only"
+        case .webOnly: return L10n.Settings.usageModeGeminiWebOnly
         }
     }
 
     public var detail: String {
         switch self {
-        case .webOnly: return "Only fetch imported gemini.google.com cookies."
+        case .webOnly: return L10n.Settings.usageModeGeminiWebOnlyDetail
         }
     }
 }
@@ -1641,21 +1641,21 @@ public enum AntigravityUsageMode: String, Codable, CaseIterable, Identifiable, S
 
     public var label: String {
         switch self {
-        case .auto: return "Auto"
-        case .localThenWeb: return "Local sources, then Web"
-        case .webThenLocal: return "Web, then Local sources"
-        case .localOnly: return "Local sources only"
-        case .webOnly: return "Web only"
+        case .auto: return L10n.Settings.usageModeAuto
+        case .localThenWeb: return L10n.Settings.usageModeAntigravityLocalThenWeb
+        case .webThenLocal: return L10n.Settings.usageModeAntigravityWebThenLocal
+        case .localOnly: return L10n.Settings.usageModeAntigravityLocalOnly
+        case .webOnly: return L10n.Settings.usageModeAntigravityWebOnly
         }
     }
 
     public var detail: String {
         switch self {
-        case .auto: return "Use the Antigravity app first, then the installed agy CLI; fall back to imported cookies when the web source is available."
-        case .localThenWeb: return "Use the Antigravity app or agy CLI first; fall back to imported cookies."
-        case .webThenLocal: return "Use imported cookies first; fall back to the Antigravity app or agy CLI."
-        case .localOnly: return "Only use the Antigravity app or installed agy CLI."
-        case .webOnly: return "Only use imported cookies. Falls back to the local probe until the Antigravity Cloud endpoint ships."
+        case .auto: return L10n.Settings.usageModeAntigravityAutoDetail
+        case .localThenWeb: return L10n.Settings.usageModeAntigravityLocalFirstDetail
+        case .webThenLocal: return L10n.Settings.usageModeAntigravityWebFirstDetail
+        case .localOnly: return L10n.Settings.usageModeAntigravityLocalOnlyDetail
+        case .webOnly: return L10n.Settings.usageModeAntigravityWebOnlyDetail
         }
     }
 }

--- a/Sources/VibeBarCore/Models/DisplayMode.swift
+++ b/Sources/VibeBarCore/Models/DisplayMode.swift
@@ -6,8 +6,8 @@ public enum DisplayMode: String, Codable, CaseIterable, Sendable {
 
     public var label: String {
         switch self {
-        case .remaining: return "Remaining"
-        case .used: return "Used"
+        case .remaining: return L10n.Settings.displayModeRemaining
+        case .used: return L10n.Settings.displayModeUsed
         }
     }
 }

--- a/Sources/VibeBarCore/Models/MenuBarSettings.swift
+++ b/Sources/VibeBarCore/Models/MenuBarSettings.swift
@@ -6,7 +6,7 @@ public enum MenuBarItemKind: String, Codable, CaseIterable, Identifiable, Sendab
     public var id: String { rawValue }
 
     public var label: String {
-        "Overview"
+        L10n.Platform.macosMenuBarOverview
     }
 
     public var title: String {
@@ -24,10 +24,10 @@ public enum MenuBarLayout: String, Codable, CaseIterable, Identifiable, Sendable
 
     public var label: String {
         switch self {
-        case .iconOnly: return "Icon Only"
-        case .singleLine: return "Single line"
-        case .twoRows: return "Two rows"
-        case .compact: return "Compact"
+        case .iconOnly: return L10n.Platform.macosMenuBarLayoutIconOnly
+        case .singleLine: return L10n.Platform.macosMenuBarLayoutSingleLine
+        case .twoRows: return L10n.Platform.macosMenuBarLayoutTwoRows
+        case .compact: return L10n.Platform.macosMenuBarLayoutCompact
         }
     }
 
@@ -51,8 +51,8 @@ public enum MenuBarColorBasis: String, Codable, CaseIterable, Identifiable, Send
 
     public var label: String {
         switch self {
-        case .forecast: return "Forecast"
-        case .actual: return "Actual"
+        case .forecast: return L10n.Platform.macosMenuBarColorForecast
+        case .actual: return L10n.Platform.macosMenuBarColorActual
         }
     }
 
@@ -61,11 +61,9 @@ public enum MenuBarColorBasis: String, Codable, CaseIterable, Identifiable, Send
     public var detail: String {
         switch self {
         case .forecast:
-            return "Green projected to last · blue a chunk will likely go unused · "
-                + "orange may run short · red projected to run out. "
-                + "Falls back to the percentage while a quota has too little history to forecast."
+            return L10n.Platform.macosMenuBarColorForecastDetail
         case .actual:
-            return "Colored by the displayed percentage alone, ignoring the forecast."
+            return L10n.Platform.macosMenuBarColorActualDetail
         }
     }
 }
@@ -137,17 +135,17 @@ public enum MenuBarFieldStyle: String, Codable, CaseIterable, Identifiable, Send
 
     public var label: String {
         switch self {
-        case .labelAndPercent: return "Label"
-        case .logoAndPercent: return "Logo"
-        case .logoLabelAndPercent: return "Logo and label"
+        case .labelAndPercent: return L10n.Platform.macosMenuBarFieldStyleLabel
+        case .logoAndPercent: return L10n.Platform.macosMenuBarFieldStyleLogo
+        case .logoLabelAndPercent: return L10n.Platform.macosMenuBarFieldStyleLogoAndLabel
         }
     }
 
     public var detail: String {
         switch self {
-        case .labelAndPercent: return "The field's name beside its percent."
-        case .logoAndPercent: return "The provider's logo beside the percent — no text."
-        case .logoLabelAndPercent: return "Logo, name, and percent."
+        case .labelAndPercent: return L10n.Platform.macosMenuBarFieldStyleLabelDetail
+        case .logoAndPercent: return L10n.Platform.macosMenuBarFieldStyleLogoDetail
+        case .logoLabelAndPercent: return L10n.Platform.macosMenuBarFieldStyleLogoAndLabelDetail
         }
     }
 }
@@ -274,6 +272,36 @@ public struct MenuBarFieldOption: Identifiable, Hashable, Sendable {
 ///
 /// The owning tool is part of the identity because one adapter can serve two
 /// SubProviders — Grok Bot rides Cursor's (see `ToolType.quotaSubProviderName`).
+/// The label as it is *shown*, rather than as the naming contract spells it.
+///
+/// `title` is a quota-axis value — `docs/contracts/quota-naming-v1.json` —
+/// and stays English wherever it is stored or compared. Only the rendered
+/// form goes through `QuotaGroupLabelLocalizer`, and a label has several
+/// readers: the field picker, the rename dialog's placeholder, the menu-bar
+/// composer. Each one that reads `title` raw is a Chinese screen with an
+/// English quota name on it, which is how the first two were found.
+///
+/// A composed title ("All Models · Weekly") is resolved part by part, so
+/// "GPT-5.3 Codex Spark · 5 Hours" keeps its product name and translates
+/// only the window.
+///
+/// Spelled to match the definition on the menu-bar composer branch, which
+/// adds the same two properties: whichever lands second resolves a trivial
+/// conflict instead of the app growing two names for one seam.
+extension MenuBarFieldOption {
+    public var displayTitle: String {
+        title
+            .components(separatedBy: " · ")
+            .map(QuotaGroupLabelLocalizer.display)
+            .joined(separator: " · ")
+    }
+
+    /// The short name, resolved the same way.
+    public var displayDefaultLabel: String {
+        QuotaGroupLabelLocalizer.display(defaultLabel)
+    }
+}
+
 public struct MenuBarSubProviderGroup: Equatable, Sendable, Identifiable {
     public let tool: ToolType
     public let name: String

--- a/Sources/VibeBarCore/Models/MiscProviderSettings.swift
+++ b/Sources/VibeBarCore/Models/MiscProviderSettings.swift
@@ -22,11 +22,11 @@ public struct MiscProviderSettings: Codable, Equatable, Sendable {
 
         public var label: String {
             switch self {
-            case .auto:        return "Auto"
-            case .browserOnly: return "Browser only"
-            case .manualOnly:  return "Manual only"
-            case .apiOnly:     return "API / OAuth only"
-            case .off:         return "Off"
+            case .auto:        return L10n.Settings.credentialSourceAuto
+            case .browserOnly: return L10n.Settings.credentialSourceBrowserOnly
+            case .manualOnly:  return L10n.Settings.credentialSourceManualOnly
+            case .apiOnly:     return L10n.Settings.credentialSourceApiOnly
+            case .off:         return L10n.Settings.credentialSourceOff
             }
         }
     }

--- a/Sources/VibeBarCore/Models/PreferredTerminal.swift
+++ b/Sources/VibeBarCore/Models/PreferredTerminal.swift
@@ -15,7 +15,7 @@ public enum PreferredTerminal: String, Codable, CaseIterable, Sendable {
         switch self {
         case .terminal: return "Terminal"
         case .iterm2:   return "iTerm2"
-        case .copyOnly: return "Copy to clipboard"
+        case .copyOnly: return L10n.Settings.terminalCopyOnly
         }
     }
 }

--- a/Sources/VibeBarCore/Models/PrimaryProviderRouteHealth.swift
+++ b/Sources/VibeBarCore/Models/PrimaryProviderRouteHealth.swift
@@ -33,18 +33,18 @@ public enum PrimaryProviderRoute: String, CaseIterable, Identifiable, Sendable {
 
     public var label: String {
         switch self {
-        case .openAICLI: return "CLI"
-        case .openAIOAuth: return "OAuth"
-        case .openAIBrowserCookies: return "Chrome/Safari cookies"
-        case .openAIWebViewCookies: return "WebView cookies"
-        case .claudeBrowserCookies: return "Chrome/Safari cookies"
-        case .claudeWebViewCookies: return "WebView cookies"
-        case .claudeOAuth: return "OAuth"
-        case .claudeCLI: return "CLI"
-        case .geminiBrowserCookies: return "Chrome/Safari cookies"
-        case .antigravityLocalProbe: return "Local Antigravity / agy"
-        case .grokAuthJSON: return "~/.grok/auth.json"
-        case .grokBrowserCookies: return "Chrome/Safari cookies"
+        case .openAICLI: return L10n.Settings.routeCli
+        case .openAIOAuth: return L10n.Settings.routeOauth
+        case .openAIBrowserCookies: return L10n.Settings.routeBrowserCookies
+        case .openAIWebViewCookies: return L10n.Settings.routeWebViewCookies
+        case .claudeBrowserCookies: return L10n.Settings.routeBrowserCookies
+        case .claudeWebViewCookies: return L10n.Settings.routeWebViewCookies
+        case .claudeOAuth: return L10n.Settings.routeOauth
+        case .claudeCLI: return L10n.Settings.routeCli
+        case .geminiBrowserCookies: return L10n.Settings.routeBrowserCookies
+        case .antigravityLocalProbe: return L10n.Settings.routeAntigravityLocal
+        case .grokAuthJSON: return L10n.Settings.routeGrokAuthFile
+        case .grokBrowserCookies: return L10n.Settings.routeBrowserCookies
         }
     }
 
@@ -205,7 +205,7 @@ public enum PrimaryProviderRouteHealthChecker {
             return PrimaryProviderRouteHealth(
                 route: route,
                 status: .ok,
-                detail: "Local LSP running",
+                detail: L10n.Settings.routeHealthLspRunning,
                 checkedAt: now
             )
         }
@@ -213,7 +213,7 @@ public enum PrimaryProviderRouteHealthChecker {
             return PrimaryProviderRouteHealth(
                 route: route,
                 status: .ok,
-                detail: "agy CLI available",
+                detail: L10n.Settings.routeHealthAgyAvailable,
                 checkedAt: now
             )
         }
@@ -221,14 +221,14 @@ public enum PrimaryProviderRouteHealthChecker {
             return PrimaryProviderRouteHealth(
                 route: route,
                 status: .failed,
-                detail: "Cached data only; live quota unavailable",
+                detail: L10n.Settings.routeHealthCachedOnly,
                 checkedAt: now
             )
         }
         return PrimaryProviderRouteHealth(
             route: route,
             status: .missing,
-            detail: "No local Antigravity data",
+            detail: L10n.Settings.routeHealthNoAntigravityData,
             checkedAt: now
         )
     }
@@ -243,28 +243,28 @@ public enum PrimaryProviderRouteHealthChecker {
                 return PrimaryProviderRouteHealth(
                     route: route,
                     status: .failed,
-                    detail: "auth.json expired",
+                    detail: L10n.Settings.routeHealthAuthFileExpired,
                     checkedAt: now
                 )
             }
             return PrimaryProviderRouteHealth(
                 route: route,
                 status: .ok,
-                detail: credentials.planLabel ?? "Credentials available",
+                detail: credentials.planLabel ?? L10n.Settings.routeHealthCredentialsAvailable,
                 checkedAt: now
             )
         } catch let error as QuotaError where error == .noCredential || error == .needsLogin {
             return PrimaryProviderRouteHealth(
                 route: route,
                 status: .missing,
-                detail: "No auth.json",
+                detail: L10n.Settings.routeHealthNoAuthFile,
                 checkedAt: now
             )
         } catch {
             return PrimaryProviderRouteHealth(
                 route: route,
                 status: .failed,
-                detail: "Could not read auth.json",
+                detail: L10n.Settings.routeHealthAuthFileUnreadable,
                 checkedAt: now
             )
         }
@@ -351,28 +351,28 @@ public enum PrimaryProviderRouteHealthChecker {
             return PrimaryProviderRouteHealth(
                 route: route,
                 status: .ok,
-                detail: "Credentials available",
+                detail: L10n.Settings.routeHealthCredentialsAvailable,
                 checkedAt: now
             )
         } catch KeychainStore.KeychainError.interactionNotAllowed {
             return PrimaryProviderRouteHealth(
                 route: route,
                 status: .blocked,
-                detail: "Keychain locked",
+                detail: L10n.Settings.routeHealthKeychainLocked,
                 checkedAt: now
             )
         } catch let error as QuotaError where error == .noCredential || error == .needsLogin {
             return PrimaryProviderRouteHealth(
                 route: route,
                 status: .missing,
-                detail: "No credential found",
+                detail: L10n.Settings.routeHealthNoCredential,
                 checkedAt: now
             )
         } catch {
             return PrimaryProviderRouteHealth(
                 route: route,
                 status: .failed,
-                detail: "Could not read credential",
+                detail: L10n.Settings.routeHealthCredentialUnreadable,
                 checkedAt: now
             )
         }
@@ -388,28 +388,28 @@ public enum PrimaryProviderRouteHealthChecker {
             return PrimaryProviderRouteHealth(
                 route: route,
                 status: .ok,
-                detail: "Saved in Keychain",
+                detail: L10n.Settings.routeHealthSavedInKeychain,
                 checkedAt: now
             )
         case .missing:
             return PrimaryProviderRouteHealth(
                 route: route,
                 status: .missing,
-                detail: "No saved cookie",
+                detail: L10n.Settings.routeHealthNoSavedCookie,
                 checkedAt: now
             )
         case .temporarilyUnavailable:
             return PrimaryProviderRouteHealth(
                 route: route,
                 status: .blocked,
-                detail: "Keychain locked",
+                detail: L10n.Settings.routeHealthKeychainLocked,
                 checkedAt: now
             )
         case .invalid:
             return PrimaryProviderRouteHealth(
                 route: route,
                 status: .failed,
-                detail: "Invalid cookie data",
+                detail: L10n.Settings.routeHealthInvalidCookie,
                 checkedAt: now
             )
         }

--- a/Sources/VibeBarCore/Models/PrimaryProviderSourcePlanner.swift
+++ b/Sources/VibeBarCore/Models/PrimaryProviderSourcePlanner.swift
@@ -11,26 +11,26 @@ public enum CodexUsageMode: String, Codable, CaseIterable, Identifiable, Sendabl
 
     public var label: String {
         switch self {
-        case .auto: return "Auto"
-        case .oauthThenCLI: return "OAuth, then CLI"
-        case .cliThenOAuth: return "CLI, then OAuth"
-        case .oauthOnly: return "OAuth only"
-        case .cliOnly: return "CLI only"
+        case .auto: return L10n.Settings.usageModeAuto
+        case .oauthThenCLI: return L10n.Settings.usageModeCodexOauthThenCli
+        case .cliThenOAuth: return L10n.Settings.usageModeCodexCliThenOauth
+        case .oauthOnly: return L10n.Settings.usageModeCodexOauthOnly
+        case .cliOnly: return L10n.Settings.usageModeCodexCliOnly
         }
     }
 
     public var detail: String {
         switch self {
         case .auto:
-            return "Use local Codex CLI credentials first; fall back to Codex OAuth and saved OpenAI web cookies."
+            return L10n.Settings.usageModeCodexAutoDetail
         case .oauthThenCLI:
-            return "Use Codex OAuth first; fall back to local Codex CLI credentials and saved OpenAI web cookies."
+            return L10n.Settings.usageModeCodexOauthFirstDetail
         case .cliThenOAuth:
-            return "Use local Codex CLI credentials first; fall back to Codex OAuth and saved OpenAI web cookies."
+            return L10n.Settings.usageModeCodexAutoDetail
         case .oauthOnly:
-            return "Use only Codex OAuth credentials from auth.json."
+            return L10n.Settings.usageModeCodexOauthOnlyDetail
         case .cliOnly:
-            return "Use only local Codex CLI credentials."
+            return L10n.Settings.usageModeCodexCliOnlyDetail
         }
     }
 }

--- a/Sources/VibeBarCore/Models/UpdateChannel.swift
+++ b/Sources/VibeBarCore/Models/UpdateChannel.swift
@@ -14,18 +14,18 @@ public enum UpdateChannel: String, Codable, CaseIterable, Identifiable, Sendable
     public var label: String {
         switch self {
         case .main:
-            return "Main"
+            return L10n.Settings.updateChannelMain
         case .dev:
-            return "Dev"
+            return L10n.Settings.updateChannelDev
         }
     }
 
     public var detail: String {
         switch self {
         case .main:
-            return "Stable releases only."
+            return L10n.Settings.updateChannelMainDetail
         case .dev:
-            return "Preview releases plus all Main releases."
+            return L10n.Settings.updateChannelDevDetail
         }
     }
 

--- a/Sources/VibeBarCore/Resources/en.lproj/Localizable.strings
+++ b/Sources/VibeBarCore/Resources/en.lproj/Localizable.strings
@@ -584,6 +584,75 @@
 /* Toggle in the setup assistant. macOS-only. */
 "platform.macos.launchAtLogin.toggle" = "Launch Vibe Bar at login";
 
+/* Menu-bar colour basis: colour by the displayed percentage. macOS-only. */
+"platform.macos.menuBar.color.actual" = "Actual";
+
+/* Caption under the Actual colour basis. macOS-only. */
+"platform.macos.menuBar.color.actualDetail" = "Colored by the displayed percentage alone, ignoring the forecast.";
+
+/* Menu-bar colour basis: colour by the forecast verdict. macOS-only. */
+"platform.macos.menuBar.color.forecast" = "Forecast";
+
+/* Caption under the Forecast colour basis. macOS-only. */
+"platform.macos.menuBar.color.forecastDetail" = "Green projected to last · blue a chunk will likely go unused · orange may run short · red projected to run out. Falls back to the percentage while a quota has too little history to forecast.";
+
+/* Picker choosing the popover density from the menu-bar editor. macOS-only. */
+"platform.macos.menuBar.displayDensity" = "Display density";
+
+/* Menu-bar field style: show the field's name. macOS-only. */
+"platform.macos.menuBar.fieldStyle.label" = "Label";
+
+/* Caption under the Label field style. macOS-only. */
+"platform.macos.menuBar.fieldStyle.labelDetail" = "The field's name beside its percent.";
+
+/* Menu-bar field style: show the provider's logo. macOS-only. */
+"platform.macos.menuBar.fieldStyle.logo" = "Logo";
+
+/* Menu-bar field style. macOS-only. */
+"platform.macos.menuBar.fieldStyle.logoAndLabel" = "Logo and label";
+
+/* Caption under the Logo and label field style. macOS-only. */
+"platform.macos.menuBar.fieldStyle.logoAndLabelDetail" = "Logo, name, and percent.";
+
+/* Caption under the Logo field style. macOS-only. */
+"platform.macos.menuBar.fieldStyle.logoDetail" = "The provider's logo beside the percent — no text.";
+
+/* Heading over the menu-bar field checklist. macOS-only. */
+"platform.macos.menuBar.fields" = "Fields";
+
+/* Picker choosing how the menu-bar item is laid out. macOS-only. Distinct from the Layout settings section, which is about page layout. */
+"platform.macos.menuBar.layout" = "Layout";
+
+/* Menu-bar layout option. macOS-only. */
+"platform.macos.menuBar.layout.compact" = "Compact";
+
+/* Menu-bar layout option. macOS-only. */
+"platform.macos.menuBar.layout.iconOnly" = "Icon Only";
+
+/* Menu-bar layout option. macOS-only. */
+"platform.macos.menuBar.layout.singleLine" = "Single line";
+
+/* Menu-bar layout option. macOS-only. */
+"platform.macos.menuBar.layout.twoRows" = "Two rows";
+
+/* Toggle that folds a quota group's windows into one entry. macOS-only. */
+"platform.macos.menuBar.mergeGroupWindows" = "Combine a group's windows";
+
+/* Caption under the combine toggle. macOS-only. */
+"platform.macos.menuBar.mergeGroupWindowsDetail" = "Shows 5 Hours and Weekly as 5%/100% instead of two entries.";
+
+/* The menu-bar item that summarises every provider. macOS-only. */
+"platform.macos.menuBar.overview" = "Overview";
+
+/* Picker choosing what colours the menu-bar percentage. macOS-only. */
+"platform.macos.menuBar.percentColor" = "Percent color";
+
+/* Toggle in the menu-bar item editor. macOS-only: no other client renders a menu-bar extra. */
+"platform.macos.menuBar.showInMenuBar" = "Show in menu bar";
+
+/* Toggle in the menu-bar item editor. macOS-only. */
+"platform.macos.menuBar.showTitleText" = "Show title text";
+
 /* Subtitle under the Machines page header */
 "popover.header.machinesSubtitle" = "End-to-end encrypted remote usage";
 
@@ -1040,6 +1109,21 @@
 /* Error line */
 "settings.couldNotDeleteGrokCookies" = "Could not delete saved Grok cookies.";
 
+/* Misc-provider credential source option */
+"settings.credentialSource.apiOnly" = "API / OAuth only";
+
+/* Misc-provider credential source option */
+"settings.credentialSource.auto" = "Auto";
+
+/* Misc-provider credential source option */
+"settings.credentialSource.browserOnly" = "Browser only";
+
+/* Misc-provider credential source option */
+"settings.credentialSource.manualOnly" = "Manual only";
+
+/* Misc-provider credential source option: do not fetch at all */
+"settings.credentialSource.off" = "Off";
+
 /* Credential state line */
 "settings.cursorNoSession" = "No usable Cursor.app session — import cursor.com cookies below.";
 
@@ -1060,6 +1144,12 @@
 
 /* Button label */
 "settings.deleteGrokCookies" = "Delete Grok cookies";
+
+/* Segmented option: the percentage shows what is left. Title case because it is a picker option; quota.mode.remaining is the lowercase caption under a bar. */
+"settings.displayMode.remaining" = "Remaining";
+
+/* Segmented option: the percentage shows what has been spent */
+"settings.displayMode.used" = "Used";
 
 /* Banner shown when a second client overwrote a setting this one had changed */
 "settings.externalChange.title" = "Another Vibe Bar replaced your change";
@@ -1187,6 +1277,24 @@
 /* Empty state under the add-bucket list */
 "settings.miniWindow.allBucketsIncluded" = "Every known bucket is already in this window.";
 
+/* Mini-window strip density */
+"settings.miniWindow.density.narrow" = "Narrow";
+
+/* Caption under the Narrow strip density */
+"settings.miniWindow.density.narrowDetail" = "The menu bar's compact style: the same cells at the small size.";
+
+/* Mini-window strip density */
+"settings.miniWindow.density.roomy" = "Roomy";
+
+/* Caption under the Roomy strip density */
+"settings.miniWindow.density.roomyDetail" = "The menu bar's single-line style: every bucket, full label beside its number.";
+
+/* Mini-window strip density */
+"settings.miniWindow.density.twoLines" = "Two Lines";
+
+/* Caption under the Two Lines strip density */
+"settings.miniWindow.density.twoLinesDetail" = "Menu-bar style: buckets pair into stacked columns, label beside each number.";
+
 /* Tooltip on the dismiss button of a built-in bucket */
 "settings.miniWindow.dismissBuiltIn" = "Dismiss this built-in bucket while the provider is not returning it. It comes back the moment the provider does.";
 
@@ -1198,6 +1306,48 @@
 
 /* Tooltip explaining a disabled remove button */
 "settings.miniWindow.lastCannotBeRemoved" = "The last mini window cannot be removed.";
+
+/* Mini-window display style */
+"settings.miniWindow.mode.compact" = "Compact";
+
+/* Caption under the Compact mini-window style */
+"settings.miniWindow.mode.compactDetail" = "The same three tiers as vertical bars, sized for a corner.";
+
+/* Mini-window display style */
+"settings.miniWindow.mode.focus" = "Focus";
+
+/* Caption under the Focus mini-window style */
+"settings.miniWindow.mode.focusDetail" = "One selected bucket at a time, large — click to cycle in your order.";
+
+/* Mini-window display style */
+"settings.miniWindow.mode.ledger" = "Ledger";
+
+/* Caption under the Ledger mini-window style */
+"settings.miniWindow.mode.ledgerDetail" = "One row per quota bucket — fixed width, grows downward.";
+
+/* Mini-window display style */
+"settings.miniWindow.mode.rail" = "Rail";
+
+/* Caption under the Rail mini-window style */
+"settings.miniWindow.mode.railDetail" = "The next seven days as a refill lane with the coming resets listed.";
+
+/* Mini-window display style */
+"settings.miniWindow.mode.regular" = "Regular";
+
+/* Caption under the Regular mini-window style */
+"settings.miniWindow.mode.regularDetail" = "Ring gauges grouped company → SubProvider → quota group.";
+
+/* Mini-window display style */
+"settings.miniWindow.mode.strip" = "Strip";
+
+/* Caption under the Strip mini-window style */
+"settings.miniWindow.mode.stripDetail" = "A slim line mirroring the menu bar's styles — one cell per bucket.";
+
+/* Mini-window display style */
+"settings.miniWindow.mode.tiles" = "Tiles";
+
+/* Caption under the Tiles mini-window style */
+"settings.miniWindow.mode.tilesDetail" = "A grid of tiles with a big number and a severity stripe.";
 
 /* Segment label: edit the shared names */
 "settings.miniWindow.namesAllWindows" = "Names: all windows";
@@ -1319,6 +1469,27 @@
 /* Picker label for a provider's service region */
 "settings.misc.region" = "Region";
 
+/* Misc-provider region option */
+"settings.misc.region.auto" = "Auto (try both)";
+
+/* Alibaba region option */
+"settings.misc.region.chinaMainland" = "China mainland (cn-beijing)";
+
+/* Alibaba region option; the region id is never translated */
+"settings.misc.region.international" = "International (ap-southeast-1)";
+
+/* MiniMax region option */
+"settings.misc.region.minimaxChina" = "China mainland (minimaxi.com)";
+
+/* MiniMax region option */
+"settings.misc.region.minimaxGlobal" = "Global (minimax.io)";
+
+/* Z.ai region option */
+"settings.misc.region.zaiChina" = "China mainland (open.bigmodel.cn)";
+
+/* Z.ai region option; the host is never translated */
+"settings.misc.region.zaiGlobal" = "Global (api.z.ai)";
+
 /* Tooltip on the button that clears a stored AK/SK pair */
 "settings.misc.removeAkSk" = "Remove stored %1$@ AK/SK";
 
@@ -1393,6 +1564,24 @@
 
 /* Caption under the plan badge field */
 "settings.planBadgeDetail" = "Leave blank to use the detected account plan.";
+
+/* Popover density option */
+"settings.popoverDensity.compact" = "Compact";
+
+/* Caption under the Compact density */
+"settings.popoverDensity.compactDetail" = "Tightest spacing, narrowest popover.";
+
+/* Popover density option */
+"settings.popoverDensity.regular" = "Regular";
+
+/* Caption under the Regular density */
+"settings.popoverDensity.regularDetail" = "Balanced spacing — default.";
+
+/* Popover density option */
+"settings.popoverDensity.spacious" = "Spacious";
+
+/* Caption under the Spacious density */
+"settings.popoverDensity.spaciousDetail" = "Roomy spacing for big displays.";
 
 /* Button that appends a blank rate card */
 "settings.pricing.addOverride" = "Add model override";
@@ -1595,6 +1784,66 @@
 /* Button label */
 "settings.rescanCostLogs" = "Rescan cost logs";
 
+/* Connection-health row: the local AntiGravity probe or agy CLI */
+"settings.route.antigravityLocal" = "Local Antigravity / agy";
+
+/* Connection-health row: cookies imported from a browser */
+"settings.route.browserCookies" = "Chrome/Safari cookies";
+
+/* Connection-health row: the local CLI credential path */
+"settings.route.cli" = "CLI";
+
+/* Connection-health row: the Grok CLI's credential file. A path, never translated. */
+"settings.route.grokAuthFile" = "~/.grok/auth.json";
+
+/* Connection-health row: the OAuth credential path */
+"settings.route.oauth" = "OAuth";
+
+/* Connection-health row: cookies from the in-app login window */
+"settings.route.webViewCookies" = "WebView cookies";
+
+/* Connection-health detail: the agy CLI is installed */
+"settings.routeHealth.agyAvailable" = "agy CLI available";
+
+/* Connection-health detail; the filename is never translated */
+"settings.routeHealth.authFileExpired" = "auth.json expired";
+
+/* Connection-health detail */
+"settings.routeHealth.authFileUnreadable" = "Could not read auth.json";
+
+/* Connection-health detail */
+"settings.routeHealth.cachedOnly" = "Cached data only; live quota unavailable";
+
+/* Connection-health detail */
+"settings.routeHealth.credentialUnreadable" = "Could not read credential";
+
+/* Connection-health detail: a usable credential was found */
+"settings.routeHealth.credentialsAvailable" = "Credentials available";
+
+/* Connection-health detail */
+"settings.routeHealth.invalidCookie" = "Invalid cookie data";
+
+/* Connection-health detail */
+"settings.routeHealth.keychainLocked" = "Keychain locked";
+
+/* Connection-health detail: the AntiGravity language server is up */
+"settings.routeHealth.lspRunning" = "Local LSP running";
+
+/* Connection-health detail */
+"settings.routeHealth.noAntigravityData" = "No local Antigravity data";
+
+/* Connection-health detail */
+"settings.routeHealth.noAuthFile" = "No auth.json";
+
+/* Connection-health detail */
+"settings.routeHealth.noCredential" = "No credential found";
+
+/* Connection-health detail */
+"settings.routeHealth.noSavedCookie" = "No saved cookie";
+
+/* Connection-health detail: a cookie is stored */
+"settings.routeHealth.savedInKeychain" = "Saved in Keychain";
+
 /* Placeholder in the settings sidebar's search field */
 "settings.search" = "Search settings";
 
@@ -1606,6 +1855,9 @@
 
 /* Settings section heading for page layout */
 "settings.section.layout" = "Layout";
+
+/* Settings sidebar destination and section heading */
+"settings.section.menuBar" = "Menu Bar";
 
 /* Settings section heading for the status-item watchdog */
 "settings.section.menuBarHealth" = "Menu Bar Health";
@@ -1621,6 +1873,9 @@
 
 /* Settings section heading for refresh intervals. Distinct from status.overview.refreshing, which says a fetch is in flight. */
 "settings.section.refreshing" = "Refreshing";
+
+/* Settings sidebar destination for remote machine sync */
+"settings.section.remoteProbes" = "Remote Probes";
 
 /* Settings section heading for login items and the setup assistant. Distinct from settings.language.system, which is a language-picker option meaning 'follow macOS'. */
 "settings.section.system" = "System";
@@ -1652,11 +1907,125 @@
 /* Explanation on the SpaceXAI settings page */
 "settings.spaceXAIIntro" = "The SpaceXAI page combines Grok with Cursor. Grok reads `~/.grok/auth.json` or grok.com cookies; Cursor reads Cursor.app first, then cursor.com cookie slots. Grok Bot contributes quota, plus read-only sessions from its local cache — its cloud runs still add no token/cost rows.";
 
+/* Terminal preference: copy the resume command instead of running it. Terminal and iTerm2 are product names and stay as spelled. */
+"settings.terminal.copyOnly" = "Copy to clipboard";
+
 /* Picker label */
 "settings.updateChannel" = "Update channel";
 
+/* Update channel option */
+"settings.updateChannel.dev" = "Dev";
+
+/* Caption under the Dev channel option */
+"settings.updateChannel.devDetail" = "Preview releases plus all Main releases.";
+
+/* Update channel option */
+"settings.updateChannel.main" = "Main";
+
+/* Caption under the Main channel option */
+"settings.updateChannel.mainDetail" = "Stable releases only.";
+
 /* Caption under the update controls */
 "settings.updateCheckDetail" = "Checks the selected channel once a day and asks before installing.";
+
+/* Caption under an AntiGravity usage-source option */
+"settings.usageMode.antigravity.autoDetail" = "Use the Antigravity app first, then the installed agy CLI; fall back to imported cookies when the web source is available.";
+
+/* Caption under an AntiGravity usage-source option */
+"settings.usageMode.antigravity.localFirstDetail" = "Use the Antigravity app or agy CLI first; fall back to imported cookies.";
+
+/* AntiGravity usage-source option */
+"settings.usageMode.antigravity.localOnly" = "Local sources only";
+
+/* Caption under an AntiGravity usage-source option */
+"settings.usageMode.antigravity.localOnlyDetail" = "Only use the Antigravity app or installed agy CLI.";
+
+/* AntiGravity usage-source option */
+"settings.usageMode.antigravity.localThenWeb" = "Local sources, then Web";
+
+/* Caption under an AntiGravity usage-source option */
+"settings.usageMode.antigravity.webFirstDetail" = "Use imported cookies first; fall back to the Antigravity app or agy CLI.";
+
+/* AntiGravity usage-source option */
+"settings.usageMode.antigravity.webOnly" = "Web only";
+
+/* Caption under an AntiGravity usage-source option */
+"settings.usageMode.antigravity.webOnlyDetail" = "Only use imported cookies. Falls back to the local probe until the Antigravity Cloud endpoint ships.";
+
+/* AntiGravity usage-source option */
+"settings.usageMode.antigravity.webThenLocal" = "Web, then Local sources";
+
+/* Usage-source option: let Vibe Bar choose the order */
+"settings.usageMode.auto" = "Auto";
+
+/* Caption under a Claude usage-source option */
+"settings.usageMode.claude.autoDetail" = "Use saved claude.ai cookies first; fall back to Claude OAuth and Claude Code.";
+
+/* Caption under a Claude usage-source option */
+"settings.usageMode.claude.codeFirstDetail" = "Use Claude Code first; fall back to saved claude.ai cookies.";
+
+/* Claude usage-source option */
+"settings.usageMode.claude.codeOnly" = "Claude Code only";
+
+/* Caption under a Claude usage-source option */
+"settings.usageMode.claude.codeOnlyDetail" = "Use only local Claude Code OAuth credentials.";
+
+/* Claude usage-source option */
+"settings.usageMode.claude.codeThenWeb" = "Claude Code, then Web";
+
+/* Claude usage-source option */
+"settings.usageMode.claude.oauthCodeWeb" = "OAuth, then Claude Code, then Web";
+
+/* Caption under a Claude usage-source option */
+"settings.usageMode.claude.oauthFirstDetail" = "Use Claude OAuth first; fall back to Claude Code and saved claude.ai cookies.";
+
+/* Claude usage-source option */
+"settings.usageMode.claude.oauthOnly" = "OAuth only";
+
+/* Caption under a Claude usage-source option */
+"settings.usageMode.claude.oauthOnlyDetail" = "Use only Claude OAuth credentials.";
+
+/* Caption under a Claude usage-source option */
+"settings.usageMode.claude.webFirstDetail" = "Use saved claude.ai cookies first; fall back to Claude Code and OAuth.";
+
+/* Claude usage-source option */
+"settings.usageMode.claude.webOnly" = "Claude Web only";
+
+/* Caption under a Claude usage-source option */
+"settings.usageMode.claude.webOnlyDetail" = "Use only saved claude.ai cookies.";
+
+/* Claude usage-source option */
+"settings.usageMode.claude.webThenCode" = "Claude Web, then Claude Code";
+
+/* Caption under a Codex usage-source option */
+"settings.usageMode.codex.autoDetail" = "Use local Codex CLI credentials first; fall back to Codex OAuth and saved OpenAI web cookies.";
+
+/* Codex usage-source option */
+"settings.usageMode.codex.cliOnly" = "CLI only";
+
+/* Caption under a Codex usage-source option */
+"settings.usageMode.codex.cliOnlyDetail" = "Use only local Codex CLI credentials.";
+
+/* Codex usage-source option */
+"settings.usageMode.codex.cliThenOauth" = "CLI, then OAuth";
+
+/* Caption under a Codex usage-source option */
+"settings.usageMode.codex.oauthFirstDetail" = "Use Codex OAuth first; fall back to local Codex CLI credentials and saved OpenAI web cookies.";
+
+/* Codex usage-source option */
+"settings.usageMode.codex.oauthOnly" = "OAuth only";
+
+/* Caption under a Codex usage-source option */
+"settings.usageMode.codex.oauthOnlyDetail" = "Use only Codex OAuth credentials from auth.json.";
+
+/* Codex usage-source option */
+"settings.usageMode.codex.oauthThenCli" = "OAuth, then CLI";
+
+/* Gemini usage-source option */
+"settings.usageMode.gemini.webOnly" = "Gemini Web only";
+
+/* Caption under the Gemini usage-source option */
+"settings.usageMode.gemini.webOnlyDetail" = "Only fetch imported gemini.google.com cookies.";
 
 /* Picker label choosing where a provider's quota is read from */
 "settings.usageSource" = "Usage source";

--- a/Sources/VibeBarCore/Resources/en.lproj/Localizable.strings
+++ b/Sources/VibeBarCore/Resources/en.lproj/Localizable.strings
@@ -2,14 +2,23 @@
    Resources/i18n/en.json. Do not edit: LocalizationCatalogTests
    regenerates this file and fails on a diff. */
 
+/* Button that appends an entry to a list */
+"common.add" = "Add";
+
 /* Filter chip or menu entry that selects every item. */
 "common.all" = "All";
+
+/* Picker option and field placeholder meaning 'let Vibe Bar decide' */
+"common.auto" = "Auto";
 
 /* Button that abandons an action in progress. */
 "common.cancel" = "Cancel";
 
 /* Button that empties a search field or resets a filter. */
 "common.clear" = "Clear";
+
+/* Confirmation shown in place of the Copy button */
+"common.copied" = "Copied";
 
 /* Button that copies the adjacent value to the clipboard. */
 "common.copy" = "Copy";
@@ -65,6 +74,9 @@
 /* Button that closes a sheet or leaves an editing mode. */
 "common.done" = "Done";
 
+/* Tooltip on a drag handle */
+"common.dragToReorder" = "Drag to reorder";
+
 /* Compact countdown, whole days only */
 "common.duration.days" = "%1$lldd";
 
@@ -86,6 +98,9 @@
 /* Countdown that has reached zero */
 "common.duration.now" = "now";
 
+/* Field label for a user-chosen name */
+"common.name" = "Name";
+
 /* A toggle's state, read as a value in a summary row */
 "common.off" = "Off";
 
@@ -101,14 +116,26 @@
 /* A whole percentage. Both languages use the sign the same way; the key exists so a language that does not can move it. */
 "common.percent" = "%1$lld%%";
 
+/* Picker label for choosing a provider */
+"common.provider" = "Provider";
+
 /* Generic refresh button and tooltip */
 "common.refresh" = "Refresh";
 
 /* Tooltip on a per-card refresh button */
 "common.refreshSection" = "Refresh this section";
 
+/* Button that takes an item out of a list */
+"common.remove" = "Remove";
+
 /* Button on a failure state */
 "common.retry" = "Retry";
+
+/* Button that retries immediately, skipping a cooldown */
+"common.retryNow" = "Retry now";
+
+/* Button that commits an edited value */
+"common.save" = "Save";
 
 /* Freshness line under five seconds old */
 "common.updated.justNow" = "Updated just now";
@@ -968,6 +995,99 @@
 /* Inline error row; reason is a provider message and is not translated */
 "quota.update.failed" = "Update failed: %1$@";
 
+/* Hint under the Antigravity source picker */
+"settings.antigravityCookieEnabled" = "Antigravity cookie import is enabled — sign in at antigravity.google first.";
+
+/* Hint under the Antigravity source picker */
+"settings.antigravityLocalOnly" = "Antigravity reads the locally running language server. Cookie import is deferred until the Antigravity Cloud endpoint ships.";
+
+/* Picker label */
+"settings.antigravitySource" = "Antigravity source";
+
+/* Current version line; version is a raw version string */
+"settings.appVersion" = "Vibe Bar %1$@";
+
+/* Badge on the version currently compiled in */
+"settings.bundled" = "bundled";
+
+/* Button that probes a company's credentials; company is an L1 company name and is never translated */
+"settings.checkConnections" = "Check %1$@ connections";
+
+/* Button label */
+"settings.checkForUpdates" = "Check for Updates…";
+
+/* Button that queries GitHub for a newer agent-session-kit */
+"settings.checkKitUpdates" = "Check for kit updates";
+
+/* Progress line while an update check runs */
+"settings.checkingGitHub" = "Checking github.com for the newest release…";
+
+/* Button label */
+"settings.clearCostData" = "Clear cost data";
+
+/* Heading over the per-provider connection rows */
+"settings.connectionHealth" = "Connection health";
+
+/* Intro under the Cost Data heading */
+"settings.costDataIntro" = "Cost is computed from local CLI session JSONL logs at ~/.codex/sessions and ~/.claude/projects. Web/desktop usage is not tracked.";
+
+/* Error under the delete-cookies button */
+"settings.couldNotDeleteCookies" = "Could not delete saved cookies.";
+
+/* Error line */
+"settings.couldNotDeleteGeminiCookies" = "Could not delete saved Gemini cookies.";
+
+/* Error line */
+"settings.couldNotDeleteGrokCookies" = "Could not delete saved Grok cookies.";
+
+/* Credential state line */
+"settings.cursorNoSession" = "No usable Cursor.app session — import cursor.com cookies below.";
+
+/* Credential state line */
+"settings.cursorSessionDetected" = "Cursor.app signed-in session detected";
+
+/* Row label */
+"settings.cursorSource" = "Cursor source";
+
+/* Value beside the Cursor source row */
+"settings.cursorSourceValue" = "Cursor.app → Web";
+
+/* Button that clears a provider's stored cookies */
+"settings.deleteCookies" = "Delete cookies";
+
+/* Button label */
+"settings.deleteGeminiCookies" = "Delete Gemini cookies";
+
+/* Button label */
+"settings.deleteGrokCookies" = "Delete Grok cookies";
+
+/* Banner shown when a second client overwrote a setting this one had changed */
+"settings.externalChange.title" = "Another Vibe Bar replaced your change";
+
+/* Confirmation line */
+"settings.geminiCookiesSaved" = "Gemini cookies saved.";
+
+/* Explanation on the Google AI settings page */
+"settings.geminiShared" = "Gemini and Antigravity share the same Google AI subscription quota. Cookie import is the only supported web path — there is no WebView login.";
+
+/* Row label for where Gemini quota is read from */
+"settings.geminiSource" = "Gemini source";
+
+/* Credential state line; the path is never translated */
+"settings.grokAuthDetected" = "~/.grok/auth.json detected";
+
+/* Confirmation line */
+"settings.grokCookiesSaved" = "Grok cookies saved.";
+
+/* Picker label for the retention window */
+"settings.keepHistory" = "Keep history";
+
+/* Caption under the retention picker */
+"settings.keepHistoryDetail" = "Applies to cost history and subscription fill history.";
+
+/* Description of the bundled agent-session-kit component */
+"settings.kitDetail" = "Session discovery, harness naming, and the MCP transport. A separate repository, pinned to an exact tag and compiled into this build.";
+
 /* Caption under the language picker in Settings */
 "settings.language.caption" = "Vibe Bar follows the macOS language unless you pick one here. Provider, model and harness names stay as their owners spell them.";
 
@@ -976,6 +1096,576 @@
 
 /* Settings row label for the in-app language override */
 "settings.language.title" = "Language";
+
+/* Toggle label */
+"settings.mcp.allowRefresh" = "Allow agents to refresh quota";
+
+/* Caption under the refresh toggle; quota.refresh is an MCP tool name and is never translated */
+"settings.mcp.allowRefreshDetail" = "With this on, an agent can ask Vibe Bar to re-fetch quota from your providers. Forced refreshes are rate-limited to one every %1$lld seconds. With it off the read-only tools keep working and quota.refresh reports that refreshing is disabled.";
+
+/* Toggle label */
+"settings.mcp.allowSkills" = "Allow agents to install skills";
+
+/* Caption under the skills toggle; skills.install is an MCP tool name */
+"settings.mcp.allowSkillsDetail" = "With this on, an agent can call skills.install to add a skill from a GitHub repository or a local folder. It goes through the same Skills manager as Workbench → Skills, so it writes only to ~/.agents/skills and the agent skills directories Vibe Bar manages — never over a folder a different skill already holds. With it off the tool reports that installing is disabled.";
+
+/* Caption on a copyable config snippet; the path is never translated */
+"settings.mcp.appendCodexConfig" = "Append to ~/.codex/config.toml.";
+
+/* Sub-heading over the setup instructions */
+"settings.mcp.connectAgent" = "Connect an agent";
+
+/* Row label for the live connection count */
+"settings.mcp.connectedClients" = "Connected clients";
+
+/* Toggle label */
+"settings.mcp.enable" = "Enable the local MCP server";
+
+/* Intro paragraph of the MCP settings section */
+"settings.mcp.intro" = "Vibe Bar can expose this Mac's quota, usage, cost and local agent sessions to your coding agents over MCP. The server listens on a Unix domain socket in your home directory — no network port is opened, and no token is created: the socket's file permissions are the access control.";
+
+/* Row label for when a client last spoke to the server */
+"settings.mcp.lastActivity" = "Last client activity";
+
+/* MCP server state: the socket is accepting connections */
+"settings.mcp.listening" = "Listening";
+
+/* Intro to the manual client configuration snippets; flag is a command-line flag and is never translated */
+"settings.mcp.manualIntro" = "Or configure a client by hand. Every client runs the same command — Vibe Bar's own binary with %1$@, which bridges stdin/stdout to the socket above.";
+
+/* Caption on a copyable config snippet */
+"settings.mcp.mergeCursorConfig" = "Merge into ~/.cursor/mcp.json.";
+
+/* Warning shown when the app runs from a build directory; path is a filesystem path */
+"settings.mcp.movePrompt" = "Vibe Bar is running from %1$@. Move it to /Applications before saving a client config, or the config breaks the next time you rebuild.";
+
+/* MCP server state: the socket is closed */
+"settings.mcp.notListening" = "Not listening";
+
+/* Heading for the generic client snippet */
+"settings.mcp.otherStdioClient" = "Any other stdio client";
+
+/* Caption on the generic client snippet */
+"settings.mcp.otherStdioDetail" = "One entry for the client's own mcpServers map.";
+
+/* Caption over the one-line setup prompt */
+"settings.mcp.quickestPath" = "The quickest path: paste this into any agent and let it configure itself, install the companion skill, and verify the connection.";
+
+/* Caption closing the MCP permissions section */
+"settings.mcp.readOnlyDetail" = "Everything else agents can reach is read-only: quota, token usage, cost, provider status, effective model prices, and the local session index (titles, projects, and — when session body indexing is on — message excerpts). Credentials, cookies and organization ids are never exposed, and email addresses are masked.";
+
+/* Caption on a copyable shell command */
+"settings.mcp.runInTerminal" = "Run in a terminal.";
+
+/* Label for the copyable one-line prompt */
+"settings.mcp.setupPrompt" = "Agent setup prompt";
+
+/* Caption under the setup prompt */
+"settings.mcp.setupPromptDetail" = "One line, works in any agent that can fetch a URL.";
+
+/* Row label for the socket path. The term stays as spelled. */
+"settings.mcp.socket" = "Socket";
+
+/* Caption under the MCP status rows. The quoted phrase is the message another tool prints and stays in English. */
+"settings.mcp.socketLifetime" = "The socket exists only while Vibe Bar is running. Agents configured below report “Vibe Bar is not running” when it is quit, which is the intended behaviour.";
+
+/* Row label for whether the MCP socket is listening. Distinct from status.overview.title, which is a provider's service status. */
+"settings.mcp.status" = "Status";
+
+/* Settings section heading for the local MCP server */
+"settings.mcp.title" = "MCP Server";
+
+/* Sub-heading over the permission toggles */
+"settings.mcp.whatAgentsMayDo" = "What agents may do";
+
+/* Shown when the watchdog is not running */
+"settings.menuBarHealthUnavailable" = "The menu bar health monitor is not attached in this process.";
+
+/* Button in the mini windows settings section */
+"settings.miniWindow.add" = "Add a mini window";
+
+/* Empty state under the add-bucket list */
+"settings.miniWindow.allBucketsIncluded" = "Every known bucket is already in this window.";
+
+/* Tooltip on the dismiss button of a built-in bucket */
+"settings.miniWindow.dismissBuiltIn" = "Dismiss this built-in bucket while the provider is not returning it. It comes back the moment the provider does.";
+
+/* Tooltip on the dismiss button of a runtime-discovered bucket */
+"settings.miniWindow.forgetDiscovered" = "Forget this discovered bucket — drops it from the list and from every window that selected it.";
+
+/* Tooltip on a style toggle; mode is a display-mode name */
+"settings.miniWindow.includeStyle" = "Include %1$@ in the double-click cycle";
+
+/* Tooltip explaining a disabled remove button */
+"settings.miniWindow.lastCannotBeRemoved" = "The last mini window cannot be removed.";
+
+/* Segment label: edit the shared names */
+"settings.miniWindow.namesAllWindows" = "Names: all windows";
+
+/* Segment label: edit only this display style's overrides; mode is a display-mode name */
+"settings.miniWindow.namesThisStyle" = "Only %1$@ here";
+
+/* Segment label: edit only this window's name overrides */
+"settings.miniWindow.namesThisWindow" = "Only “%1$@”";
+
+/* Empty state under the field list */
+"settings.miniWindow.noFieldsSelected" = "No fields selected — tick some above.";
+
+/* Caption over the list of buckets not yet in this window */
+"settings.miniWindow.notInWindow" = "Not in “%1$@” — tick a bucket to add it. Buckets the adapters discover at runtime appear here automatically; a dimmed row is remembered but not in the account's current response, and ✕ dismisses it until the provider returns it.";
+
+/* Badge on a remote machine's row in the mini window preview */
+"settings.miniWindow.offline" = "offline";
+
+/* Button that shows or hides a mini window */
+"settings.miniWindow.openClose" = "Open / Close";
+
+/* Caption over the per-style name fields */
+"settings.miniWindow.overridesStyle" = "Overrides for the %1$@ style of this window only. An empty field inherits the window name, then the shared one — shown as the placeholder.";
+
+/* Caption over the per-window name fields */
+"settings.miniWindow.overridesWindow" = "Name overrides for this window only. An empty field inherits the shared name — shown as the placeholder.";
+
+/* Ordinal badge showing a field's place in the order */
+"settings.miniWindow.position" = "%1$lld";
+
+/* Tooltip on a row's remove control */
+"settings.miniWindow.removeFromWindow" = "Remove from this window";
+
+/* Tooltip on the remove button */
+"settings.miniWindow.removeHelp" = "Remove this mini window";
+
+/* Picker label for the mini window's row density */
+"settings.miniWindow.stripDensity" = "Strip density";
+
+/* Caption over the style cycle picker */
+"settings.miniWindow.styleCycle" = "Double-click on the window cycles its style. Tap a style to include it — the badge is its turn in the cycle. Nothing selected means every style, in this order.";
+
+/* Tooltip on the open/close button */
+"settings.miniWindow.toggleHelp" = "Toggle this mini window on screen";
+
+/* Caption over the mini window field tree */
+"settings.miniWindow.treeDetail" = "One tree for the window — grouped exactly as it folds them (company → SubProvider → quota group → bucket). Drag a row to reorder, ✕ to remove, and rename any level in place. First field renders leftmost (or topmost).";
+
+/* Field placeholder for the AK half of an AK/SK pair */
+"settings.misc.accessKeyId" = "Access Key ID (AKLT…)";
+
+/* Confirmation under an AK/SK field */
+"settings.misc.akSkSaved" = "AK/SK saved in Keychain.";
+
+/* Confirmation under a credential field */
+"settings.misc.apiKeySaved" = "API key saved in Keychain.";
+
+/* Tooltip on the button that forgets a stored workspace id */
+"settings.misc.clearWorkspace" = "Clear saved workspace";
+
+/* Tooltip on the button that adds a second instance of a provider */
+"settings.misc.clone" = "Clone %1$@";
+
+/* Console link row; title is the provider's own page name */
+"settings.misc.consoleLink" = "%1$@ →";
+
+/* Picker label for a provider's edition (Team, Personal, …) */
+"settings.misc.edition" = "Edition";
+
+/* Hint under the GitHub sign-in row */
+"settings.misc.githubSignInHint" = "Sign in with GitHub device flow.";
+
+/* Confirmation under the GitHub sign-in row */
+"settings.misc.githubTokenSaved" = "GitHub device token saved in Keychain.";
+
+/* Caption under the cookie import button */
+"settings.misc.importDetail" = "Adds or refreshes the first signed-in browser profile found; profiles already imported stay stacked, and this provider's quota is the average across every slot listed above. macOS may ask for your login-keychain password once per Chromium-family browser.";
+
+/* Hint under the Kiro row; the commands are never translated */
+"settings.misc.kiroHint" = "Run `kiro-cli login`, then Vibe Bar probes `kiro-cli chat --no-interactive /usage`.";
+
+/* Shown when a provider has no cookie import path */
+"settings.misc.noCookieSpec" = "No cookie spec is registered for %1$@.";
+
+/* Empty state in the cookie slot list */
+"settings.misc.noCookiesYet" = "No cookies imported yet — import from your browser or paste below.";
+
+/* Button that runs a local CLI probe */
+"settings.misc.probe" = "Probe";
+
+/* Field placeholder */
+"settings.misc.prompt.copilotHost" = "GitHub Enterprise host (optional, e.g. github.example.com)";
+
+/* Field placeholder */
+"settings.misc.prompt.dashscope" = "Paste DashScope API key (sk-...) — optional";
+
+/* Field placeholder */
+"settings.misc.prompt.kilo" = "Paste Kilo API key (optional)";
+
+/* Field placeholder */
+"settings.misc.prompt.minimax" = "Paste MiniMax Token Plan API key (sk-cp-... or MINIMAX_CODING_API_KEY)";
+
+/* Field placeholder */
+"settings.misc.prompt.openRouter" = "Paste OpenRouter API key (sk-or-v1-...)";
+
+/* Field placeholder */
+"settings.misc.prompt.openRouterHost" = "OpenRouter API URL (optional, defaults to https://openrouter.ai/api/v1)";
+
+/* Field placeholder */
+"settings.misc.prompt.warp" = "Paste Warp API key (wk-...)";
+
+/* Field placeholder */
+"settings.misc.prompt.workspace" = "Workspace ID or URL (optional, wrk_... or /workspace/wrk_.../go)";
+
+/* Field placeholder; the key prefix is a format example */
+"settings.misc.prompt.zai" = "Paste Z.ai API key (zai-...)";
+
+/* Picker label for a provider's service region */
+"settings.misc.region" = "Region";
+
+/* Tooltip on the button that clears a stored AK/SK pair */
+"settings.misc.removeAkSk" = "Remove stored %1$@ AK/SK";
+
+/* Tooltip on the button that clears a stored key */
+"settings.misc.removeApiKey" = "Remove stored %1$@ API key";
+
+/* Tooltip on a cookie slot's delete button */
+"settings.misc.removeCookieSlot" = "Remove this cookie slot";
+
+/* Tooltip on the button that deletes a cloned instance */
+"settings.misc.removeCopy" = "Remove this %1$@ copy";
+
+/* Destructive button in the remove-copy dialog */
+"settings.misc.removeCopyButton" = "Remove Copy";
+
+/* Confirmation dialog body */
+"settings.misc.removeCopyDetail" = "Its saved credentials are deleted from your Keychain — the API key or AK/SK and every imported cookie slot. This cannot be undone.";
+
+/* Confirmation dialog title */
+"settings.misc.removeCopyTitle" = "Remove this %1$@ copy?";
+
+/* Tooltip on the button that clears the GitHub token */
+"settings.misc.removeGithubToken" = "Remove stored GitHub device token";
+
+/* Tooltip on the rename button of a cloned instance */
+"settings.misc.rename" = "Rename this copy";
+
+/* Field placeholder for the SK half of an AK/SK pair. The term is the provider's own and stays as spelled. */
+"settings.misc.secretAccessKey" = "Secret Access Key";
+
+/* Button that starts a device-flow sign-in */
+"settings.misc.signIn" = "Sign in";
+
+/* Button that opens a WebView login */
+"settings.misc.signInViaWeb" = "Sign in via Web";
+
+/* Caption under the Tencent token plan row */
+"settings.misc.tencentTokenPlanNote" = "Personal Token Plan is currently available only in China mainland (cn-beijing). Clone this row to track Team and Personal together.";
+
+/* Picker label for a provider's plan variant */
+"settings.misc.variant" = "Variant";
+
+/* Button label while a device-flow sign-in is pending */
+"settings.misc.waiting" = "Waiting...";
+
+/* Caption under the workspace field */
+"settings.misc.workspaceNote" = "Only needed when the account owns more than one workspace — otherwise Vibe Bar uses the first one it finds.";
+
+/* Provider state: credentials are missing */
+"settings.needsSetup" = "Needs setup";
+
+/* Connection state before any probe has run */
+"settings.notChecked" = "Not checked";
+
+/* Line under the update-check button */
+"settings.notCheckedYet" = "Not checked. Nothing is fetched until you ask.";
+
+/* Picker label */
+"settings.openRefreshCooldown" = "Minimum open-refresh cooldown";
+
+/* Caption under the cooldown picker */
+"settings.openRefreshDetail" = "Opening the popover refreshes all visible providers at most once per cooldown period.";
+
+/* Link to a company's public status page */
+"settings.openStatusPage" = "Open %1$@ status page";
+
+/* Picker label choosing between remaining and used */
+"settings.percentShows" = "Percent shows";
+
+/* Field label for a user-chosen plan label override */
+"settings.planBadge" = "Plan badge";
+
+/* Caption under the plan badge field */
+"settings.planBadgeDetail" = "Leave blank to use the detected account plan.";
+
+/* Button that appends a blank rate card */
+"settings.pricing.addOverride" = "Add model override";
+
+/* Disclosure heading over the threshold rate fields */
+"settings.pricing.advancedTiers" = "Advanced tiers";
+
+/* Detail beside the local-overrides source */
+"settings.pricing.alwaysWins" = "Always wins";
+
+/* Name of the lowest-priority price source */
+"settings.pricing.bundledFallback" = "Bundled fallback";
+
+/* Rate field label */
+"settings.pricing.cacheReadAbove" = "Cache read above";
+
+/* Rate field label */
+"settings.pricing.cacheWriteAbove" = "Cache write above";
+
+/* Tooltip on a rate card's delete button */
+"settings.pricing.deleteOverride" = "Delete override";
+
+/* Placeholder in the model-name field of a rate card */
+"settings.pricing.exactModelName" = "Exact model name";
+
+/* Rate field label: the multiplier applied to a fast tier */
+"settings.pricing.fastMultiplier" = "Fast multiplier";
+
+/* Rate field label for input tokens beyond the threshold */
+"settings.pricing.inputAbove" = "Input above";
+
+/* Intro under the Model Pricing heading */
+"settings.pricing.intro" = "Catalogs refresh in the background. Higher entries win when the same provider and model name appears more than once.";
+
+/* Settings section heading over the user's own rate cards */
+"settings.pricing.localOverrides" = "Local overrides";
+
+/* Name of the highest-priority price source */
+"settings.pricing.localOverridesName" = "Local overrides";
+
+/* Empty state in the overrides list */
+"settings.pricing.noOverrides" = "No local overrides.";
+
+/* Ordinal badge beside a price source */
+"settings.pricing.number" = "%1$lld";
+
+/* Detail beside the bundled source */
+"settings.pricing.offlineFloor" = "Offline floor";
+
+/* Rate field label for output tokens beyond the threshold */
+"settings.pricing.outputAbove" = "Output above";
+
+/* Intro under the Local overrides heading */
+"settings.pricing.overridesIntro" = "Prices are USD per one million tokens. Leave cache fields empty when the provider does not publish them.";
+
+/* Settings section heading over the price-source list */
+"settings.pricing.priorityHealth" = "Priority and source health";
+
+/* Rate field label: input tokens */
+"settings.pricing.rateInput" = "Input";
+
+/* Rate field label: output tokens */
+"settings.pricing.rateOutput" = "Output";
+
+/* Button that fetches price catalogs immediately */
+"settings.pricing.refreshNow" = "Refresh now";
+
+/* Button label while a price refresh runs */
+"settings.pricing.refreshing" = "Refreshing…";
+
+/* Field label: the token count above which the higher rates apply */
+"settings.pricing.thresholdTokens" = "Threshold tokens";
+
+/* Footer showing when the bundled price table was built; date is a raw stamp */
+"settings.pricingDataDate" = "Pricing data: %1$@";
+
+/* Body of the Privacy section */
+"settings.privacyDetail" = "Tokens are read from local CLI credentials. Saved OpenAI and Claude Web cookies are stored in macOS Keychain, split by browser and WebView source. Legacy plaintext cookie files under ~/.vibebar/cookies are migrated once and deleted. Settings, quota cache, and cost summaries stay under ~/.vibebar.";
+
+/* Toggle label */
+"settings.privacyMode" = "Privacy mode";
+
+/* Caption under the privacy toggle */
+"settings.privacyModeDetail" = "Privacy mode keeps cost data off disk and clears local cost history, snapshots, and scan cache.";
+
+/* Provider state: credentials are usable */
+"settings.ready" = "Ready";
+
+/* Picker label for a background refresh interval */
+"settings.refreshEvery" = "Refresh every";
+
+/* Toggle label */
+"settings.refreshOnPopoverOpen" = "Refresh when the popover opens";
+
+/* Link label */
+"settings.releaseNotes" = "Release notes";
+
+/* Settings section heading. Core is the product term for this Mac's aggregator. */
+"settings.remote.core" = "Remote Core";
+
+/* Settings section heading */
+"settings.remote.costAggregation" = "Cost aggregation";
+
+/* Intro under the cost aggregation heading */
+"settings.remote.costAggregationIntro" = "Choose which remote machines join this Mac's local cost and token totals. Selection and aggregation stay on this Core; the Relay never sees plaintext usage.";
+
+/* Toggle that reveals the control-centre URL field */
+"settings.remote.differentControlCenter" = "Use a different control center";
+
+/* Button that abandons a pending join */
+"settings.remote.discard" = "Discard";
+
+/* Confirmation dialog body */
+"settings.remote.discardPendingDetail" = "Its pairing code is already spent, and the workspace still counts this Mac as its Core. To join again, revoke this Mac in the web control center, then create a fresh code.";
+
+/* Confirmation dialog title */
+"settings.remote.discardPendingTitle" = "Discard this pending join?";
+
+/* Settings section heading, and the destructive button in its dialog */
+"settings.remote.disconnect" = "Disconnect";
+
+/* Button that unpairs this Mac */
+"settings.remote.disconnectButton" = "Disconnect from Workspace…";
+
+/* Confirmation dialog body */
+"settings.remote.disconnectDetail" = "Reconnecting later requires a new pairing code or provisioning file.";
+
+/* Explanation under the Disconnect heading */
+"settings.remote.disconnectIntro" = "Disconnecting removes this Mac's Relay credential from the Keychain and its workspace binding. Probes keep uploading to the Relay until they are revoked there. Usage already decrypted stays in the local ledger.";
+
+/* Confirmation dialog title */
+"settings.remote.disconnectTitle" = "Disconnect from this workspace?";
+
+/* Button that writes this Mac's public identity to a file */
+"settings.remote.exportIdentity" = "Export Core Identity…";
+
+/* Button that reads a provisioning file */
+"settings.remote.importProvisioning" = "Import Provisioning File…";
+
+/* Button that submits a pairing code */
+"settings.remote.join" = "Join";
+
+/* Explanation above the pairing-code field; device is the Mac's name */
+"settings.remote.joinIntro" = "Create a Core code in the Vibe Bar control center, then paste it here. This Mac joins as “%1$@”.";
+
+/* Heading over the pairing-code field */
+"settings.remote.joinWithCode" = "Join with a code";
+
+/* Row label for the last sync time */
+"settings.remote.lastSync" = "Last sync";
+
+/* Second line of a remote machine row; platform and version are raw values */
+"settings.remote.machineDetail" = "%1$@ · Probe %2$@";
+
+/* Empty state in the machine list */
+"settings.remote.machinesAppearAfterImport" = "Machines appear here after their first encrypted batch is imported.";
+
+/* Row label for the machine count */
+"settings.remote.machinesSynced" = "Machines synced";
+
+/* Explanation of the manual pairing flow */
+"settings.remote.manualPairingIntro" = "Pairing runs in three steps: export this Mac's Core identity, register it with your Relay to produce a provisioning file, then import that file here. Importing moves the Relay credential into the macOS Keychain — but the provisioning file itself still contains that credential, so delete the file once the import succeeds.";
+
+/* Explanation shown when no workspace is paired */
+"settings.remote.notConnected" = "This Mac is not connected to a workspace. Remote probes collect normalized usage on your other machines, encrypt it to this Mac's Core keys, and drop it at a Relay — no inbound port is ever opened here.";
+
+/* Caption above the manual pairing buttons */
+"settings.remote.orPairManually" = "Or pair manually.";
+
+/* Explanation of a half-finished join */
+"settings.remote.pendingIntro" = "A previous join was accepted by the control center but never finished saving on this Mac. Its pairing code is already spent, so resume the save instead of requesting a new code.";
+
+/* Settings section heading over the pairing controls */
+"settings.remote.provisioning" = "Provisioning";
+
+/* Row label for the probe count */
+"settings.remote.registeredProbes" = "Registered probes";
+
+/* Row label for the relay URL. The term stays as spelled. */
+"settings.remote.relay" = "Relay";
+
+/* Button that finishes a half-completed join */
+"settings.remote.resumeSaving" = "Resume saving";
+
+/* Button that retries a failed save */
+"settings.remote.retrySaving" = "Retry saving";
+
+/* Sync status line: a translated title and the raw status code */
+"settings.remote.statusWithCode" = "%1$@ · %2$@";
+
+/* Button that pulls remote batches immediately */
+"settings.remote.syncNow" = "Sync now";
+
+/* Row label for the workspace id */
+"settings.remote.workspace" = "Workspace";
+
+/* Link label */
+"settings.repository" = "Repository";
+
+/* Button label */
+"settings.rescanCostLogs" = "Rescan cost logs";
+
+/* Placeholder in the settings sidebar's search field */
+"settings.search" = "Search settings";
+
+/* Settings section heading listing bundled components. Distinct from status.card.components, which are a provider's status-page components. */
+"settings.section.components" = "Components";
+
+/* Settings section heading */
+"settings.section.costData" = "Cost Data";
+
+/* Settings section heading for page layout */
+"settings.section.layout" = "Layout";
+
+/* Settings section heading for the status-item watchdog */
+"settings.section.menuBarHealth" = "Menu Bar Health";
+
+/* Settings section heading */
+"settings.section.miniWindows" = "Mini Windows";
+
+/* Settings section heading for the Overview surface */
+"settings.section.overview" = "Overview";
+
+/* Settings section heading */
+"settings.section.privacy" = "Privacy";
+
+/* Settings section heading for refresh intervals. Distinct from status.overview.refreshing, which says a fetch is in flight. */
+"settings.section.refreshing" = "Refreshing";
+
+/* Settings section heading for login items and the setup assistant. Distinct from settings.language.system, which is a language-picker option meaning 'follow macOS'. */
+"settings.section.system" = "System";
+
+/* Settings section heading for the app updater */
+"settings.section.updates" = "Updates";
+
+/* Button that reopens the first-run assistant */
+"settings.showAssistant" = "Show setup assistant";
+
+/* Caption under the assistant button */
+"settings.showAssistantDetail" = "Walk through subscriptions, browser cookies, API keys, model pricing and login items again. Nothing is reset.";
+
+/* Sidebar group heading over the four core provider pages */
+"settings.sidebar.coreProviders" = "Core Providers";
+
+/* Tooltip on the toggle that turns a misc provider off */
+"settings.sidebar.disableProvider" = "Disable Provider";
+
+/* Tooltip on the toggle that turns a misc provider on */
+"settings.sidebar.enableProvider" = "Enable Provider";
+
+/* Tooltip on the toggle that removes a provider from the Overview */
+"settings.sidebar.hideFromOverview" = "Hide from Overview";
+
+/* Sidebar group heading over the static preference pages */
+"settings.sidebar.settings" = "Settings";
+
+/* Explanation on the SpaceXAI settings page */
+"settings.spaceXAIIntro" = "The SpaceXAI page combines Grok with Cursor. Grok reads `~/.grok/auth.json` or grok.com cookies; Cursor reads Cursor.app first, then cursor.com cookie slots. Grok Bot contributes quota, plus read-only sessions from its local cache — its cloud runs still add no token/cost rows.";
+
+/* Picker label */
+"settings.updateChannel" = "Update channel";
+
+/* Caption under the update controls */
+"settings.updateCheckDetail" = "Checks the selected channel once a day and asks before installing.";
+
+/* Picker label choosing where a provider's quota is read from */
+"settings.usageSource" = "Usage source";
+
+/* Value beside the Gemini source row */
+"settings.webQuota" = "Web quota";
+
+/* Link to a release's notes; version is a tag name */
+"settings.whatChangedIn" = "What changed in %1$@";
 
 /* Group heading for a provider's status components */
 "status.card.components" = "Components";

--- a/Sources/VibeBarCore/Resources/en.lproj/Localizable.strings
+++ b/Sources/VibeBarCore/Resources/en.lproj/Localizable.strings
@@ -662,6 +662,36 @@
 /* Subtitle under the Overview page header */
 "popover.header.overviewSubtitle" = "All providers · quota & cost";
 
+/* Empty-state title while a sync is in flight */
+"popover.machines.checking" = "Checking the Relay…";
+
+/* Toggle on a remote machine card */
+"popover.machines.includeInTotals" = "Include in totals";
+
+/* Tooltip on the include-in-totals toggle */
+"popover.machines.includeInTotalsHelp" = "Add this machine's decrypted usage to Overview and provider cost pages on this Core";
+
+/* A source label followed by its status; both halves arrive already localized */
+"popover.machines.labelWithStatus" = "%1$@ · %2$@";
+
+/* Empty-state title when the Relay is connected but nothing has arrived */
+"popover.machines.noData" = "No remote machine data yet";
+
+/* Empty-state body on the Machines page */
+"popover.machines.noDataDetail" = "The Relay is connected. A Probe will appear after its first encrypted batch is decrypted and imported.";
+
+/* Empty-state title on the Machines page */
+"popover.machines.notConfigured" = "Remote Core is not configured";
+
+/* Empty-state body on the Machines page */
+"popover.machines.notConfiguredDetail" = "Create a Core descriptor, provision a workspace-scoped Relay credential, then import the signed provisioning file. No inbound port is required on this Mac.";
+
+/* The last imported batch's sequence number on a machine card; the number is raw */
+"popover.machines.sequence" = "seq %1$@";
+
+/* Metric label on a remote machine card */
+"popover.machines.thirtyDayCost" = "30-day cost";
+
 /* Tooltip on the Google AI page's refresh button; the SubProvider names are never translated */
 "popover.refreshGoogleAI" = "Refresh Gemini Web + AntiGravity";
 
@@ -1771,6 +1801,60 @@
 
 /* Sync status line: a translated title and the raw status code */
 "settings.remote.statusWithCode" = "%1$@ · %2$@";
+
+/* Remote sync status title for HTTP 429/503 */
+"settings.remote.sync.busy" = "Relay is temporarily busy";
+
+/* Remote sync status title */
+"settings.remote.sync.connectionFailed" = "Relay connection was interrupted";
+
+/* Remote sync status title */
+"settings.remote.sync.hostLookupFailed" = "Relay host could not be resolved";
+
+/* Remote sync status title */
+"settings.remote.sync.invalidResponse" = "Relay returned an unexpected response";
+
+/* Remote sync status detail for an offline or DNS failure */
+"settings.remote.sync.networkDetail" = "Check this Mac's network or proxy path; existing machine data is still available.";
+
+/* Remote sync status title. The error code beside it is a machine-readable identifier and stays English. */
+"settings.remote.sync.offline" = "This Mac is offline";
+
+/* Remote sync status title for HTTP 401/403 */
+"settings.remote.sync.rejected" = "Relay access was rejected";
+
+/* Remote sync status detail for HTTP 401/403 */
+"settings.remote.sync.rejectedDetail" = "The workspace credential may have been revoked. Reconnect this Core in Settings.";
+
+/* Remote sync status detail for a transient transport failure */
+"settings.remote.sync.retryDetail" = "Existing machine data is still available. Vibe Bar will retry automatically.";
+
+/* Remote sync status title */
+"settings.remote.sync.secureConnectionFailed" = "Secure Relay connection failed";
+
+/* Remote sync status title */
+"settings.remote.sync.sequenceGap" = "Probe history has a sequence gap";
+
+/* Remote sync status detail */
+"settings.remote.sync.sequenceGapDetail" = "A Probe batch is missing from the Relay stream, so later batches were not imported.";
+
+/* Remote sync status title */
+"settings.remote.sync.timeout" = "Relay connection timed out";
+
+/* Remote sync status title */
+"settings.remote.sync.transportFailed" = "Relay transport failed";
+
+/* Remote sync status title for a code this build does not recognize. A new Relay error code must still render a sentence. */
+"settings.remote.sync.unknown" = "Remote sync needs attention";
+
+/* Remote sync status detail for an unrecognized code */
+"settings.remote.sync.unknownDetail" = "No local usage was deleted. Retry now or inspect Remote Core settings for the error code.";
+
+/* Remote sync status title for an invalid signature or unauthorized producer */
+"settings.remote.sync.unverifiedProbe" = "A Probe could not be verified";
+
+/* Remote sync status detail */
+"settings.remote.sync.unverifiedProbeDetail" = "The current workspace roster does not authorize one of the received batches.";
 
 /* Button that pulls remote batches immediately */
 "settings.remote.syncNow" = "Sync now";

--- a/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.strings
@@ -584,6 +584,75 @@
 /* Toggle in the setup assistant. macOS-only. */
 "platform.macos.launchAtLogin.toggle" = "登录时启动 Vibe Bar";
 
+/* Menu-bar colour basis: colour by the displayed percentage. macOS-only. */
+"platform.macos.menuBar.color.actual" = "实际";
+
+/* Caption under the Actual colour basis. macOS-only. */
+"platform.macos.menuBar.color.actualDetail" = "仅按显示的百分比着色，忽略预测。";
+
+/* Menu-bar colour basis: colour by the forecast verdict. macOS-only. */
+"platform.macos.menuBar.color.forecast" = "预测";
+
+/* Caption under the Forecast colour basis. macOS-only. */
+"platform.macos.menuBar.color.forecastDetail" = "绿色表示预计够用 · 蓝色表示预计会有较多闲置 · 橙色表示可能不足 · 红色表示预计会用尽。当某项额度历史过少、无法预测时，回退为按百分比着色。";
+
+/* Picker choosing the popover density from the menu-bar editor. macOS-only. */
+"platform.macos.menuBar.displayDensity" = "显示密度";
+
+/* Menu-bar field style: show the field's name. macOS-only. */
+"platform.macos.menuBar.fieldStyle.label" = "名称";
+
+/* Caption under the Label field style. macOS-only. */
+"platform.macos.menuBar.fieldStyle.labelDetail" = "名称与百分比并列。";
+
+/* Menu-bar field style: show the provider's logo. macOS-only. */
+"platform.macos.menuBar.fieldStyle.logo" = "图标";
+
+/* Menu-bar field style. macOS-only. */
+"platform.macos.menuBar.fieldStyle.logoAndLabel" = "图标与名称";
+
+/* Caption under the Logo and label field style. macOS-only. */
+"platform.macos.menuBar.fieldStyle.logoAndLabelDetail" = "图标、名称与百分比。";
+
+/* Caption under the Logo field style. macOS-only. */
+"platform.macos.menuBar.fieldStyle.logoDetail" = "厂商图标与百分比并列 — 不显示文字。";
+
+/* Heading over the menu-bar field checklist. macOS-only. */
+"platform.macos.menuBar.fields" = "字段";
+
+/* Picker choosing how the menu-bar item is laid out. macOS-only. Distinct from the Layout settings section, which is about page layout. */
+"platform.macos.menuBar.layout" = "排布";
+
+/* Menu-bar layout option. macOS-only. */
+"platform.macos.menuBar.layout.compact" = "紧凑";
+
+/* Menu-bar layout option. macOS-only. */
+"platform.macos.menuBar.layout.iconOnly" = "仅图标";
+
+/* Menu-bar layout option. macOS-only. */
+"platform.macos.menuBar.layout.singleLine" = "单行";
+
+/* Menu-bar layout option. macOS-only. */
+"platform.macos.menuBar.layout.twoRows" = "双行";
+
+/* Toggle that folds a quota group's windows into one entry. macOS-only. */
+"platform.macos.menuBar.mergeGroupWindows" = "合并同组的窗口";
+
+/* Caption under the combine toggle. macOS-only. */
+"platform.macos.menuBar.mergeGroupWindowsDetail" = "把 5 小时与每周显示为 5%/100%，而不是两条独立条目。";
+
+/* The menu-bar item that summarises every provider. macOS-only. */
+"platform.macos.menuBar.overview" = "总览";
+
+/* Picker choosing what colours the menu-bar percentage. macOS-only. */
+"platform.macos.menuBar.percentColor" = "百分比配色";
+
+/* Toggle in the menu-bar item editor. macOS-only: no other client renders a menu-bar extra. */
+"platform.macos.menuBar.showInMenuBar" = "在菜单栏中显示";
+
+/* Toggle in the menu-bar item editor. macOS-only. */
+"platform.macos.menuBar.showTitleText" = "显示标题文字";
+
 /* Subtitle under the Machines page header */
 "popover.header.machinesSubtitle" = "端到端加密的远程用量";
 
@@ -1040,6 +1109,21 @@
 /* Error line */
 "settings.couldNotDeleteGrokCookies" = "无法删除已保存的 Grok cookies。";
 
+/* Misc-provider credential source option */
+"settings.credentialSource.apiOnly" = "仅 API / OAuth";
+
+/* Misc-provider credential source option */
+"settings.credentialSource.auto" = "自动";
+
+/* Misc-provider credential source option */
+"settings.credentialSource.browserOnly" = "仅浏览器";
+
+/* Misc-provider credential source option */
+"settings.credentialSource.manualOnly" = "仅手动";
+
+/* Misc-provider credential source option: do not fetch at all */
+"settings.credentialSource.off" = "关闭";
+
 /* Credential state line */
 "settings.cursorNoSession" = "没有可用的 Cursor.app 会话 — 请在下方导入 cursor.com 的 cookies。";
 
@@ -1060,6 +1144,12 @@
 
 /* Button label */
 "settings.deleteGrokCookies" = "删除 Grok 的 cookies";
+
+/* Segmented option: the percentage shows what is left. Title case because it is a picker option; quota.mode.remaining is the lowercase caption under a bar. */
+"settings.displayMode.remaining" = "剩余";
+
+/* Segmented option: the percentage shows what has been spent */
+"settings.displayMode.used" = "已用";
 
 /* Banner shown when a second client overwrote a setting this one had changed */
 "settings.externalChange.title" = "另一个 Vibe Bar 覆盖了此处的修改";
@@ -1187,6 +1277,24 @@
 /* Empty state under the add-bucket list */
 "settings.miniWindow.allBucketsIncluded" = "已知的 bucket 都已在此窗口中。";
 
+/* Mini-window strip density */
+"settings.miniWindow.density.narrow" = "紧凑";
+
+/* Caption under the Narrow strip density */
+"settings.miniWindow.density.narrowDetail" = "菜单栏的紧凑样式：同样的单元，尺寸更小。";
+
+/* Mini-window strip density */
+"settings.miniWindow.density.roomy" = "宽松";
+
+/* Caption under the Roomy strip density */
+"settings.miniWindow.density.roomyDetail" = "菜单栏的单行样式：显示全部 bucket，名称与数字并列。";
+
+/* Mini-window strip density */
+"settings.miniWindow.density.twoLines" = "双行";
+
+/* Caption under the Two Lines strip density */
+"settings.miniWindow.density.twoLinesDetail" = "菜单栏样式：bucket 两两成列堆叠，每个数字旁附名称。";
+
 /* Tooltip on the dismiss button of a built-in bucket */
 "settings.miniWindow.dismissBuiltIn" = "在厂商未返回该内置 bucket 期间将其隐藏。厂商一旦恢复返回，它便会重新出现。";
 
@@ -1198,6 +1306,48 @@
 
 /* Tooltip explaining a disabled remove button */
 "settings.miniWindow.lastCannotBeRemoved" = "最后一个迷你窗口无法移除。";
+
+/* Mini-window display style */
+"settings.miniWindow.mode.compact" = "紧凑";
+
+/* Caption under the Compact mini-window style */
+"settings.miniWindow.mode.compactDetail" = "同样的三层结构，改为竖条，适合放在屏幕角落。";
+
+/* Mini-window display style */
+"settings.miniWindow.mode.focus" = "聚焦";
+
+/* Caption under the Focus mini-window style */
+"settings.miniWindow.mode.focusDetail" = "一次只显示一个选定 bucket，尺寸更大 — 点击按设定顺序切换。";
+
+/* Mini-window display style */
+"settings.miniWindow.mode.ledger" = "清单";
+
+/* Caption under the Ledger mini-window style */
+"settings.miniWindow.mode.ledgerDetail" = "每个额度 bucket 一行 — 宽度固定，向下延伸。";
+
+/* Mini-window display style */
+"settings.miniWindow.mode.rail" = "时间轴";
+
+/* Caption under the Rail mini-window style */
+"settings.miniWindow.mode.railDetail" = "把未来 7 天画成一条补额轴，并列出即将到来的重置。";
+
+/* Mini-window display style */
+"settings.miniWindow.mode.regular" = "标准";
+
+/* Caption under the Regular mini-window style */
+"settings.miniWindow.mode.regularDetail" = "环形仪表，按 company → SubProvider → 额度组分组。";
+
+/* Mini-window display style */
+"settings.miniWindow.mode.strip" = "条带";
+
+/* Caption under the Strip mini-window style */
+"settings.miniWindow.mode.stripDetail" = "与菜单栏样式一致的细长条 — 每个 bucket 一格。";
+
+/* Mini-window display style */
+"settings.miniWindow.mode.tiles" = "磁贴";
+
+/* Caption under the Tiles mini-window style */
+"settings.miniWindow.mode.tilesDetail" = "磁贴网格，含大号数字与状态色条。";
 
 /* Segment label: edit the shared names */
 "settings.miniWindow.namesAllWindows" = "名称：全部窗口";
@@ -1319,6 +1469,27 @@
 /* Picker label for a provider's service region */
 "settings.misc.region" = "区域";
 
+/* Misc-provider region option */
+"settings.misc.region.auto" = "自动（两者都试）";
+
+/* Alibaba region option */
+"settings.misc.region.chinaMainland" = "中国大陆（cn-beijing）";
+
+/* Alibaba region option; the region id is never translated */
+"settings.misc.region.international" = "国际站（ap-southeast-1）";
+
+/* MiniMax region option */
+"settings.misc.region.minimaxChina" = "中国大陆（minimaxi.com）";
+
+/* MiniMax region option */
+"settings.misc.region.minimaxGlobal" = "全球站（minimax.io）";
+
+/* Z.ai region option */
+"settings.misc.region.zaiChina" = "中国大陆（open.bigmodel.cn）";
+
+/* Z.ai region option; the host is never translated */
+"settings.misc.region.zaiGlobal" = "全球站（api.z.ai）";
+
 /* Tooltip on the button that clears a stored AK/SK pair */
 "settings.misc.removeAkSk" = "移除已保存的 %1$@ AK/SK";
 
@@ -1393,6 +1564,24 @@
 
 /* Caption under the plan badge field */
 "settings.planBadgeDetail" = "留空则使用自动检测到的账号套餐。";
+
+/* Popover density option */
+"settings.popoverDensity.compact" = "紧凑";
+
+/* Caption under the Compact density */
+"settings.popoverDensity.compactDetail" = "间距最紧，面板最窄。";
+
+/* Popover density option */
+"settings.popoverDensity.regular" = "标准";
+
+/* Caption under the Regular density */
+"settings.popoverDensity.regularDetail" = "间距均衡 — 默认。";
+
+/* Popover density option */
+"settings.popoverDensity.spacious" = "宽松";
+
+/* Caption under the Spacious density */
+"settings.popoverDensity.spaciousDetail" = "间距宽裕，适合大屏。";
 
 /* Button that appends a blank rate card */
 "settings.pricing.addOverride" = "添加模型覆盖值";
@@ -1595,6 +1784,66 @@
 /* Button label */
 "settings.rescanCostLogs" = "重新扫描花费日志";
 
+/* Connection-health row: the local AntiGravity probe or agy CLI */
+"settings.route.antigravityLocal" = "本地 Antigravity / agy";
+
+/* Connection-health row: cookies imported from a browser */
+"settings.route.browserCookies" = "Chrome/Safari cookies";
+
+/* Connection-health row: the local CLI credential path */
+"settings.route.cli" = "CLI";
+
+/* Connection-health row: the Grok CLI's credential file. A path, never translated. */
+"settings.route.grokAuthFile" = "~/.grok/auth.json";
+
+/* Connection-health row: the OAuth credential path */
+"settings.route.oauth" = "OAuth";
+
+/* Connection-health row: cookies from the in-app login window */
+"settings.route.webViewCookies" = "WebView cookies";
+
+/* Connection-health detail: the agy CLI is installed */
+"settings.routeHealth.agyAvailable" = "agy CLI 可用";
+
+/* Connection-health detail; the filename is never translated */
+"settings.routeHealth.authFileExpired" = "auth.json 已过期";
+
+/* Connection-health detail */
+"settings.routeHealth.authFileUnreadable" = "无法读取 auth.json";
+
+/* Connection-health detail */
+"settings.routeHealth.cachedOnly" = "仅有缓存数据；无法获取实时额度";
+
+/* Connection-health detail */
+"settings.routeHealth.credentialUnreadable" = "无法读取凭据";
+
+/* Connection-health detail: a usable credential was found */
+"settings.routeHealth.credentialsAvailable" = "凭据可用";
+
+/* Connection-health detail */
+"settings.routeHealth.invalidCookie" = "cookie 数据无效";
+
+/* Connection-health detail */
+"settings.routeHealth.keychainLocked" = "Keychain 已锁定";
+
+/* Connection-health detail: the AntiGravity language server is up */
+"settings.routeHealth.lspRunning" = "本地 LSP 正在运行";
+
+/* Connection-health detail */
+"settings.routeHealth.noAntigravityData" = "没有本地 Antigravity 数据";
+
+/* Connection-health detail */
+"settings.routeHealth.noAuthFile" = "没有 auth.json";
+
+/* Connection-health detail */
+"settings.routeHealth.noCredential" = "未找到凭据";
+
+/* Connection-health detail */
+"settings.routeHealth.noSavedCookie" = "没有已保存的 cookie";
+
+/* Connection-health detail: a cookie is stored */
+"settings.routeHealth.savedInKeychain" = "已保存到 Keychain";
+
 /* Placeholder in the settings sidebar's search field */
 "settings.search" = "搜索设置";
 
@@ -1606,6 +1855,9 @@
 
 /* Settings section heading for page layout */
 "settings.section.layout" = "布局";
+
+/* Settings sidebar destination and section heading */
+"settings.section.menuBar" = "菜单栏";
 
 /* Settings section heading for the status-item watchdog */
 "settings.section.menuBarHealth" = "菜单栏健康";
@@ -1621,6 +1873,9 @@
 
 /* Settings section heading for refresh intervals. Distinct from status.overview.refreshing, which says a fetch is in flight. */
 "settings.section.refreshing" = "刷新";
+
+/* Settings sidebar destination for remote machine sync */
+"settings.section.remoteProbes" = "远程探针";
 
 /* Settings section heading for login items and the setup assistant. Distinct from settings.language.system, which is a language-picker option meaning 'follow macOS'. */
 "settings.section.system" = "系统";
@@ -1652,11 +1907,125 @@
 /* Explanation on the SpaceXAI settings page */
 "settings.spaceXAIIntro" = "SpaceXAI 页面同时包含 Grok 与 Cursor。Grok 读取 `~/.grok/auth.json` 或 grok.com 的 cookies；Cursor 先读 Cursor.app，再读 cursor.com 的 cookie 槽位。Grok Bot 提供额度，以及来自本地缓存的只读会话 — 其云端运行仍不产生 token 或花费记录。";
 
+/* Terminal preference: copy the resume command instead of running it. Terminal and iTerm2 are product names and stay as spelled. */
+"settings.terminal.copyOnly" = "复制到剪贴板";
+
 /* Picker label */
 "settings.updateChannel" = "更新通道";
 
+/* Update channel option */
+"settings.updateChannel.dev" = "预览版";
+
+/* Caption under the Dev channel option */
+"settings.updateChannel.devDetail" = "预览版本，以及全部正式版本。";
+
+/* Update channel option */
+"settings.updateChannel.main" = "正式版";
+
+/* Caption under the Main channel option */
+"settings.updateChannel.mainDetail" = "仅稳定版本。";
+
 /* Caption under the update controls */
 "settings.updateCheckDetail" = "每天检查一次所选通道，安装前会先询问。";
+
+/* Caption under an AntiGravity usage-source option */
+"settings.usageMode.antigravity.autoDetail" = "优先使用 Antigravity 应用，其次是本机安装的 agy CLI；在网页来源可用时回退到已导入的 cookies。";
+
+/* Caption under an AntiGravity usage-source option */
+"settings.usageMode.antigravity.localFirstDetail" = "优先使用 Antigravity 应用或 agy CLI；其次回退到已导入的 cookies。";
+
+/* AntiGravity usage-source option */
+"settings.usageMode.antigravity.localOnly" = "仅本地来源";
+
+/* Caption under an AntiGravity usage-source option */
+"settings.usageMode.antigravity.localOnlyDetail" = "仅使用 Antigravity 应用或本机安装的 agy CLI。";
+
+/* AntiGravity usage-source option */
+"settings.usageMode.antigravity.localThenWeb" = "先本地来源，后网页";
+
+/* Caption under an AntiGravity usage-source option */
+"settings.usageMode.antigravity.webFirstDetail" = "优先使用已导入的 cookies；其次回退到 Antigravity 应用或 agy CLI。";
+
+/* AntiGravity usage-source option */
+"settings.usageMode.antigravity.webOnly" = "仅网页";
+
+/* Caption under an AntiGravity usage-source option */
+"settings.usageMode.antigravity.webOnlyDetail" = "仅使用已导入的 cookies。在 Antigravity Cloud 端点上线前会回退到本地探测。";
+
+/* AntiGravity usage-source option */
+"settings.usageMode.antigravity.webThenLocal" = "先网页，后本地来源";
+
+/* Usage-source option: let Vibe Bar choose the order */
+"settings.usageMode.auto" = "自动";
+
+/* Caption under a Claude usage-source option */
+"settings.usageMode.claude.autoDetail" = "优先使用已保存的 claude.ai cookies；其次回退到 Claude OAuth 与 Claude Code。";
+
+/* Caption under a Claude usage-source option */
+"settings.usageMode.claude.codeFirstDetail" = "优先使用 Claude Code；其次回退到已保存的 claude.ai cookies。";
+
+/* Claude usage-source option */
+"settings.usageMode.claude.codeOnly" = "仅 Claude Code";
+
+/* Caption under a Claude usage-source option */
+"settings.usageMode.claude.codeOnlyDetail" = "仅使用本地 Claude Code 的 OAuth 凭据。";
+
+/* Claude usage-source option */
+"settings.usageMode.claude.codeThenWeb" = "先 Claude Code，后网页";
+
+/* Claude usage-source option */
+"settings.usageMode.claude.oauthCodeWeb" = "依次使用 OAuth、Claude Code、网页";
+
+/* Caption under a Claude usage-source option */
+"settings.usageMode.claude.oauthFirstDetail" = "优先使用 Claude OAuth；其次回退到 Claude Code 与已保存的 claude.ai cookies。";
+
+/* Claude usage-source option */
+"settings.usageMode.claude.oauthOnly" = "仅 OAuth";
+
+/* Caption under a Claude usage-source option */
+"settings.usageMode.claude.oauthOnlyDetail" = "仅使用 Claude OAuth 凭据。";
+
+/* Caption under a Claude usage-source option */
+"settings.usageMode.claude.webFirstDetail" = "优先使用已保存的 claude.ai cookies；其次回退到 Claude Code 与 OAuth。";
+
+/* Claude usage-source option */
+"settings.usageMode.claude.webOnly" = "仅 Claude 网页";
+
+/* Caption under a Claude usage-source option */
+"settings.usageMode.claude.webOnlyDetail" = "仅使用已保存的 claude.ai cookies。";
+
+/* Claude usage-source option */
+"settings.usageMode.claude.webThenCode" = "先 Claude 网页，后 Claude Code";
+
+/* Caption under a Codex usage-source option */
+"settings.usageMode.codex.autoDetail" = "优先使用本地 Codex CLI 凭据；其次回退到 Codex OAuth 与已保存的 OpenAI 网页 cookies。";
+
+/* Codex usage-source option */
+"settings.usageMode.codex.cliOnly" = "仅 CLI";
+
+/* Caption under a Codex usage-source option */
+"settings.usageMode.codex.cliOnlyDetail" = "仅使用本地 Codex CLI 凭据。";
+
+/* Codex usage-source option */
+"settings.usageMode.codex.cliThenOauth" = "先 CLI，后 OAuth";
+
+/* Caption under a Codex usage-source option */
+"settings.usageMode.codex.oauthFirstDetail" = "优先使用 Codex OAuth；其次回退到本地 Codex CLI 凭据与已保存的 OpenAI 网页 cookies。";
+
+/* Codex usage-source option */
+"settings.usageMode.codex.oauthOnly" = "仅 OAuth";
+
+/* Caption under a Codex usage-source option */
+"settings.usageMode.codex.oauthOnlyDetail" = "仅使用 auth.json 中的 Codex OAuth 凭据。";
+
+/* Codex usage-source option */
+"settings.usageMode.codex.oauthThenCli" = "先 OAuth，后 CLI";
+
+/* Gemini usage-source option */
+"settings.usageMode.gemini.webOnly" = "仅 Gemini Web";
+
+/* Caption under the Gemini usage-source option */
+"settings.usageMode.gemini.webOnlyDetail" = "仅读取已导入的 gemini.google.com cookies。";
 
 /* Picker label choosing where a provider's quota is read from */
 "settings.usageSource" = "用量来源";

--- a/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.strings
@@ -144,7 +144,7 @@
 "cost.fullCharts" = "%1$@ — 完整图表";
 
 /* Empty Google AI cost card body */
-"cost.gemini.emptyDetail" = "Vibe Bar 会优先从 AntiGravity 桌面端读取实时额度，其次回退到本机安装的 agy CLI。两个本地来源都刷新不了时，缓存值会标记为已过期。";
+"cost.gemini.emptyDetail" = "Vibe Bar 会优先从 AntiGravity 桌面端读取实时额度，其次回退到本机安装的 agy CLI。两个本地来源均无法刷新时，缓存值将标记为已过期。";
 
 /* Empty Google AI cost card headline */
 "cost.gemini.emptyTitle" = "暂未发现 Gemini 或 AntiGravity 的用量。";
@@ -177,10 +177,10 @@
 "cost.metric.thirtyDayTokens" = "近 30 天 token";
 
 /* All-caps metric label */
-"cost.metric.today" = "今天";
+"cost.metric.today" = "今日";
 
 /* All-caps metric label */
-"cost.metric.todayTokens" = "今天 token";
+"cost.metric.todayTokens" = "今日 token";
 
 /* All-caps metric label on the Overview cost card. English is set in caps by the copy; Chinese has no case. */
 "cost.metric.totalCost" = "总花费";
@@ -189,10 +189,10 @@
 "cost.metric.totalTokens" = "总 token";
 
 /* All-caps metric label */
-"cost.metric.yesterday" = "昨天";
+"cost.metric.yesterday" = "昨日";
 
 /* All-caps metric label */
-"cost.metric.yesterdayTokens" = "昨天 token";
+"cost.metric.yesterdayTokens" = "昨日 token";
 
 /* Scope subtitle on the Overview's combined Model Ranking card */
 "cost.modelRanking.allProvidersAllTime" = "全部厂商 · 全部时间";
@@ -243,7 +243,7 @@
 "cost.timeframe.monthShort" = "30 天";
 
 /* Cost timeframe label */
-"cost.timeframe.today" = "今天";
+"cost.timeframe.today" = "今日";
 
 /* Cost timeframe label, full form */
 "cost.timeframe.week" = "7 天";
@@ -252,7 +252,7 @@
 "cost.timeframe.weekShort" = "7 天";
 
 /* Cost timeframe label */
-"cost.timeframe.yesterday" = "昨天";
+"cost.timeframe.yesterday" = "昨日";
 
 /* Card title on a provider page */
 "cost.title" = "花费";
@@ -300,7 +300,7 @@
 "onboarding.apiKeys.hide" = "收起";
 
 /* Intro paragraph of the API-key providers step */
-"onboarding.apiKeys.intro" = "这些套餐靠 API key 或控制台 cookie 跟踪，而不是 CLI 登录。勾选你有的那些 — 勾选后会在「其他厂商」页得到一张卡片 — 展开某一行即可现在填写凭据。密钥和 cookies 都会存进你的登录 Keychain。";
+"onboarding.apiKeys.intro" = "这些套餐通过 API key 或控制台 cookie 跟踪，而非 CLI 登录。勾选已持有的项 — 勾选后将在「其他厂商」页生成一张卡片 — 展开对应行即可填写凭据。密钥与 cookies 均存入登录 Keychain。";
 
 /* Button that unfolds a provider's credential form */
 "onboarding.apiKeys.setUp" = "设置";
@@ -315,7 +315,7 @@
 "onboarding.continue" = "下一步";
 
 /* Caption under the batch import button */
-"onboarding.cookies.batchScope" = "这个按钮只覆盖上面四个套餐。下一步的控制台 cookie 套餐有各自的一键批量导入，在「设置 → 浏览器 Cookies」里。";
+"onboarding.cookies.batchScope" = "此按钮仅覆盖上述四个套餐。下一步的控制台 cookie 套餐另有一键批量导入，位于「设置 → 浏览器 Cookies」。";
 
 /* Batch import button in the setup assistant */
 "onboarding.cookies.importAll" = "立即从所有浏览器导入";
@@ -333,7 +333,7 @@
 "onboarding.cookies.importing" = "正在导入…";
 
 /* Intro paragraph of the browser-cookies step */
-"onboarding.cookies.intro" = "网页端额度 — 也就是厂商在自己网站上显示的那份 — 来自浏览器里已有的登录会话。Vibe Bar 会读取这台 Mac 上各浏览器（Chrome 及其他 Chromium 浏览器、Safari、Firefox）的 cookie 存储，只保留每个厂商真正需要的那几条，并存进你的登录 Keychain，绝不写入明文文件。首次读取浏览器的 cookie 密钥时，macOS 可能会要求授权一次。";
+"onboarding.cookies.intro" = "网页端额度 — 即厂商在其自有网站上展示的部分 — 来自浏览器中已有的登录会话。Vibe Bar 会读取本机各浏览器（Chrome 及其他 Chromium 浏览器、Safari、Firefox）的 cookie 存储，仅保留各厂商所需的少量 cookie，并存入登录 Keychain，不写入明文文件。首次读取浏览器 cookie 密钥时，macOS 可能要求授权一次。";
 
 /* Status line before any import */
 "onboarding.cookies.notImported" = "尚未导入";
@@ -345,7 +345,7 @@
 "onboarding.cookies.saved" = "cookies 已保存。";
 
 /* Caption under the batch import button */
-"onboarding.cookies.signInFirst" = "请先在浏览器里登录 chatgpt.com、claude.ai、gemini.google.com 或 grok.com — 导入只能找到已经存在的会话。没登录过的厂商不会有任何结果。";
+"onboarding.cookies.signInFirst" = "请先在浏览器中登录 chatgpt.com、claude.ai、gemini.google.com 或 grok.com — 导入只能找到已存在的会话；未登录的厂商不会返回任何结果。";
 
 /* Summary row label */
 "onboarding.done.apiKeyProviders" = "API key 厂商";
@@ -357,16 +357,16 @@
 "onboarding.done.cookieCount" = "已保存 %1$lld/%2$lld 个厂商";
 
 /* Closing line of the final step */
-"onboarding.done.footer" = "这里的每一项在设置里都能改，向导本身也在「设置 → 系统」里一键可达。";
+"onboarding.done.footer" = "此处各项均可在设置中修改，向导亦可在「设置 → 系统」中一键打开。";
 
 /* Intro line of the final step */
-"onboarding.done.intro" = "菜单栏需要的都齐了。点「完成」会打开面板并显示当前已能读到的额度，其余的会在第一次刷新时补上。";
+"onboarding.done.intro" = "菜单栏所需配置已齐备。点击「完成」将打开面板并显示当前可读取的额度，其余部分在首次刷新时补全。";
 
 /* Summary row label */
 "onboarding.done.launchAtLogin" = "开机启动";
 
 /* Summary value counting visible misc providers */
-"onboarding.done.miscCount" = "「其他厂商」页有 %1$lld 个";
+"onboarding.done.miscCount" = "「其他厂商」页 %1$lld 个";
 
 /* Summary row label */
 "onboarding.done.modelPricing" = "模型价格";
@@ -393,7 +393,7 @@
 "onboarding.pricing.fetching" = "正在获取…";
 
 /* Closing line of the pricing step */
-"onboarding.pricing.footer" = "价格单位是每百万 token 的美元数。本地覆盖值在「设置 → 模型价格」里。";
+"onboarding.pricing.footer" = "价格单位为每百万 token 的美元数。本地覆盖值位于「设置 → 模型价格」。";
 
 /* Refresh interval of exactly one hour, read inside a sentence */
 "onboarding.pricing.interval.hour" = "小时";
@@ -402,7 +402,7 @@
 "onboarding.pricing.interval.hours" = "%1$lld 小时";
 
 /* Intro paragraph of the pricing step; interval is a duration phrase */
-"onboarding.pricing.intro" = "Token 花费完全在这台 Mac 上按 agent 的会话日志计算，价格来自若干公开价目表合并后的目录 — 同一个模型出现在多处时优先级高的胜出，你自己的覆盖值优先于全部，内置表是离线兜底。目录每 %1$@在后台刷新一次；现在抓一次能让第一批费用数字用上当前价格。";
+"onboarding.pricing.intro" = "Token 花费完全在本机依据 agent 的会话日志计算，价格取自若干公开价目表合并后的目录 — 同一模型出现在多个目录时以优先级高者为准，自定义覆盖值优先于全部，内置表为离线兜底。目录每 %1$@在后台刷新一次；此刻获取可使首批费用数字采用当前价格。";
 
 /* Status line after a successful merge; when is an already-formatted date */
 "onboarding.pricing.merged" = "%1$@合并 · %2$lld 个模型";
@@ -438,25 +438,25 @@
 "onboarding.step.browserCookies.title" = "浏览器 cookies";
 
 /* Setup assistant step subtitle */
-"onboarding.step.done.subtitle" = "这里的每一项在设置里也能改。";
+"onboarding.step.done.subtitle" = "此处各项均可在设置中修改。";
 
 /* Setup assistant step name */
 "onboarding.step.done.title" = "完成";
 
 /* Setup assistant step subtitle */
-"onboarding.step.pricing.subtitle" = "费用数字背后的 token 单价从哪来。";
+"onboarding.step.pricing.subtitle" = "费用数字背后的 token 单价来源。";
 
 /* Setup assistant step name */
 "onboarding.step.pricing.title" = "模型价格";
 
 /* Setup assistant step subtitle */
-"onboarding.step.subscriptions.subtitle" = "打开你付费的套餐。";
+"onboarding.step.subscriptions.subtitle" = "启用已订阅的套餐。";
 
 /* Setup assistant step name */
 "onboarding.step.subscriptions.title" = "订阅";
 
 /* Setup assistant step subtitle */
-"onboarding.step.welcome.subtitle" = "一段话讲清 Vibe Bar 能做什么。";
+"onboarding.step.welcome.subtitle" = "用一段话说明 Vibe Bar 的功能。";
 
 /* Setup assistant step name in the rail */
 "onboarding.step.welcome.title" = "欢迎";
@@ -480,16 +480,16 @@
 "onboarding.subscriptions.codex.web" = "已保存 ChatGPT 网页 cookies — 额度将从这里读取。";
 
 /* Credential hint */
-"onboarding.subscriptions.gemini.hint" = "Gemini 的额度只能从 gemini.google.com 的 cookies 读取，没有 CLI 登录或 WebView 途径。AntiGravity 在运行时会被本地探测。";
+"onboarding.subscriptions.gemini.hint" = "Gemini 的额度只能从 gemini.google.com 的 cookies 读取，无 CLI 登录或 WebView 途径。AntiGravity 在运行时会被本地探测。";
 
 /* Credential hint; the path is never translated */
 "onboarding.subscriptions.grok.detected" = "已检测到 ~/.grok/auth.json — 额度将从这里读取。";
 
 /* Credential hint */
-"onboarding.subscriptions.grok.missing" = "还没有 ~/.grok/auth.json。运行 `grok login`，或在下方从浏览器导入 grok.com 的 cookies。";
+"onboarding.subscriptions.grok.missing" = "尚未找到 ~/.grok/auth.json。运行 `grok login`，或在下方从浏览器导入 grok.com 的 cookies。";
 
 /* Intro line of the subscriptions step */
-"onboarding.subscriptions.intro" = "打开你在用的订阅。关掉的厂商不会出现在总览和菜单栏里；之后再关掉也不会丢失凭据和历史。";
+"onboarding.subscriptions.intro" = "启用正在使用的订阅。已关闭的厂商不会出现在总览与菜单栏；之后关闭亦不会删除其凭据与历史。";
 
 /* Where this provider's quota can come from */
 "onboarding.subscriptions.productLine.claude" = "Claude Code · claude.ai 网页";
@@ -516,31 +516,31 @@
 "onboarding.welcome.cost.title" = "Token 花费";
 
 /* Closing line of the welcome step */
-"onboarding.welcome.footer" = "整个过程约两分钟。这里的每个选择之后都能在设置里改，向导本身也在「设置 → 系统」里一键可达。";
+"onboarding.welcome.footer" = "全程约两分钟。此处的每项选择均可稍后在设置中修改，向导亦可在「设置 → 系统」中一键打开。";
 
 /* Opening paragraph of the setup assistant */
-"onboarding.welcome.intro" = "Vibe Bar 常驻菜单栏，一眼就能看到每个 AI 订阅还剩多少、编码 agent 花了多少钱，以及这台 Mac 上有哪些会话和 skills。它读取 Codex、Claude Code、Gemini、Grok 这些 CLI 本就保存在本机的凭据，在你允许时再从浏览器 cookies 补上网页端额度，并且只会把这些数据发回它们各自的厂商。";
+"onboarding.welcome.intro" = "Vibe Bar 常驻菜单栏，可一览各 AI 订阅的剩余量、编码 agent 的支出，以及本机存有哪些会话与 skills。它读取 Codex、Claude Code、Gemini、Grok 等 CLI 已保存在本机的凭据，并在获得授权后从浏览器 cookies 补充网页端额度；所有数据仅发送至其来源厂商。";
 
 /* Feature row body */
-"onboarding.welcome.mcp.detail" = "你的 agent 可以通过 home 目录下的 Unix socket 向 Vibe Bar 查询额度和花费。";
+"onboarding.welcome.mcp.detail" = "agent 可通过 home 目录下的 Unix socket 向 Vibe Bar 查询额度与花费。";
 
 /* Feature row title */
 "onboarding.welcome.mcp.title" = "本地 MCP 服务";
 
 /* Feature row body */
-"onboarding.welcome.quotas.detail" = "Codex、Claude Code、Gemini、Grok，以及一排 API key 套餐，每个都带重置倒计时。";
+"onboarding.welcome.quotas.detail" = "Codex、Claude Code、Gemini、Grok，以及一系列 API key 套餐，均附带重置倒计时。";
 
 /* Feature row title */
 "onboarding.welcome.quotas.title" = "订阅额度";
 
 /* Feature row body */
-"onboarding.welcome.sessions.detail" = "在 Workbench 里浏览、搜索和整理 agent 会话与共享 skills。";
+"onboarding.welcome.sessions.detail" = "在 Workbench 中浏览、搜索并整理 agent 会话与共享 skills。";
 
 /* Feature row title */
 "onboarding.welcome.sessions.title" = "会话与 skills";
 
 /* Body of the launch-at-login step. macOS-only. */
-"platform.macos.launchAtLogin.detail" = "Vibe Bar 是没有 Dock 图标的菜单栏应用。开机启动能让额度读数和本地 MCP 服务在你登录后立刻可用；首次启用时 macOS 可能会要求你在「系统设置」中批准这个登录项。";
+"platform.macos.launchAtLogin.detail" = "Vibe Bar 是无 Dock 图标的菜单栏应用。开机启动可使额度读数与本地 MCP 服务在登录后即刻可用；首次启用时 macOS 可能要求在「系统设置」中批准该登录项。";
 
 /* Status line under the launch-at-login toggle. macOS-only. */
 "platform.macos.launchAtLogin.enabled" = "已在 macOS 登录项中启用。";
@@ -549,7 +549,7 @@
 "platform.macos.launchAtLogin.off" = "已关闭。";
 
 /* Setup assistant step subtitle. macOS-only. */
-"platform.macos.launchAtLogin.subtitle" = "登录 Mac 后菜单栏立刻显示读数。";
+"platform.macos.launchAtLogin.subtitle" = "登录 Mac 后菜单栏即刻显示读数。";
 
 /* Setup assistant step name. macOS-only: a login item has no counterpart on other clients. */
 "platform.macos.launchAtLogin.title" = "开机启动";
@@ -594,7 +594,7 @@
 "quota.bucket.resetsIn" = "距重置 %1$@";
 
 /* Empty state body; command is a CLI name such as codex or claude and is never translated */
-"quota.empty.needsLogin.detail" = "在终端里运行 `%1$@ login`，然后刷新。";
+"quota.empty.needsLogin.detail" = "在终端中运行 `%1$@ login`，然后刷新。";
 
 /* Empty state headline */
 "quota.empty.needsLogin.headline" = "需重新登录";
@@ -618,7 +618,7 @@
 "quota.empty.parseChanged.headline" = "响应格式已变化";
 
 /* Empty state body */
-"quota.empty.rateLimited.detail" = "官方 API 要求稍候，请过一会儿再试。";
+"quota.empty.rateLimited.detail" = "官方 API 要求稍候，请稍后重试。";
 
 /* Empty state headline */
 "quota.empty.rateLimited.headline" = "请求过于频繁";
@@ -633,19 +633,19 @@
 "quota.forecast.confidence.medium" = "中等置信度";
 
 /* What to do about an at-risk forecast */
-"quota.forecast.guidance.atRisk" = "放慢节奏，或把工作转到别的额度上";
+"quota.forecast.guidance.atRisk" = "降低使用速度，或将任务转移至其他额度";
 
 /* Remaining-mode guidance when there is headroom */
 "quota.forecast.guidance.available" = "目标保留 %1$lld%% · 约有 %2$lld%% 可用";
 
 /* Remaining-mode guidance for a surplus verdict */
-"quota.forecast.guidance.surplus" = "预计有约 %1$lld%% 会闲置，超出 %2$lld%% 的安全余量";
+"quota.forecast.guidance.surplus" = "预计约 %1$lld%% 将闲置，超出 %2$lld%% 的安全余量";
 
 /* Used-mode guidance when there is headroom */
 "quota.forecast.guidance.usedAvailable" = "目标用到 %1$lld%% · 约有 %2$lld%% 额度可用";
 
 /* Used-mode guidance for a surplus verdict */
-"quota.forecast.guidance.usedSurplus" = "预计有约 %1$lld%% 的额度会剩下，超出 %2$lld%% 的使用目标";
+"quota.forecast.guidance.usedSurplus" = "预计约 %1$lld%% 的额度将剩余，超出 %2$lld%% 的使用目标";
 
 /* Used-mode guidance when nothing needs saying */
 "quota.forecast.guidance.usedWithinTarget" = "仍在 %1$lld%% 的使用目标之内";
@@ -657,22 +657,22 @@
 "quota.forecast.guidance.withinTarget" = "仍在 %1$lld%% 的安全余量之内";
 
 /* One-line forecast summary */
-"quota.forecast.reset.atRisk" = "大概率在重置前用尽";
+"quota.forecast.reset.atRisk" = "很可能在重置前耗尽";
 
 /* One-line forecast summary */
 "quota.forecast.reset.enough" = "预计重置时剩余 %1$lld%%";
 
 /* One-line forecast summary */
-"quota.forecast.reset.learning" = "正在学习你的使用规律 · 约剩余 %1$lld%%";
+"quota.forecast.reset.learning" = "正在学习使用规律 · 约剩余 %1$lld%%";
 
 /* One-line forecast summary */
-"quota.forecast.reset.surplus" = "大概率有盈余 · 预计剩余 %1$lld%%";
+"quota.forecast.reset.surplus" = "预计将有盈余 · 重置时剩余 %1$lld%%";
 
 /* One-line forecast summary */
-"quota.forecast.reset.watch" = "可能不够用 · 预计剩余 %1$lld%%";
+"quota.forecast.reset.watch" = "可能不足 · 预计剩余 %1$lld%%";
 
 /* Status line under the quota bar */
-"quota.forecast.status.atRisk" = "有风险 · 大概率在重置前用尽";
+"quota.forecast.status.atRisk" = "有风险 · 很可能在重置前耗尽";
 
 /* Status line under the quota bar; value is the already-formatted forecast figure */
 "quota.forecast.status.enough" = "充足 · 预计重置时%1$@";
@@ -687,19 +687,19 @@
 "quota.forecast.status.watch" = "需关注 · 预计重置时%1$@";
 
 /* Use-up line for an at-risk verdict with no ETA */
-"quota.forecast.useUp.beforeReset" = "预计会在重置前用尽";
+"quota.forecast.useUp.beforeReset" = "预计将在重置前耗尽";
 
 /* Use-up ETA for a watch verdict, which is possible rather than certain */
-"quota.forecast.useUp.couldRunOut" = "可能在 %1$@后用尽";
+"quota.forecast.useUp.couldRunOut" = "可能在 %1$@后耗尽";
 
 /* Use-up ETA from the personal forecast */
-"quota.forecast.useUp.estimated" = "预计 %1$@后用尽";
+"quota.forecast.useUp.estimated" = "预计 %1$@后耗尽";
 
 /* Use-up line when the model does not predict exhaustion before the refill */
 "quota.forecast.useUp.lastsUntilReset" = "预计可用到重置";
 
 /* Use-up line when no ETA can be derived */
-"quota.forecast.useUp.uncertain" = "用尽时间不确定 · 可能在重置前不够用";
+"quota.forecast.useUp.uncertain" = "耗尽时间不确定 · 可能在重置前不足";
 
 /* The forecast figure in Remaining mode, used inside the status line */
 "quota.forecast.value.left" = "剩余 %1$lld%%";
@@ -735,7 +735,7 @@
 "quota.freshness.age.seconds" = "%1$lld 秒";
 
 /* Fragment inside the freshness badge saying how old the shown numbers are */
-"quota.freshness.dataAge" = "数据已 %1$@";
+"quota.freshness.dataAge" = "数据已有 %1$@";
 
 /* Tooltip on a stale freshness badge */
 "quota.freshness.defaultHelp" = "实时额度未在预期间隔内刷新。";
@@ -771,7 +771,7 @@
 "quota.group.monthly" = "每月";
 
 /* Empty state inside a quota group card */
-"quota.group.noUtilization" = "暂无使用数据 — 试试刷新。";
+"quota.group.noUtilization" = "暂无使用数据 — 可尝试刷新";
 
 /* Fallback group heading for a bucket with no group of its own */
 "quota.group.other" = "其他";
@@ -810,7 +810,7 @@
 "quota.pace.lastsUntilReset" = "可用到重置";
 
 /* Legacy elapsed-time pace ETA on a Misc provider card */
-"quota.pace.runsOutIn" = "%1$@后用尽";
+"quota.pace.runsOutIn" = "%1$@后耗尽";
 
 /* Live countdown to a bucket's refill; duration is a compact span, sometimes followed by an absolute time */
 "quota.reset.in" = "距重置 %1$@";
@@ -879,7 +879,7 @@
 "quota.resetHistory.reset.earlyClockUnchanged" = "提前补额，下次重置时间不变";
 
 /* An early refill that matches neither shape */
-"quota.resetHistory.reset.earlyUnclear" = "提前补额，切换到了别的节奏";
+"quota.resetHistory.reset.earlyUnclear" = "提前补额，重置节奏已改变";
 
 /* Spoken window name */
 "quota.resetHistory.spoken.allCycles" = "全部已记录周期";
@@ -909,19 +909,19 @@
 "quota.resetHistory.title" = "重置历史";
 
 /* Header arithmetic when nothing has closed */
-"quota.resetHistory.totals.none" = "该区间内没有完整周期";
+"quota.resetHistory.totals.none" = "该区间内无完整周期";
 
 /* Caveat when the grid draws fewer cycles than the numbers describe */
 "quota.resetHistory.truncation" = "仅显示最近 %1$lld 个周期，共 %2$lld 个";
 
 /* Header sentence when everything is being spent */
-"quota.resetHistory.verdict.clean" = "没有明显浪费 — 补回的额度用掉了 %1$@%%。";
+"quota.resetHistory.verdict.clean" = "无明显浪费 — 补回的额度已使用 %1$@%%。";
 
 /* Header sentence: lanes exist but none has closed */
 "quota.resetHistory.verdict.noCycles" = "尚无完整周期 — 额度补满时才会记录一个周期。";
 
 /* Header sentence: nothing to compare */
-"quota.resetHistory.verdict.noQuota" = "目前还没有跟踪任何按周或更长周期的额度。";
+"quota.resetHistory.verdict.noQuota" = "尚未跟踪任何按周或更长周期的额度。";
 
 /* Compact window picker label covering every recorded cycle */
 "quota.resetHistory.window.all" = "全部";
@@ -942,7 +942,7 @@
 "quota.upcoming.axisHours" = "+%1$lld 小时";
 
 /* Empty state on the resets timeline */
-"quota.upcoming.empty" = "未来 7 天内没有额度会补满。";
+"quota.upcoming.empty" = "未来 7 天内无额度补满。";
 
 /* Row caption showing the forecast remaining quota at the refill */
 "quota.upcoming.forecastAtReset" = "预计重置时剩余 %1$lld%%";
@@ -1065,7 +1065,7 @@
 "status.overview.maintenance" = "维护中";
 
 /* Overview status tile detail */
-"status.overview.needsAttention" = "需要处理";
+"status.overview.needsAttention" = "需处理";
 
 /* Overview status tile detail */
 "status.overview.operational" = "运行正常";
@@ -1179,7 +1179,7 @@
 "usage.harnessMix.byRealTokens" = "按实际 token 计";
 
 /* Empty state inside the harness mix card */
-"usage.harnessMix.empty" = "所选范围内没有 harness 流量";
+"usage.harnessMix.empty" = "所选范围内无 harness 流量";
 
 /* All-caps card title. 'Harness' is the usage-axis unit and stays as spelled. */
 "usage.harnessMix.title" = "Harness 分布";
@@ -1272,7 +1272,7 @@
 "usage.mix.tokenFlow.title" = "Token 流向";
 
 /* Empty state body explaining the All chip */
-"usage.noHarnessSelected.detail" = "「全部 harness」是一个开关：再点一次即可把所有 harness 放回查询。";
+"usage.noHarnessSelected.detail" = "「全部 harness」是一个开关：再次点击即可将全部 harness 重新纳入查询。";
 
 /* Empty state when the harness filter excludes everything. 'harness' is the usage-axis unit and stays as spelled. */
 "usage.noHarnessSelected.title" = "未选择任何 harness — 请在上方选择";
@@ -1455,13 +1455,13 @@
 "usage.trend.tokensChartLabel" = "Token 用量随时间变化";
 
 /* Heatmap title on the Overview, covering every provider at once */
-"usage.whenYouUse.everything" = "你什么时候在用";
+"usage.whenYouUse.everything" = "整体使用时段";
 
 /* Heatmap title on the Google AI page */
-"usage.whenYouUse.googleAI" = "你什么时候用 Google AI";
+"usage.whenYouUse.googleAI" = "Google AI 使用时段";
 
 /* Heatmap title on the SpaceXAI page */
-"usage.whenYouUse.spaceXAI" = "你什么时候用 SpaceXAI";
+"usage.whenYouUse.spaceXAI" = "SpaceXAI 使用时段";
 
 /* Tooltip on the Workbench header button that switches the window to dark */
 "workbench.appearance.useDark" = "使用深色外观";

--- a/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.strings
@@ -662,6 +662,36 @@
 /* Subtitle under the Overview page header */
 "popover.header.overviewSubtitle" = "全部厂商 · 额度与花费";
 
+/* Empty-state title while a sync is in flight */
+"popover.machines.checking" = "正在检查 Relay…";
+
+/* Toggle on a remote machine card */
+"popover.machines.includeInTotals" = "计入总计";
+
+/* Tooltip on the include-in-totals toggle */
+"popover.machines.includeInTotalsHelp" = "把这台机器解密后的用量计入本 Core 的总览与厂商花费页";
+
+/* A source label followed by its status; both halves arrive already localized */
+"popover.machines.labelWithStatus" = "%1$@ · %2$@";
+
+/* Empty-state title when the Relay is connected but nothing has arrived */
+"popover.machines.noData" = "暂无远程机器数据";
+
+/* Empty-state body on the Machines page */
+"popover.machines.noDataDetail" = "Relay 已连接。探针会在其首个加密批次被解密并导入后出现。";
+
+/* Empty-state title on the Machines page */
+"popover.machines.notConfigured" = "尚未配置远程 Core";
+
+/* Empty-state body on the Machines page */
+"popover.machines.notConfiguredDetail" = "先创建 Core 描述文件，再签发工作区范围的 Relay 凭据，然后导入已签名的配置文件。本机无需开放任何入站端口。";
+
+/* The last imported batch's sequence number on a machine card; the number is raw */
+"popover.machines.sequence" = "序号 %1$@";
+
+/* Metric label on a remote machine card */
+"popover.machines.thirtyDayCost" = "近 30 天花费";
+
 /* Tooltip on the Google AI page's refresh button; the SubProvider names are never translated */
 "popover.refreshGoogleAI" = "刷新 Gemini Web + AntiGravity";
 
@@ -1771,6 +1801,60 @@
 
 /* Sync status line: a translated title and the raw status code */
 "settings.remote.statusWithCode" = "%1$@ · %2$@";
+
+/* Remote sync status title for HTTP 429/503 */
+"settings.remote.sync.busy" = "Relay 暂时繁忙";
+
+/* Remote sync status title */
+"settings.remote.sync.connectionFailed" = "Relay 连接中断";
+
+/* Remote sync status title */
+"settings.remote.sync.hostLookupFailed" = "无法解析 Relay 主机";
+
+/* Remote sync status title */
+"settings.remote.sync.invalidResponse" = "Relay 返回了预期之外的响应";
+
+/* Remote sync status detail for an offline or DNS failure */
+"settings.remote.sync.networkDetail" = "请检查本机的网络或代理设置；已有的机器数据仍然可用。";
+
+/* Remote sync status title. The error code beside it is a machine-readable identifier and stays English. */
+"settings.remote.sync.offline" = "本机当前离线";
+
+/* Remote sync status title for HTTP 401/403 */
+"settings.remote.sync.rejected" = "Relay 拒绝了访问";
+
+/* Remote sync status detail for HTTP 401/403 */
+"settings.remote.sync.rejectedDetail" = "工作区凭据可能已被吊销，请在设置中重新连接本 Core。";
+
+/* Remote sync status detail for a transient transport failure */
+"settings.remote.sync.retryDetail" = "已有的机器数据仍然可用，Vibe Bar 会自动重试。";
+
+/* Remote sync status title */
+"settings.remote.sync.secureConnectionFailed" = "Relay 安全连接失败";
+
+/* Remote sync status title */
+"settings.remote.sync.sequenceGap" = "探针历史存在序号缺口";
+
+/* Remote sync status detail */
+"settings.remote.sync.sequenceGapDetail" = "Relay 流中缺少一个探针批次，因此后续批次未被导入。";
+
+/* Remote sync status title */
+"settings.remote.sync.timeout" = "Relay 连接超时";
+
+/* Remote sync status title */
+"settings.remote.sync.transportFailed" = "Relay 传输失败";
+
+/* Remote sync status title for a code this build does not recognize. A new Relay error code must still render a sentence. */
+"settings.remote.sync.unknown" = "远程同步需要处理";
+
+/* Remote sync status detail for an unrecognized code */
+"settings.remote.sync.unknownDetail" = "本地用量未被删除。可立即重试，或在「远程 Core」设置中查看错误码。";
+
+/* Remote sync status title for an invalid signature or unauthorized producer */
+"settings.remote.sync.unverifiedProbe" = "有探针无法通过校验";
+
+/* Remote sync status detail */
+"settings.remote.sync.unverifiedProbeDetail" = "当前工作区名单未授权收到的某个批次。";
 
 /* Button that pulls remote batches immediately */
 "settings.remote.syncNow" = "立即同步";

--- a/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.strings
@@ -2,14 +2,23 @@
    Resources/i18n/zh-Hans.json. Do not edit: LocalizationCatalogTests
    regenerates this file and fails on a diff. */
 
+/* Button that appends an entry to a list */
+"common.add" = "添加";
+
 /* Filter chip or menu entry that selects every item. */
 "common.all" = "全部";
+
+/* Picker option and field placeholder meaning 'let Vibe Bar decide' */
+"common.auto" = "自动";
 
 /* Button that abandons an action in progress. */
 "common.cancel" = "取消";
 
 /* Button that empties a search field or resets a filter. */
 "common.clear" = "清除";
+
+/* Confirmation shown in place of the Copy button */
+"common.copied" = "已复制";
 
 /* Button that copies the adjacent value to the clipboard. */
 "common.copy" = "复制";
@@ -65,6 +74,9 @@
 /* Button that closes a sheet or leaves an editing mode. */
 "common.done" = "完成";
 
+/* Tooltip on a drag handle */
+"common.dragToReorder" = "拖动可重新排序";
+
 /* Compact countdown, whole days only */
 "common.duration.days" = "%1$lld 天";
 
@@ -86,6 +98,9 @@
 /* Countdown that has reached zero */
 "common.duration.now" = "现在";
 
+/* Field label for a user-chosen name */
+"common.name" = "名称";
+
 /* A toggle's state, read as a value in a summary row */
 "common.off" = "已关闭";
 
@@ -101,14 +116,26 @@
 /* A whole percentage. Both languages use the sign the same way; the key exists so a language that does not can move it. */
 "common.percent" = "%1$lld%%";
 
+/* Picker label for choosing a provider */
+"common.provider" = "厂商";
+
 /* Generic refresh button and tooltip */
 "common.refresh" = "刷新";
 
 /* Tooltip on a per-card refresh button */
 "common.refreshSection" = "刷新此区块";
 
+/* Button that takes an item out of a list */
+"common.remove" = "移除";
+
 /* Button on a failure state */
 "common.retry" = "重试";
+
+/* Button that retries immediately, skipping a cooldown */
+"common.retryNow" = "立即重试";
+
+/* Button that commits an edited value */
+"common.save" = "保存";
 
 /* Freshness line under five seconds old */
 "common.updated.justNow" = "刚刚更新";
@@ -968,6 +995,99 @@
 /* Inline error row; reason is a provider message and is not translated */
 "quota.update.failed" = "更新失败：%1$@";
 
+/* Hint under the Antigravity source picker */
+"settings.antigravityCookieEnabled" = "Antigravity 的 cookie 导入已启用 — 请先在 antigravity.google 登录。";
+
+/* Hint under the Antigravity source picker */
+"settings.antigravityLocalOnly" = "Antigravity 读取本机运行的语言服务。cookie 导入将等到 Antigravity Cloud 端点上线后再启用。";
+
+/* Picker label */
+"settings.antigravitySource" = "Antigravity 来源";
+
+/* Current version line; version is a raw version string */
+"settings.appVersion" = "Vibe Bar %1$@";
+
+/* Badge on the version currently compiled in */
+"settings.bundled" = "内置";
+
+/* Button that probes a company's credentials; company is an L1 company name and is never translated */
+"settings.checkConnections" = "检查 %1$@ 连接";
+
+/* Button label */
+"settings.checkForUpdates" = "检查更新…";
+
+/* Button that queries GitHub for a newer agent-session-kit */
+"settings.checkKitUpdates" = "检查组件更新";
+
+/* Progress line while an update check runs */
+"settings.checkingGitHub" = "正在向 github.com 查询最新版本…";
+
+/* Button label */
+"settings.clearCostData" = "清除花费数据";
+
+/* Heading over the per-provider connection rows */
+"settings.connectionHealth" = "连接状态";
+
+/* Intro under the Cost Data heading */
+"settings.costDataIntro" = "花费根据 ~/.codex/sessions 与 ~/.claude/projects 下的本地 CLI 会话 JSONL 日志计算。网页端与桌面端用量不计入。";
+
+/* Error under the delete-cookies button */
+"settings.couldNotDeleteCookies" = "无法删除已保存的 cookies。";
+
+/* Error line */
+"settings.couldNotDeleteGeminiCookies" = "无法删除已保存的 Gemini cookies。";
+
+/* Error line */
+"settings.couldNotDeleteGrokCookies" = "无法删除已保存的 Grok cookies。";
+
+/* Credential state line */
+"settings.cursorNoSession" = "没有可用的 Cursor.app 会话 — 请在下方导入 cursor.com 的 cookies。";
+
+/* Credential state line */
+"settings.cursorSessionDetected" = "已检测到 Cursor.app 的登录会话";
+
+/* Row label */
+"settings.cursorSource" = "Cursor 来源";
+
+/* Value beside the Cursor source row */
+"settings.cursorSourceValue" = "Cursor.app → 网页";
+
+/* Button that clears a provider's stored cookies */
+"settings.deleteCookies" = "删除 cookies";
+
+/* Button label */
+"settings.deleteGeminiCookies" = "删除 Gemini 的 cookies";
+
+/* Button label */
+"settings.deleteGrokCookies" = "删除 Grok 的 cookies";
+
+/* Banner shown when a second client overwrote a setting this one had changed */
+"settings.externalChange.title" = "另一个 Vibe Bar 覆盖了此处的修改";
+
+/* Confirmation line */
+"settings.geminiCookiesSaved" = "Gemini 的 cookies 已保存。";
+
+/* Explanation on the Google AI settings page */
+"settings.geminiShared" = "Gemini 与 Antigravity 共用同一份 Google AI 订阅额度。网页端仅支持 cookie 导入，没有 WebView 登录途径。";
+
+/* Row label for where Gemini quota is read from */
+"settings.geminiSource" = "Gemini 来源";
+
+/* Credential state line; the path is never translated */
+"settings.grokAuthDetected" = "已检测到 ~/.grok/auth.json";
+
+/* Confirmation line */
+"settings.grokCookiesSaved" = "Grok 的 cookies 已保存。";
+
+/* Picker label for the retention window */
+"settings.keepHistory" = "保留历史";
+
+/* Caption under the retention picker */
+"settings.keepHistoryDetail" = "适用于花费历史与订阅填充历史。";
+
+/* Description of the bundled agent-session-kit component */
+"settings.kitDetail" = "会话发现、harness 命名与 MCP 传输。独立仓库，固定到确切 tag 并编译进本次构建。";
+
 /* Caption under the language picker in Settings */
 "settings.language.caption" = "Vibe Bar 默认跟随 macOS 语言，也可以在此单独指定。厂商、模型与 harness 名称保持原始拼写。";
 
@@ -976,6 +1096,576 @@
 
 /* Settings row label for the in-app language override */
 "settings.language.title" = "语言";
+
+/* Toggle label */
+"settings.mcp.allowRefresh" = "允许 agent 刷新额度";
+
+/* Caption under the refresh toggle; quota.refresh is an MCP tool name and is never translated */
+"settings.mcp.allowRefreshDetail" = "开启后，agent 可以让 Vibe Bar 重新向厂商拉取额度。强制刷新限流为每 %1$lld 秒一次。关闭后只读工具照常可用，quota.refresh 会报告刷新已禁用。";
+
+/* Toggle label */
+"settings.mcp.allowSkills" = "允许 agent 安装 skills";
+
+/* Caption under the skills toggle; skills.install is an MCP tool name */
+"settings.mcp.allowSkillsDetail" = "开启后，agent 可以调用 skills.install，从 GitHub 仓库或本地文件夹添加 skill。它走的是与 Workbench → Skills 相同的管理流程，因此只写入 ~/.agents/skills 以及 Vibe Bar 管理的 agent skills 目录 — 绝不覆盖已被其他 skill 占用的文件夹。关闭后该工具会报告安装已禁用。";
+
+/* Caption on a copyable config snippet; the path is never translated */
+"settings.mcp.appendCodexConfig" = "追加到 ~/.codex/config.toml。";
+
+/* Sub-heading over the setup instructions */
+"settings.mcp.connectAgent" = "接入一个 agent";
+
+/* Row label for the live connection count */
+"settings.mcp.connectedClients" = "已连接客户端";
+
+/* Toggle label */
+"settings.mcp.enable" = "启用本地 MCP 服务";
+
+/* Intro paragraph of the MCP settings section */
+"settings.mcp.intro" = "Vibe Bar 可通过 MCP 向编码 agent 提供本机的额度、用量、花费与本地会话。服务监听 home 目录下的 Unix domain socket — 不开放网络端口，也不创建 token：socket 的文件权限即访问控制。";
+
+/* Row label for when a client last spoke to the server */
+"settings.mcp.lastActivity" = "最近一次客户端活动";
+
+/* MCP server state: the socket is accepting connections */
+"settings.mcp.listening" = "监听中";
+
+/* Intro to the manual client configuration snippets; flag is a command-line flag and is never translated */
+"settings.mcp.manualIntro" = "也可手动配置客户端。所有客户端运行同一条命令 — Vibe Bar 自身的可执行文件加 %1$@，它把 stdin/stdout 桥接到上面的 socket。";
+
+/* Caption on a copyable config snippet */
+"settings.mcp.mergeCursorConfig" = "合并到 ~/.cursor/mcp.json。";
+
+/* Warning shown when the app runs from a build directory; path is a filesystem path */
+"settings.mcp.movePrompt" = "Vibe Bar 正从 %1$@ 运行。保存客户端配置前请先移动到 /Applications，否则下次重新构建后配置会失效。";
+
+/* MCP server state: the socket is closed */
+"settings.mcp.notListening" = "未监听";
+
+/* Heading for the generic client snippet */
+"settings.mcp.otherStdioClient" = "其他 stdio 客户端";
+
+/* Caption on the generic client snippet */
+"settings.mcp.otherStdioDetail" = "给客户端自己的 mcpServers 映射加一条。";
+
+/* Caption over the one-line setup prompt */
+"settings.mcp.quickestPath" = "最快的方式：把这段粘贴给任意 agent，让它自行完成配置、安装配套 skill 并验证连接。";
+
+/* Caption closing the MCP permissions section */
+"settings.mcp.readOnlyDetail" = "agent 能访问的其余内容均为只读：额度、token 用量、花费、厂商状态、生效模型价格，以及本地会话索引（标题、项目，以及在开启会话正文索引时的消息摘录）。凭据、cookies 与组织 id 从不暴露，邮箱地址会被掩码。";
+
+/* Caption on a copyable shell command */
+"settings.mcp.runInTerminal" = "在终端中运行。";
+
+/* Label for the copyable one-line prompt */
+"settings.mcp.setupPrompt" = "Agent 配置提示词";
+
+/* Caption under the setup prompt */
+"settings.mcp.setupPromptDetail" = "一行内容，适用于任何能抓取 URL 的 agent。";
+
+/* Row label for the socket path. The term stays as spelled. */
+"settings.mcp.socket" = "Socket";
+
+/* Caption under the MCP status rows. The quoted phrase is the message another tool prints and stays in English. */
+"settings.mcp.socketLifetime" = "socket 仅在 Vibe Bar 运行时存在。退出后，下方配置的 agent 会报告 “Vibe Bar is not running”，这是预期行为。";
+
+/* Row label for whether the MCP socket is listening. Distinct from status.overview.title, which is a provider's service status. */
+"settings.mcp.status" = "状态";
+
+/* Settings section heading for the local MCP server */
+"settings.mcp.title" = "MCP 服务";
+
+/* Sub-heading over the permission toggles */
+"settings.mcp.whatAgentsMayDo" = "agent 的权限范围";
+
+/* Shown when the watchdog is not running */
+"settings.menuBarHealthUnavailable" = "本进程未接入菜单栏健康监控。";
+
+/* Button in the mini windows settings section */
+"settings.miniWindow.add" = "添加迷你窗口";
+
+/* Empty state under the add-bucket list */
+"settings.miniWindow.allBucketsIncluded" = "已知的 bucket 都已在此窗口中。";
+
+/* Tooltip on the dismiss button of a built-in bucket */
+"settings.miniWindow.dismissBuiltIn" = "在厂商未返回该内置 bucket 期间将其隐藏。厂商一旦恢复返回，它便会重新出现。";
+
+/* Tooltip on the dismiss button of a runtime-discovered bucket */
+"settings.miniWindow.forgetDiscovered" = "忘记这个已发现的 bucket — 将其从列表以及所有选中它的窗口中移除。";
+
+/* Tooltip on a style toggle; mode is a display-mode name */
+"settings.miniWindow.includeStyle" = "将%1$@纳入双击循环";
+
+/* Tooltip explaining a disabled remove button */
+"settings.miniWindow.lastCannotBeRemoved" = "最后一个迷你窗口无法移除。";
+
+/* Segment label: edit the shared names */
+"settings.miniWindow.namesAllWindows" = "名称：全部窗口";
+
+/* Segment label: edit only this display style's overrides; mode is a display-mode name */
+"settings.miniWindow.namesThisStyle" = "仅此处的%1$@";
+
+/* Segment label: edit only this window's name overrides */
+"settings.miniWindow.namesThisWindow" = "仅“%1$@”";
+
+/* Empty state under the field list */
+"settings.miniWindow.noFieldsSelected" = "未选择任何字段 — 请在上方勾选。";
+
+/* Caption over the list of buckets not yet in this window */
+"settings.miniWindow.notInWindow" = "不在“%1$@”中 — 勾选 bucket 即可加入。适配器在运行时发现的 bucket 会自动出现在这里；灰显的行表示已记录但不在账号当前响应中，✕ 可将其忽略，直到厂商重新返回。";
+
+/* Badge on a remote machine's row in the mini window preview */
+"settings.miniWindow.offline" = "离线";
+
+/* Button that shows or hides a mini window */
+"settings.miniWindow.openClose" = "打开 / 关闭";
+
+/* Caption over the per-style name fields */
+"settings.miniWindow.overridesStyle" = "仅对此窗口的%1$@样式生效的覆盖。留空则先继承窗口名称，再继承共享名称 — 以占位文本显示。";
+
+/* Caption over the per-window name fields */
+"settings.miniWindow.overridesWindow" = "仅对此窗口生效的名称覆盖。留空则继承共享名称 — 以占位文本显示。";
+
+/* Ordinal badge showing a field's place in the order */
+"settings.miniWindow.position" = "%1$lld";
+
+/* Tooltip on a row's remove control */
+"settings.miniWindow.removeFromWindow" = "从此窗口移除";
+
+/* Tooltip on the remove button */
+"settings.miniWindow.removeHelp" = "移除此迷你窗口";
+
+/* Picker label for the mini window's row density */
+"settings.miniWindow.stripDensity" = "条带密度";
+
+/* Caption over the style cycle picker */
+"settings.miniWindow.styleCycle" = "双击窗口可循环切换样式。点选某个样式即将其纳入循环 — 徽标表示它在循环中的次序。未选任何样式即表示按此顺序使用全部样式。";
+
+/* Tooltip on the open/close button */
+"settings.miniWindow.toggleHelp" = "在屏幕上显示或隐藏此迷你窗口";
+
+/* Caption over the mini window field tree */
+"settings.miniWindow.treeDetail" = "窗口的一棵树 — 按其折叠方式分组（company → SubProvider → 额度组 → bucket）。拖动行可重新排序，✕ 可移除，任一层级均可就地重命名。第一个字段渲染在最左（或最上）。";
+
+/* Field placeholder for the AK half of an AK/SK pair */
+"settings.misc.accessKeyId" = "Access Key ID（AKLT…）";
+
+/* Confirmation under an AK/SK field */
+"settings.misc.akSkSaved" = "AK/SK 已保存到 Keychain。";
+
+/* Confirmation under a credential field */
+"settings.misc.apiKeySaved" = "API key 已保存到 Keychain。";
+
+/* Tooltip on the button that forgets a stored workspace id */
+"settings.misc.clearWorkspace" = "清除已保存的工作区";
+
+/* Tooltip on the button that adds a second instance of a provider */
+"settings.misc.clone" = "复制 %1$@";
+
+/* Console link row; title is the provider's own page name */
+"settings.misc.consoleLink" = "%1$@ →";
+
+/* Picker label for a provider's edition (Team, Personal, …) */
+"settings.misc.edition" = "版本";
+
+/* Hint under the GitHub sign-in row */
+"settings.misc.githubSignInHint" = "通过 GitHub 设备流程登录。";
+
+/* Confirmation under the GitHub sign-in row */
+"settings.misc.githubTokenSaved" = "GitHub 设备令牌已保存到 Keychain。";
+
+/* Caption under the cookie import button */
+"settings.misc.importDetail" = "添加或刷新找到的第一个已登录浏览器配置；已导入的配置会保留叠加，该厂商的额度取上方所有槽位的平均值。每个 Chromium 系浏览器，macOS 可能会要求输入一次登录钥匙串密码。";
+
+/* Hint under the Kiro row; the commands are never translated */
+"settings.misc.kiroHint" = "运行 `kiro-cli login`，之后 Vibe Bar 会探测 `kiro-cli chat --no-interactive /usage`。";
+
+/* Shown when a provider has no cookie import path */
+"settings.misc.noCookieSpec" = "%1$@ 未注册 cookie 规格。";
+
+/* Empty state in the cookie slot list */
+"settings.misc.noCookiesYet" = "尚未导入 cookies — 可从浏览器导入或在下方粘贴。";
+
+/* Button that runs a local CLI probe */
+"settings.misc.probe" = "探测";
+
+/* Field placeholder */
+"settings.misc.prompt.copilotHost" = "GitHub Enterprise 主机（可选，例如 github.example.com）";
+
+/* Field placeholder */
+"settings.misc.prompt.dashscope" = "粘贴 DashScope API key（sk-...）— 可选";
+
+/* Field placeholder */
+"settings.misc.prompt.kilo" = "粘贴 Kilo API key（可选）";
+
+/* Field placeholder */
+"settings.misc.prompt.minimax" = "粘贴 MiniMax Token Plan API key（sk-cp-... 或 MINIMAX_CODING_API_KEY）";
+
+/* Field placeholder */
+"settings.misc.prompt.openRouter" = "粘贴 OpenRouter API key（sk-or-v1-...）";
+
+/* Field placeholder */
+"settings.misc.prompt.openRouterHost" = "OpenRouter API URL（可选，默认为 https://openrouter.ai/api/v1）";
+
+/* Field placeholder */
+"settings.misc.prompt.warp" = "粘贴 Warp API key（wk-...）";
+
+/* Field placeholder */
+"settings.misc.prompt.workspace" = "工作区 ID 或 URL（可选，wrk_... 或 /workspace/wrk_.../go）";
+
+/* Field placeholder; the key prefix is a format example */
+"settings.misc.prompt.zai" = "粘贴 Z.ai API key（zai-...）";
+
+/* Picker label for a provider's service region */
+"settings.misc.region" = "区域";
+
+/* Tooltip on the button that clears a stored AK/SK pair */
+"settings.misc.removeAkSk" = "移除已保存的 %1$@ AK/SK";
+
+/* Tooltip on the button that clears a stored key */
+"settings.misc.removeApiKey" = "移除已保存的 %1$@ API key";
+
+/* Tooltip on a cookie slot's delete button */
+"settings.misc.removeCookieSlot" = "移除此 cookie 槽位";
+
+/* Tooltip on the button that deletes a cloned instance */
+"settings.misc.removeCopy" = "移除此 %1$@ 副本";
+
+/* Destructive button in the remove-copy dialog */
+"settings.misc.removeCopyButton" = "移除副本";
+
+/* Confirmation dialog body */
+"settings.misc.removeCopyDetail" = "其保存的凭据会从 Keychain 中删除 — 包括 API key 或 AK/SK 以及全部已导入的 cookie 槽位。此操作不可撤销。";
+
+/* Confirmation dialog title */
+"settings.misc.removeCopyTitle" = "是否移除此 %1$@ 副本？";
+
+/* Tooltip on the button that clears the GitHub token */
+"settings.misc.removeGithubToken" = "移除已保存的 GitHub 设备令牌";
+
+/* Tooltip on the rename button of a cloned instance */
+"settings.misc.rename" = "重命名此副本";
+
+/* Field placeholder for the SK half of an AK/SK pair. The term is the provider's own and stays as spelled. */
+"settings.misc.secretAccessKey" = "Secret Access Key";
+
+/* Button that starts a device-flow sign-in */
+"settings.misc.signIn" = "登录";
+
+/* Button that opens a WebView login */
+"settings.misc.signInViaWeb" = "通过网页登录";
+
+/* Caption under the Tencent token plan row */
+"settings.misc.tencentTokenPlanNote" = "个人版 Token Plan 目前仅在中国大陆（cn-beijing）提供。复制此行即可同时跟踪团队版与个人版。";
+
+/* Picker label for a provider's plan variant */
+"settings.misc.variant" = "变体";
+
+/* Button label while a device-flow sign-in is pending */
+"settings.misc.waiting" = "等待中…";
+
+/* Caption under the workspace field */
+"settings.misc.workspaceNote" = "仅当账号拥有多个工作区时才需要填写 — 否则 Vibe Bar 使用找到的第一个。";
+
+/* Provider state: credentials are missing */
+"settings.needsSetup" = "需配置";
+
+/* Connection state before any probe has run */
+"settings.notChecked" = "未检查";
+
+/* Line under the update-check button */
+"settings.notCheckedYet" = "尚未检查。在主动发起前不会请求任何内容。";
+
+/* Picker label */
+"settings.openRefreshCooldown" = "打开刷新的最小间隔";
+
+/* Caption under the cooldown picker */
+"settings.openRefreshDetail" = "每个间隔周期内，打开面板最多刷新一次全部可见厂商。";
+
+/* Link to a company's public status page */
+"settings.openStatusPage" = "打开 %1$@ 状态页";
+
+/* Picker label choosing between remaining and used */
+"settings.percentShows" = "百分比显示";
+
+/* Field label for a user-chosen plan label override */
+"settings.planBadge" = "套餐标签";
+
+/* Caption under the plan badge field */
+"settings.planBadgeDetail" = "留空则使用自动检测到的账号套餐。";
+
+/* Button that appends a blank rate card */
+"settings.pricing.addOverride" = "添加模型覆盖值";
+
+/* Disclosure heading over the threshold rate fields */
+"settings.pricing.advancedTiers" = "高级分档";
+
+/* Detail beside the local-overrides source */
+"settings.pricing.alwaysWins" = "始终优先";
+
+/* Name of the lowest-priority price source */
+"settings.pricing.bundledFallback" = "内置兜底";
+
+/* Rate field label */
+"settings.pricing.cacheReadAbove" = "阈值以上缓存读取";
+
+/* Rate field label */
+"settings.pricing.cacheWriteAbove" = "阈值以上缓存写入";
+
+/* Tooltip on a rate card's delete button */
+"settings.pricing.deleteOverride" = "删除覆盖值";
+
+/* Placeholder in the model-name field of a rate card */
+"settings.pricing.exactModelName" = "模型名称（精确匹配）";
+
+/* Rate field label: the multiplier applied to a fast tier */
+"settings.pricing.fastMultiplier" = "快速档倍率";
+
+/* Rate field label for input tokens beyond the threshold */
+"settings.pricing.inputAbove" = "阈值以上输入";
+
+/* Intro under the Model Pricing heading */
+"settings.pricing.intro" = "目录在后台刷新。同一厂商与模型名出现多次时，靠前的条目优先。";
+
+/* Settings section heading over the user's own rate cards */
+"settings.pricing.localOverrides" = "本地覆盖值";
+
+/* Name of the highest-priority price source */
+"settings.pricing.localOverridesName" = "本地覆盖值";
+
+/* Empty state in the overrides list */
+"settings.pricing.noOverrides" = "暂无本地覆盖值。";
+
+/* Ordinal badge beside a price source */
+"settings.pricing.number" = "%1$lld";
+
+/* Detail beside the bundled source */
+"settings.pricing.offlineFloor" = "离线下限";
+
+/* Rate field label for output tokens beyond the threshold */
+"settings.pricing.outputAbove" = "阈值以上输出";
+
+/* Intro under the Local overrides heading */
+"settings.pricing.overridesIntro" = "价格单位为每百万 token 的美元数。厂商未公布缓存价格时，相应字段留空。";
+
+/* Settings section heading over the price-source list */
+"settings.pricing.priorityHealth" = "优先级与来源状态";
+
+/* Rate field label: input tokens */
+"settings.pricing.rateInput" = "输入";
+
+/* Rate field label: output tokens */
+"settings.pricing.rateOutput" = "输出";
+
+/* Button that fetches price catalogs immediately */
+"settings.pricing.refreshNow" = "立即刷新";
+
+/* Button label while a price refresh runs */
+"settings.pricing.refreshing" = "正在刷新…";
+
+/* Field label: the token count above which the higher rates apply */
+"settings.pricing.thresholdTokens" = "分档阈值 token 数";
+
+/* Footer showing when the bundled price table was built; date is a raw stamp */
+"settings.pricingDataDate" = "价格数据：%1$@";
+
+/* Body of the Privacy section */
+"settings.privacyDetail" = "token 从本地 CLI 凭据读取。已保存的 OpenAI 与 Claude 网页 cookies 存放在 macOS Keychain 中，按浏览器与 WebView 来源分开。~/.vibebar/cookies 下的旧版明文 cookie 文件会迁移一次并删除。设置、额度缓存与花费汇总保留在 ~/.vibebar 下。";
+
+/* Toggle label */
+"settings.privacyMode" = "隐私模式";
+
+/* Caption under the privacy toggle */
+"settings.privacyModeDetail" = "隐私模式不将花费数据写入磁盘，并清除本地花费历史、快照与扫描缓存。";
+
+/* Provider state: credentials are usable */
+"settings.ready" = "就绪";
+
+/* Picker label for a background refresh interval */
+"settings.refreshEvery" = "刷新间隔";
+
+/* Toggle label */
+"settings.refreshOnPopoverOpen" = "打开面板时刷新";
+
+/* Link label */
+"settings.releaseNotes" = "发行说明";
+
+/* Settings section heading. Core is the product term for this Mac's aggregator. */
+"settings.remote.core" = "远程 Core";
+
+/* Settings section heading */
+"settings.remote.costAggregation" = "花费汇总";
+
+/* Intro under the cost aggregation heading */
+"settings.remote.costAggregationIntro" = "选择哪些远程机器计入本机的花费与 token 总计。选择与汇总均在本 Core 完成；Relay 不会看到明文用量。";
+
+/* Toggle that reveals the control-centre URL field */
+"settings.remote.differentControlCenter" = "使用其他控制台";
+
+/* Button that abandons a pending join */
+"settings.remote.discard" = "丢弃";
+
+/* Confirmation dialog body */
+"settings.remote.discardPendingDetail" = "该配对码已失效，且工作区仍将本机视为其 Core。如需重新加入，请先在网页控制台吊销本机，再创建新的配对码。";
+
+/* Confirmation dialog title */
+"settings.remote.discardPendingTitle" = "是否丢弃这次待完成的加入？";
+
+/* Settings section heading, and the destructive button in its dialog */
+"settings.remote.disconnect" = "断开连接";
+
+/* Button that unpairs this Mac */
+"settings.remote.disconnectButton" = "断开与工作区的连接…";
+
+/* Confirmation dialog body */
+"settings.remote.disconnectDetail" = "日后重新连接需要新的配对码或配置文件。";
+
+/* Explanation under the Disconnect heading */
+"settings.remote.disconnectIntro" = "断开会从 Keychain 移除本机的 Relay 凭据及其工作区绑定。在 Relay 端吊销之前，探针仍会继续上传。已解密的用量保留在本地账本中。";
+
+/* Confirmation dialog title */
+"settings.remote.disconnectTitle" = "是否断开与该工作区的连接？";
+
+/* Button that writes this Mac's public identity to a file */
+"settings.remote.exportIdentity" = "导出 Core 身份…";
+
+/* Button that reads a provisioning file */
+"settings.remote.importProvisioning" = "导入配置文件…";
+
+/* Button that submits a pairing code */
+"settings.remote.join" = "加入";
+
+/* Explanation above the pairing-code field; device is the Mac's name */
+"settings.remote.joinIntro" = "在 Vibe Bar 控制台创建 Core 配对码，然后粘贴到此处。本机将以“%1$@”的名义加入。";
+
+/* Heading over the pairing-code field */
+"settings.remote.joinWithCode" = "用配对码加入";
+
+/* Row label for the last sync time */
+"settings.remote.lastSync" = "最近同步";
+
+/* Second line of a remote machine row; platform and version are raw values */
+"settings.remote.machineDetail" = "%1$@ · 探针 %2$@";
+
+/* Empty state in the machine list */
+"settings.remote.machinesAppearAfterImport" = "机器在首批加密数据导入后出现在此。";
+
+/* Row label for the machine count */
+"settings.remote.machinesSynced" = "已同步机器";
+
+/* Explanation of the manual pairing flow */
+"settings.remote.manualPairingIntro" = "配对分三步：导出本机 Core 身份，在 Relay 注册以生成配置文件，然后在此导入该文件。导入会把 Relay 凭据移入 macOS Keychain — 但配置文件本身仍包含该凭据，导入成功后请删除该文件。";
+
+/* Explanation shown when no workspace is paired */
+"settings.remote.notConnected" = "本机尚未连接到工作区。远程探针在其他机器上采集归一化用量，用本机 Core 的密钥加密后投递到 Relay — 本机不会开放任何入站端口。";
+
+/* Caption above the manual pairing buttons */
+"settings.remote.orPairManually" = "也可手动配对。";
+
+/* Explanation of a half-finished join */
+"settings.remote.pendingIntro" = "上一次加入已被控制台接受，但在本机未完成保存。该配对码已失效，请继续保存，而不是重新申请配对码。";
+
+/* Settings section heading over the pairing controls */
+"settings.remote.provisioning" = "配置接入";
+
+/* Row label for the probe count */
+"settings.remote.registeredProbes" = "已注册探针";
+
+/* Row label for the relay URL. The term stays as spelled. */
+"settings.remote.relay" = "Relay";
+
+/* Button that finishes a half-completed join */
+"settings.remote.resumeSaving" = "继续保存";
+
+/* Button that retries a failed save */
+"settings.remote.retrySaving" = "重试保存";
+
+/* Sync status line: a translated title and the raw status code */
+"settings.remote.statusWithCode" = "%1$@ · %2$@";
+
+/* Button that pulls remote batches immediately */
+"settings.remote.syncNow" = "立即同步";
+
+/* Row label for the workspace id */
+"settings.remote.workspace" = "工作区";
+
+/* Link label */
+"settings.repository" = "仓库";
+
+/* Button label */
+"settings.rescanCostLogs" = "重新扫描花费日志";
+
+/* Placeholder in the settings sidebar's search field */
+"settings.search" = "搜索设置";
+
+/* Settings section heading listing bundled components. Distinct from status.card.components, which are a provider's status-page components. */
+"settings.section.components" = "组件";
+
+/* Settings section heading */
+"settings.section.costData" = "花费数据";
+
+/* Settings section heading for page layout */
+"settings.section.layout" = "布局";
+
+/* Settings section heading for the status-item watchdog */
+"settings.section.menuBarHealth" = "菜单栏健康";
+
+/* Settings section heading */
+"settings.section.miniWindows" = "迷你窗口";
+
+/* Settings section heading for the Overview surface */
+"settings.section.overview" = "总览";
+
+/* Settings section heading */
+"settings.section.privacy" = "隐私";
+
+/* Settings section heading for refresh intervals. Distinct from status.overview.refreshing, which says a fetch is in flight. */
+"settings.section.refreshing" = "刷新";
+
+/* Settings section heading for login items and the setup assistant. Distinct from settings.language.system, which is a language-picker option meaning 'follow macOS'. */
+"settings.section.system" = "系统";
+
+/* Settings section heading for the app updater */
+"settings.section.updates" = "更新";
+
+/* Button that reopens the first-run assistant */
+"settings.showAssistant" = "打开设置向导";
+
+/* Caption under the assistant button */
+"settings.showAssistantDetail" = "重新走一遍订阅、浏览器 cookies、API key、模型价格与登录项。不会重置任何设置。";
+
+/* Sidebar group heading over the four core provider pages */
+"settings.sidebar.coreProviders" = "核心厂商";
+
+/* Tooltip on the toggle that turns a misc provider off */
+"settings.sidebar.disableProvider" = "停用厂商";
+
+/* Tooltip on the toggle that turns a misc provider on */
+"settings.sidebar.enableProvider" = "启用厂商";
+
+/* Tooltip on the toggle that removes a provider from the Overview */
+"settings.sidebar.hideFromOverview" = "从总览中隐藏";
+
+/* Sidebar group heading over the static preference pages */
+"settings.sidebar.settings" = "设置";
+
+/* Explanation on the SpaceXAI settings page */
+"settings.spaceXAIIntro" = "SpaceXAI 页面同时包含 Grok 与 Cursor。Grok 读取 `~/.grok/auth.json` 或 grok.com 的 cookies；Cursor 先读 Cursor.app，再读 cursor.com 的 cookie 槽位。Grok Bot 提供额度，以及来自本地缓存的只读会话 — 其云端运行仍不产生 token 或花费记录。";
+
+/* Picker label */
+"settings.updateChannel" = "更新通道";
+
+/* Caption under the update controls */
+"settings.updateCheckDetail" = "每天检查一次所选通道，安装前会先询问。";
+
+/* Picker label choosing where a provider's quota is read from */
+"settings.usageSource" = "用量来源";
+
+/* Value beside the Gemini source row */
+"settings.webQuota" = "网页端额度";
+
+/* Link to a release's notes; version is a tag name */
+"settings.whatChangedIn" = "%1$@ 的更新内容";
 
 /* Group heading for a provider's status components */
 "status.card.components" = "组件";

--- a/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.stringsdict
+++ b/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.stringsdict
@@ -104,7 +104,7 @@
 	<key>quota.resetHistory.verdict.leaky</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$@ 在 %3$#@count@里平均有 %2$@%% 没用掉。</string>
+		<string>%1$@ 在 %3$#@count@中平均有 %2$@%% 未使用。</string>
 		<key>count</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -118,7 +118,7 @@
 	<key>quota.resetHistory.verdict.wasteful</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$@ 有 %2$#@count@补额时超过一半没用掉。</string>
+		<string>%1$@ 有 %2$#@count@补额后超过一半未使用。</string>
 		<key>count</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -160,7 +160,7 @@
 	<key>usage.harnessMix.activeCount</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>所选范围内有 %1$#@count@ harness 在使用</string>
+		<string>所选范围内 %1$#@count@ harness 活跃</string>
 		<key>count</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -174,7 +174,7 @@
 	<key>usage.hero.unpricedHelp</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$#@count@没有可用价格，计入 $0。</string>
+		<string>%1$#@count@无可用价格，计入 $0。</string>
 		<key>count</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/Tests/VibeBarCoreTests/LocalizationCatalogTests.swift
+++ b/Tests/VibeBarCoreTests/LocalizationCatalogTests.swift
@@ -238,6 +238,41 @@ final class LocalizationCatalogTests: XCTestCase {
         }
     }
 
+    /// A quota label has one renderer and several readers, and the readers
+    /// get forgotten one at a time — the field picker, the rename dialog's
+    /// placeholder, the calendar entry, the menu-bar composer. Each one that
+    /// reads `title` raw is a Chinese screen with an English quota name on
+    /// it, which is how three of them were found. `displayTitle` is the one
+    /// renderer; this pins what it must do.
+    func testAComposedFieldTitleIsResolvedPartByPart() {
+        let restore = L10n.languageOverride
+        defer { L10n.languageOverride = restore }
+        L10n.languageOverride = .simplifiedChinese
+
+        func option(_ title: String, default label: String) -> MenuBarFieldOption {
+            MenuBarFieldOption(
+                id: "f", tool: .claude, bucketId: "b", title: title, defaultLabel: label
+            )
+        }
+
+        // Both halves are generic window words, so both translate.
+        XCTAssertEqual(option("All Models · Weekly", default: "Weekly").displayTitle,
+                       "全部模型 · 每周")
+        // A model name is a name: only the window half moves.
+        XCTAssertEqual(option("GPT-5.3 Codex Spark · 5 Hours", default: "5 Hours").displayTitle,
+                       "GPT-5.3 Codex Spark · 5 小时")
+        XCTAssertEqual(option("Weekly", default: "Weekly").displayDefaultLabel, "每周")
+        XCTAssertEqual(option("Sonnet", default: "Sonnet").displayDefaultLabel, "Sonnet")
+
+        // The stored value is a naming-contract value and never moves.
+        XCTAssertEqual(option("All Models · Weekly", default: "Weekly").title,
+                       "All Models · Weekly")
+
+        L10n.languageOverride = .english
+        XCTAssertEqual(option("All Models · Weekly", default: "Weekly").displayTitle,
+                       "All Models · Weekly")
+    }
+
     private func locatePython() throws -> URL? {
         for candidate in ["/usr/bin/python3", "/opt/homebrew/bin/python3", "/usr/local/bin/python3"] {
             if FileManager.default.isExecutableFile(atPath: candidate) {

--- a/Tests/VibeBarCoreTests/LocalizationCatalogTests.swift
+++ b/Tests/VibeBarCoreTests/LocalizationCatalogTests.swift
@@ -273,6 +273,49 @@ final class LocalizationCatalogTests: XCTestCase {
                        "All Models · Weekly")
     }
 
+    /// A machine-readable identifier inside a translated sentence stays
+    /// as it arrived. The Relay's error codes and per-source statuses are
+    /// wire vocabulary — `network_timeout` is something a person greps for
+    /// and a support thread quotes, not something a translator improves —
+    /// so the copy around them moves and they do not.
+    func testAWireIdentifierSurvivesInsideATranslatedSentence() {
+        let restore = L10n.languageOverride
+        defer { L10n.languageOverride = restore }
+
+        L10n.languageOverride = .simplifiedChinese
+        let line = L10n.Settings.remoteStatusWithCode(
+            title: L10n.Settings.remoteSyncTimeout, code: "network_timeout"
+        )
+        XCTAssertTrue(line.contains("network_timeout"), "the error code was altered: \(line)")
+        XCTAssertTrue(line.contains("Relay 连接超时"), "the sentence stayed English: \(line)")
+        XCTAssertFalse(
+            line.contains("Relay connection timed out"),
+            "the English diagnosis survived into the Chinese pane: \(line)"
+        )
+
+        let capsule = L10n.Popover.machinesLabelWithStatus(label: "Claude", status: "ok")
+        XCTAssertEqual(capsule, "Claude · ok", "a wire status is not copy")
+    }
+
+    /// Every Relay status code this build knows must resolve, and a code it
+    /// does not know must still produce a sentence — an unrecognized code
+    /// arriving from a newer Relay cannot leave the pane blank.
+    func testEveryRemoteSyncStatusResolvesAndTheFallbackIsNotEmpty() {
+        let restore = L10n.languageOverride
+        defer { L10n.languageOverride = restore }
+
+        for language in [AppLanguage.english, .simplifiedChinese] {
+            L10n.languageOverride = language
+            for key in L10n.allKeys where key.hasPrefix("settings.remote.sync.") {
+                let value = L10n.string(key)
+                XCTAssertNotEqual(value, key, "\(key) does not resolve in \(language.rawValue)")
+                XCTAssertFalse(value.isEmpty)
+            }
+            XCTAssertFalse(L10n.Settings.remoteSyncUnknown.isEmpty)
+            XCTAssertFalse(L10n.Settings.remoteSyncUnknownDetail.isEmpty)
+        }
+    }
+
     private func locatePython() throws -> URL? {
         for candidate in ["/usr/bin/python3", "/opt/homebrew/bin/python3", "/usr/local/bin/python3"] {
             if FileManager.default.isExecutableFile(atPath: candidate) {

--- a/Tests/VibeBarCoreTests/ResetHistoryComparisonTests.swift
+++ b/Tests/VibeBarCoreTests/ResetHistoryComparisonTests.swift
@@ -990,7 +990,7 @@ final class ResetHistoryComparisonTests: XCTestCase {
         L10n.languageOverride = .simplifiedChinese
         XCTAssertEqual(
             built.verdict,
-            "Anthropic · Claude · 每周 有 1 次补额时超过一半没用掉。"
+            "Anthropic · Claude · 每周 有 1 次补额后超过一半未使用。"
         )
         XCTAssertTrue(
             built.accessibilitySummary.contains("重置历史对比"),


### PR DESCRIPTION
Two commits, both on the same seam.

## Register

65 of the 394 existing values were spoken register — the kind of Chinese
a person says, not the kind an application prints. `用不完` was the
headline offender and is gone (`盈余`), along with `需留意`→`需关注`,
`用尽`→`耗尽` standardised across all seven use-up strings, `大概率`→`很可能`,
`试试`→`可尝试`, `今天/昨天`→`今日/昨日`, and every second-person `你`.
Onboarding was the worst of it — roughly thirty values written as speech.

A keyword scan found five of the sixty-five, so all 394 were read. The
durable half is the guard in `build_localizations.py`: the build now
fails on spoken-register words, sentence-final mood particles, `！`, and
`请您`/`您`. The banned list holds only substrings that cannot appear in a
correct written compound — `超` is absent because `超出` is right, `了` is
absent because it is a good aspect marker, and `你` is absent because it
lives inside `迷你`.

## Settings

265 literals across seven files, 234 new keys, all seven added to the
lint manifest.

Twenty-three literals already had a key and did not get a second one. The
Grok credential hint in Settings turned out to be a reworded duplicate of
the assistant's, so Settings uses the assistant's key rather than
acquiring its own spelling of the same sentence.

Four pairs that share an English string were deliberately not folded:
Settings' `System` heading against the "follow macOS" language option,
the `Refreshing` heading against the in-flight fetch state, `Components`
against a status page's components, and MCP `Status` against a provider's
service status. Each carries a comment naming what it is distinct from,
because a reviewer can weigh a sentence and cannot weigh a silence.

The menu-bar half is deliberately absent: #305 rewrites those files and
owns their strings. `menuBarOverviewEditor()` inside `SettingsView` is
the one function #305 also rewrites, so its eight strings are an explicit
lint exemption naming them and their owner — deferring the whole file
would have left the other ninety-two unguarded.

## Verification

    swift build                            → clean
    swift test                             → 2089 tests, 0 failures
    Scripts/build_localizations.py --check → 628 keys x 2 languages
    Scripts/lint_localization.py           → 31 migrated file(s) clean
    ./Scripts/build_app.sh release         → en.lproj + zh-Hans.lproj present

🤖 Generated with [Claude Code](https://claude.com/claude-code)