### PR TITLE
Localize the popover and provider surfaces

### DIFF
--- a/Resources/i18n/en.json
+++ b/Resources/i18n/en.json
@@ -154,6 +154,10 @@
     "comment": "Field label for a user-chosen name",
     "value": "Name"
   },
+  "common.noData": {
+    "comment": "A chart tooltip row for a moment nothing was recorded — the app was not watching, rather than the value being zero",
+    "value": "No data recorded"
+  },
   "common.off": {
     "comment": "A toggle's state, read as a value in a summary row",
     "value": "Off"
@@ -245,6 +249,18 @@
     "comment": "Scope name for the combined cost card",
     "value": "All providers"
   },
+  "cost.chart.metricCostHelp": {
+    "comment": "Tooltip on the cost chart's dollar option",
+    "value": "Plot spend in dollars"
+  },
+  "cost.chart.metricTokens": {
+    "comment": "Segmented-control label that plots token volume instead of spend; the dollar option is the '$' sign and needs no key",
+    "value": "Tok"
+  },
+  "cost.chart.metricTokensHelp": {
+    "comment": "Tooltip on the cost chart's token option",
+    "value": "Plot token volume"
+  },
   "cost.empty.antigravity": {
     "comment": "Empty cost history",
     "value": "No Antigravity conversation token metadata found yet."
@@ -289,9 +305,108 @@
     "comment": "Card title; the company name is never translated",
     "value": "Google AI Cost"
   },
+  "cost.granularity.auto": {
+    "comment": "Cost chart bucket width that follows the visible span instead of being pinned",
+    "value": "Auto"
+  },
+  "cost.granularity.day": {
+    "comment": "Cost chart bucket width: one bar per day",
+    "value": "Day"
+  },
+  "cost.granularity.hour": {
+    "comment": "Cost chart bucket width: one bar per hour",
+    "value": "Hour"
+  },
+  "cost.granularity.month": {
+    "comment": "Cost chart bucket width: one bar per calendar month",
+    "value": "Month"
+  },
+  "cost.granularity.week": {
+    "comment": "Cost chart bucket width: one bar per week",
+    "value": "Week"
+  },
   "cost.history.allProviders": {
     "comment": "Card title on the Overview",
     "value": "All Providers Cost History"
+  },
+  "cost.history.building": {
+    "comment": "Empty state of the cost history chart before the first samples exist",
+    "value": "Building history…"
+  },
+  "cost.history.buildingDetail": {
+    "comment": "Second line of the cost history chart's empty state",
+    "value": "Cost samples appear after the next local scan."
+  },
+  "cost.history.clearModelSelection": {
+    "comment": "Tooltip on the button that closes the model breakdown panel",
+    "value": "Clear model selection"
+  },
+  "cost.history.emptyCost": {
+    "comment": "Overlay on the cost chart when the visible range holds no spend",
+    "value": "No cost recorded in this range."
+  },
+  "cost.history.emptyTokens": {
+    "comment": "Overlay on the cost chart when the visible range holds no tokens",
+    "value": "No tokens recorded in this range."
+  },
+  "cost.history.extentNote": {
+    "comment": "Caption naming the visible span of the cost chart and the dates at its ends",
+    "value": "{span} · {start} – {end}"
+  },
+  "cost.history.granularityDisabled": {
+    "comment": "Tooltip on a bucket-width button the current zoom level cannot draw",
+    "value": "{granularity} needs a different zoom level"
+  },
+  "cost.history.groupBy": {
+    "comment": "Tooltip on a bucket-width button in the cost chart",
+    "value": "Group cost history by {granularity}"
+  },
+  "cost.history.hourlyFallback": {
+    "comment": "Note under the cost chart when hourly buckets were asked for but only daily ones exist that far back",
+    "value": "hourly n/a · showing daily"
+  },
+  "cost.history.metricAverage": {
+    "comment": "Summary figure under the cost chart: the per-bucket average; granularity is the bucket width",
+    "value": "Avg/{granularity}"
+  },
+  "cost.history.metricPeak": {
+    "comment": "Summary figure under the cost chart: the largest single bucket",
+    "value": "Peak"
+  },
+  "cost.history.metricTotal": {
+    "comment": "Summary figure under the cost chart: the visible range's total",
+    "value": "Total"
+  },
+  "cost.history.modelDetailUnavailable": {
+    "comment": "Shown in the model breakdown panel for a bucket old enough that per-model rows were not kept",
+    "value": "Model detail is unavailable for this historical period."
+  },
+  "cost.history.modelsAt": {
+    "comment": "Heading of the model breakdown panel; when is the bucket the user clicked",
+    "value": "Models · {when}"
+  },
+  "cost.history.moreModels": {
+    "args": {
+      "count": "int"
+    },
+    "comment": "Last row of a cost-chart tooltip, standing in for the models it could not fit",
+    "value": "+{count} more · click to inspect"
+  },
+  "cost.history.navigator": {
+    "comment": "Accessibility label for the range navigator under the cost history chart",
+    "value": "Cost history range navigator"
+  },
+  "cost.history.title": {
+    "comment": "Title of the navigable cost history chart",
+    "value": "Cost History"
+  },
+  "cost.history.weekOf": {
+    "comment": "Cost chart tooltip heading for a weekly bucket; date is the week's first day",
+    "value": "Week of {date}"
+  },
+  "cost.history.weekShortOf": {
+    "comment": "Compact form of the weekly bucket label, used under the peak figure",
+    "value": "wk {date}"
   },
   "cost.metric.peakDay": {
     "comment": "All-caps metric label: the most expensive day on record",
@@ -949,13 +1064,33 @@
     "comment": "Subtitle under the Machines page header",
     "value": "End-to-end encrypted remote usage"
   },
+  "popover.header.mini": {
+    "comment": "Tooltip on the popover header button that opens the floating mini window",
+    "value": "Mini"
+  },
   "popover.header.miscSubtitle": {
     "comment": "Subtitle under the Misc Providers page header",
     "value": "Usage-only · sign in or paste a key"
   },
+  "popover.header.openWorkbench": {
+    "comment": "Tooltip on the popover header button that opens the Workbench window",
+    "value": "Open Workbench"
+  },
   "popover.header.overviewSubtitle": {
     "comment": "Subtitle under the Overview page header",
     "value": "All providers · quota & cost"
+  },
+  "popover.header.refreshing": {
+    "comment": "Popover header caption while a refresh is in flight",
+    "value": "Refreshing…"
+  },
+  "popover.header.settings": {
+    "comment": "Tooltip on the popover header's gear button",
+    "value": "Settings"
+  },
+  "popover.header.updatedLine": {
+    "comment": "Popover header caption: the page's own subtitle followed by how long ago the data was updated",
+    "value": "{subtitle} · {updated}"
   },
   "popover.machines.checking": {
     "comment": "Empty-state title while a sync is in flight",
@@ -1025,6 +1160,10 @@
     "comment": "Popover tab. The other tabs are company names (OpenAI, Anthropic, Google AI, SpaceXAI) and are never translated.",
     "value": "Overview"
   },
+  "quota.awaitingFirstObservation": {
+    "comment": "Placeholder inside an empty reset-history strip, before any quota reading has landed",
+    "value": "Waiting for the first quota observation"
+  },
   "quota.bucket.noResetInfo": {
     "comment": "Caption under a quota bar when the provider reported no reset time",
     "value": "No reset info"
@@ -1032,6 +1171,10 @@
   "quota.bucket.resetsIn": {
     "comment": "Caption under a quota bar; when is a countdown, sometimes with an absolute time",
     "value": "Resets in {when}"
+  },
+  "quota.cycleRecordedOnRefill": {
+    "comment": "Caption under an empty reset-history strip explaining when a cycle is recorded",
+    "value": "A cycle is recorded when the quota refills"
   },
   "quota.empty.needsLogin.detail": {
     "comment": "Empty state body; command is a CLI name such as codex or claude and is never translated",
@@ -1084,6 +1227,22 @@
   "quota.forecast.confidence.medium": {
     "comment": "Forecast confidence level",
     "value": "Medium confidence"
+  },
+  "quota.forecast.explain.footer": {
+    "comment": "Footnote under the forecast metric grid explaining what token history is and is not used for",
+    "value": "Quota observations drive consumption. Token history only weights when you tend to work; it is never converted into quota usage."
+  },
+  "quota.forecast.explain.hide": {
+    "comment": "Accessibility label on the disclosure button while the grid is open",
+    "value": "Hide forecast calculation"
+  },
+  "quota.forecast.explain.show": {
+    "comment": "Accessibility label on the disclosure button while the grid is closed",
+    "value": "Show forecast calculation"
+  },
+  "quota.forecast.explain.title": {
+    "comment": "Disclosure button that opens the forecast's metric grid",
+    "value": "How this forecast was calculated"
   },
   "quota.forecast.guidance.atRisk": {
     "comment": "What to do about an at-risk forecast",
@@ -1138,6 +1297,210 @@
     },
     "comment": "Remaining-mode guidance when nothing needs saying",
     "value": "Within the {target}% safety target"
+  },
+  "quota.forecast.legend.item": {
+    "comment": "One reference marker in the quota bar legend: its name followed by the figure it marks",
+    "value": "{label} {value}"
+  },
+  "quota.forecast.metric.aboveTarget": {
+    "args": {
+      "percent": "int"
+    },
+    "comment": "Detail under the safety target metric when the forecast leaves capacity above it",
+    "value": "{percent}% capacity above target"
+  },
+  "quota.forecast.metric.activityFallback": {
+    "comment": "Detail under the activity timing metric before any habits exist",
+    "value": "wall-clock fallback until habits exist"
+  },
+  "quota.forecast.metric.activityTiming": {
+    "comment": "Forecast metric: how far through the window the user's own working rhythm says we are",
+    "value": "Activity timing"
+  },
+  "quota.forecast.metric.activityWeighted": {
+    "comment": "Detail under the activity timing metric when weekday and hour habits are known",
+    "value": "weekday and hour weighted"
+  },
+  "quota.forecast.metric.behaviorDetail": {
+    "comment": "Detail under the behavior fallback metric",
+    "value": "used when stronger evidence is sparse"
+  },
+  "quota.forecast.metric.behaviorFallback": {
+    "comment": "Forecast metric: the projection used when stronger inputs are missing",
+    "value": "Behavior fallback"
+  },
+  "quota.forecast.metric.comparableCycles": {
+    "args": {
+      "count": "int"
+    },
+    "comment": "Detail under the reset-history metric: how many past cycles were comparable",
+    "value": "{count, plural, one {1 comparable reset cycle} other {# comparable reset cycles}}"
+  },
+  "quota.forecast.metric.coverage": {
+    "comment": "Forecast metric: how completely each input covers the window",
+    "value": "Coverage"
+  },
+  "quota.forecast.metric.coverageDetail": {
+    "args": {
+      "fresh": "int",
+      "habits": "int"
+    },
+    "comment": "Detail under the coverage metric: freshness of the data and how well habits are known",
+    "value": "fresh {fresh}% · habits {habits}%"
+  },
+  "quota.forecast.metric.coverageValue": {
+    "args": {
+      "observations": "int",
+      "history": "int"
+    },
+    "comment": "Value of the coverage metric: observation and reset-history coverage",
+    "value": "obs {observations}% · history {history}%"
+  },
+  "quota.forecast.metric.cyclesPending": {
+    "comment": "Detail under the reset-history metric before any cycle has completed",
+    "value": "Completed cycles will appear here"
+  },
+  "quota.forecast.metric.elapsed": {
+    "args": {
+      "percent": "int"
+    },
+    "comment": "Value of the activity timing metric: share of the window already behind us",
+    "value": "{percent}% elapsed"
+  },
+  "quota.forecast.metric.evidence": {
+    "comment": "Forecast metric: how much data the projection stands on",
+    "value": "Evidence"
+  },
+  "quota.forecast.metric.evidenceDetail": {
+    "args": {
+      "score": "int"
+    },
+    "comment": "Detail under the evidence metric; confidence is the forecast's own confidence label",
+    "value": "{confidence} · score {score}%"
+  },
+  "quota.forecast.metric.evidenceValue": {
+    "args": {
+      "observations": "int",
+      "cycles": "int"
+    },
+    "comment": "Value of the evidence metric: observations in this cycle and completed cycles behind it",
+    "value": "{observations} obs · {cycles} cycles"
+  },
+  "quota.forecast.metric.expectedLeft": {
+    "args": {
+      "percent": "int"
+    },
+    "comment": "Detail under the forecast metric while the card shows used percentages",
+    "value": "{percent}% expected left"
+  },
+  "quota.forecast.metric.expectedUsed": {
+    "args": {
+      "percent": "int"
+    },
+    "comment": "Detail under the forecast metric while the card shows remaining percentages",
+    "value": "{percent}% expected used"
+  },
+  "quota.forecast.metric.forecastAtReset": {
+    "comment": "Forecast metric and bar legend entry: the projected figure at the next reset",
+    "value": "Forecast at reset"
+  },
+  "quota.forecast.metric.forecastRange": {
+    "comment": "Forecast metric: the spread the projection considers plausible",
+    "value": "Forecast range"
+  },
+  "quota.forecast.metric.insideTarget": {
+    "comment": "Detail under the safety target metric when the forecast sits inside it",
+    "value": "inside the target range"
+  },
+  "quota.forecast.metric.noComparison": {
+    "comment": "Value of the reset-history metric before any cycle can be compared",
+    "value": "No comparison yet"
+  },
+  "quota.forecast.metric.plan": {
+    "comment": "Forecast metric: where the personal plan says usage should be right now",
+    "value": "Personal plan now"
+  },
+  "quota.forecast.metric.planDetail": {
+    "args": {
+      "target": "int"
+    },
+    "comment": "Detail under the personal plan metric: what the plan is built from",
+    "value": "activity timing + {target}% safety target"
+  },
+  "quota.forecast.metric.rangeLeft": {
+    "args": {
+      "lower": "int",
+      "upper": "int"
+    },
+    "comment": "Value of the forecast range metric in Remaining mode",
+    "value": "{lower}–{upper}% left"
+  },
+  "quota.forecast.metric.rangeUsed": {
+    "args": {
+      "lower": "int",
+      "upper": "int"
+    },
+    "comment": "Value of the forecast range metric in Used mode",
+    "value": "{lower}–{upper}% used"
+  },
+  "quota.forecast.metric.recentBurn": {
+    "comment": "Forecast metric: the projection from the most recent intervals alone",
+    "value": "Recent burn"
+  },
+  "quota.forecast.metric.recentIntervals": {
+    "args": {
+      "count": "int"
+    },
+    "comment": "Detail under the recent burn metric: how many recent observation intervals fed it",
+    "value": "{count, plural, one {1 recent interval} other {# recent intervals}}"
+  },
+  "quota.forecast.metric.recentMissing": {
+    "comment": "Detail under the recent burn metric when there is not enough recent data",
+    "value": "Needs at least two useful observations"
+  },
+  "quota.forecast.metric.recentTrend": {
+    "comment": "Forecast metric: whether recent activity is above or below the earlier baseline",
+    "value": "Recent trend"
+  },
+  "quota.forecast.metric.safetyTarget": {
+    "comment": "Forecast metric: the share of the quota the user wants to still hold at reset",
+    "value": "Safety target"
+  },
+  "quota.forecast.metric.timePace": {
+    "comment": "Forecast metric: the projection that only knows how much of the window has elapsed",
+    "value": "Time-only pace"
+  },
+  "quota.forecast.metric.timePaceDetail": {
+    "comment": "Detail under the time-only pace metric; stage is the pace summary such as '5% in deficit'",
+    "value": "{stage} by wall clock"
+  },
+  "quota.forecast.metric.timePaceMissing": {
+    "comment": "Detail under the time-only pace metric when the bucket reports no window",
+    "value": "Needs reset time and window length"
+  },
+  "quota.forecast.metric.trendDetail": {
+    "comment": "Detail under the recent trend metric: the two spans being compared",
+    "value": "last 7 days versus prior 21 days"
+  },
+  "quota.forecast.metric.trendDetailMissing": {
+    "comment": "Detail under the recent trend metric when the earlier span has no activity",
+    "value": "needs prior daily activity"
+  },
+  "quota.forecast.metric.trendMissing": {
+    "comment": "Value of the recent trend metric before a baseline exists",
+    "value": "No baseline yet"
+  },
+  "quota.forecast.metric.trendMultiplier": {
+    "comment": "Value of the recent trend metric; multiplier is a decimal already formatted at the call site",
+    "value": "{multiplier}× activity"
+  },
+  "quota.forecast.metric.unavailable": {
+    "comment": "Value of a forecast metric whose inputs the bucket does not report",
+    "value": "Unavailable"
+  },
+  "quota.forecast.metric.uncertaintyInterval": {
+    "comment": "Detail under the forecast range metric",
+    "value": "uncertainty interval"
   },
   "quota.forecast.reset.atRisk": {
     "comment": "One-line forecast summary",
@@ -1210,6 +1573,14 @@
   "quota.forecast.useUp.uncertain": {
     "comment": "Use-up line when no ETA can be derived",
     "value": "Use-up time uncertain · may run short before reset"
+  },
+  "quota.forecast.value.atReset": {
+    "comment": "A quota figure qualified as the projection for the next reset; value is one of the used/left figures",
+    "value": "{value} at reset"
+  },
+  "quota.forecast.value.expectedNow": {
+    "comment": "A quota figure qualified as where usage should stand at this moment",
+    "value": "{value} expected now"
   },
   "quota.forecast.value.left": {
     "args": {
@@ -1341,6 +1712,101 @@
     "comment": "Quota group: a weekly credit balance rather than a percentage",
     "value": "Weekly Credits"
   },
+  "quota.history.allCurvesHidden": {
+    "comment": "Empty state of the all-providers quota history chart when every curve has been switched off",
+    "value": "Every curve is hidden — pick one from the menu above."
+  },
+  "quota.history.buildingUp": {
+    "comment": "Empty state of the quota history chart before enough refreshes have landed",
+    "value": "Quota history builds up as refreshes come in."
+  },
+  "quota.history.curveCount": {
+    "args": {
+      "count": "int"
+    },
+    "comment": "How many quota curves the all-providers chart holds; used inside the footer note",
+    "value": "{count, plural, one {1 curve} other {# curves}}"
+  },
+  "quota.history.curvePickerA11y": {
+    "comment": "Accessibility label for the quota history curve picker",
+    "value": "Choose which quota curves to show"
+  },
+  "quota.history.curvesAll": {
+    "args": {
+      "total": "int"
+    },
+    "comment": "Curve picker summary when nothing is hidden",
+    "value": "All {total}"
+  },
+  "quota.history.curvesSome": {
+    "args": {
+      "shown": "int",
+      "total": "int"
+    },
+    "comment": "Curve picker summary when some curves are hidden",
+    "value": "{shown} of {total}"
+  },
+  "quota.history.forecastLegend": {
+    "comment": "Legend entry marking the dotted projection line on the quota history chart",
+    "value": "forecast"
+  },
+  "quota.history.moreBuckets": {
+    "args": {
+      "count": "int"
+    },
+    "comment": "Scope note when a group holds more quotas than the note can name; names are the ones it did name",
+    "value": "{names} +{count}"
+  },
+  "quota.history.moreReadings": {
+    "args": {
+      "count": "int"
+    },
+    "comment": "Last row of a crowded chart tooltip, standing in for the readings it could not fit",
+    "value": "+{count} more"
+  },
+  "quota.history.navigatorAllProviders": {
+    "comment": "Accessibility label for the range navigator under the all-providers quota chart",
+    "value": "All-providers quota history range navigator"
+  },
+  "quota.history.navigatorProvider": {
+    "comment": "Accessibility label for the range navigator under a single provider's quota chart",
+    "value": "Quota history range navigator"
+  },
+  "quota.history.providerCount": {
+    "args": {
+      "count": "int"
+    },
+    "comment": "How many providers the all-providers chart covers; used inside the footer note",
+    "value": "{count, plural, one {1 provider} other {# providers}}"
+  },
+  "quota.history.scopeNote": {
+    "comment": "Footer under a quota history chart; scope names what the chart covers, visible and total are compact spans such as 7d",
+    "value": "{scope} · showing {visible} of {total} recorded"
+  },
+  "quota.history.showAllCurves": {
+    "comment": "Menu item that puts every quota curve back on the chart",
+    "value": "Show all curves"
+  },
+  "quota.history.showBusiest": {
+    "comment": "Menu item that leaves only the most-used quota curves on the chart",
+    "value": "Show only the busiest"
+  },
+  "quota.history.title": {
+    "comment": "Title of the quota history chart card",
+    "value": "Quota history"
+  },
+  "quota.history.tooltipAtReset": {
+    "comment": "Tooltip row on the quota history chart: the projection for the next reset",
+    "value": "At reset"
+  },
+  "quota.history.tooltipPace": {
+    "comment": "Tooltip row on the quota history chart: where the wall clock said usage should be",
+    "value": "Pace"
+  },
+  "quota.history.tooltipQuotaLeft": {
+    "comment": "Tooltip row on the quota history chart: the recorded remaining quota",
+    "value": "Quota left"
+  },
   "quota.login.claude": {
     "comment": "What to do when no credential is stored",
     "value": "Run claude login, then refresh."
@@ -1361,6 +1827,52 @@
     "comment": "Fallback for a misc provider; provider is a SubProvider name",
     "value": "Configure {provider} in Settings → Misc Providers."
   },
+  "quota.mini.forecastLearning": {
+    "args": {
+      "percent": "int"
+    },
+    "comment": "Mini window forecast line while the forecast is still learning the usage pattern",
+    "value": "learning · {percent}% left"
+  },
+  "quota.mini.forecastLearningCompact": {
+    "args": {
+      "percent": "int"
+    },
+    "comment": "Narrow form of the mini window learning forecast line",
+    "value": "~{percent}% left"
+  },
+  "quota.mini.forecastLeft": {
+    "args": {
+      "percent": "int"
+    },
+    "comment": "Mini window forecast line for a quota that is comfortably ahead",
+    "value": "{percent}% left"
+  },
+  "quota.mini.forecastLeftCompact": {
+    "args": {
+      "percent": "int"
+    },
+    "comment": "Narrow form of the mini window forecast line for a quota that is comfortably ahead",
+    "value": "left {percent}%"
+  },
+  "quota.mini.forecastMayRunOut": {
+    "comment": "Mini window forecast line for a quota that may, rather than will, be exhausted before reset",
+    "value": "may run out {countdown}"
+  },
+  "quota.mini.forecastSurplus": {
+    "args": {
+      "percent": "int"
+    },
+    "comment": "Mini window forecast line for a quota expected to finish its window well under target",
+    "value": "surplus · {percent}% left"
+  },
+  "quota.mini.forecastSurplusCompact": {
+    "args": {
+      "percent": "int"
+    },
+    "comment": "Narrow form of the mini window surplus forecast line",
+    "value": "surplus {percent}%"
+  },
   "quota.mode.remaining": {
     "comment": "Caption saying the bar shows what is left",
     "value": "remaining"
@@ -1369,13 +1881,49 @@
     "comment": "Caption saying the bar shows what has been spent",
     "value": "used"
   },
+  "quota.pace.deficit": {
+    "args": {
+      "percent": "int"
+    },
+    "comment": "Pace summary when usage is running ahead of the linear expectation",
+    "value": "{percent}% in deficit"
+  },
+  "quota.pace.deficitShort": {
+    "args": {
+      "percent": "int"
+    },
+    "comment": "Compact form of the pace summary for the mini window when usage runs ahead of the linear expectation",
+    "value": "{percent}% deficit"
+  },
   "quota.pace.lastsUntilReset": {
     "comment": "Legacy elapsed-time pace ETA on a Misc provider card",
     "value": "Lasts until reset"
   },
+  "quota.pace.onTrack": {
+    "comment": "Pace summary when usage matches the linear expectation",
+    "value": "On pace"
+  },
+  "quota.pace.reserve": {
+    "args": {
+      "percent": "int"
+    },
+    "comment": "Pace summary when usage is running behind the linear expectation",
+    "value": "{percent}% in reserve"
+  },
+  "quota.pace.reserveShort": {
+    "args": {
+      "percent": "int"
+    },
+    "comment": "Compact form of the pace summary for the mini window when usage runs behind the linear expectation",
+    "value": "{percent}% reserve"
+  },
   "quota.pace.runsOutIn": {
     "comment": "Legacy elapsed-time pace ETA on a Misc provider card",
     "value": "Runs out in {countdown}"
+  },
+  "quota.pace.runsOutShort": {
+    "comment": "Compact projection in the mini window: when the quota is estimated to be exhausted",
+    "value": "out {countdown}"
   },
   "quota.perModelLimits": {
     "args": {
@@ -1453,6 +2001,10 @@
     "comment": "Tooltip on the Time axis option",
     "value": "Each cycle where it actually happened, on a shared calendar"
   },
+  "quota.resetHistory.axisCurrent": {
+    "comment": "Axis label for the cycle that has not reset yet",
+    "value": "Current"
+  },
   "quota.resetHistory.axisCyclesBack": {
     "args": {
       "count": "int"
@@ -1463,6 +2015,45 @@
   "quota.resetHistory.axisNow": {
     "comment": "Caption on the live column of the reset-history grid",
     "value": "now"
+  },
+  "quota.resetHistory.barIsOneCycle": {
+    "comment": "Caption beside the reset-history strip's title",
+    "value": "Each bar is one quota cycle"
+  },
+  "quota.resetHistory.compareEmpty": {
+    "comment": "Empty state of the reset history comparison before any weekly or longer quota is known",
+    "value": "Nothing to compare yet — weekly and longer quotas appear here once a provider reports one."
+  },
+  "quota.resetHistory.compareTitle": {
+    "comment": "Title of the card that puts every weekly-and-longer quota's reset history side by side",
+    "value": "Reset History Compare"
+  },
+  "quota.resetHistory.compareWindow": {
+    "comment": "Tooltip on a window button in the reset history comparison; window is the spoken span such as 'last 8 weeks'",
+    "value": "Compare the {window}"
+  },
+  "quota.resetHistory.currentCycleCaption": {
+    "args": {
+      "used": "int",
+      "left": "int"
+    },
+    "comment": "Caption for the cycle still running in the reset-history strip",
+    "value": "Current cycle · {used}% used so far · {left}% left"
+  },
+  "quota.resetHistory.cycleCaption": {
+    "args": {
+      "used": "int",
+      "left": "int"
+    },
+    "comment": "Caption for one completed cycle in the reset-history strip; time is the reset moment",
+    "value": "{time} reset · {used}% used · {left}% left"
+  },
+  "quota.resetHistory.earlyRefillCount": {
+    "args": {
+      "count": "int"
+    },
+    "comment": "Note under the reset-history strip: how many cycles refilled before their window ended",
+    "value": "{count, plural, one {1 cycle refilled before the window was up} other {# cycles refilled before the window was up}}"
   },
   "quota.resetHistory.lane.emptyState": {
     "comment": "Empty-state copy for a lane",
@@ -1490,6 +2081,26 @@
     "comment": "Line under a lane label; says how many cycles it averages so one cycle cannot read as a settled habit",
     "value": "avg wasted {percent}% · last {count, plural, one {1 cycle} other {# cycles}}"
   },
+  "quota.resetHistory.lastSeenBefore": {
+    "comment": "Note appended to a cycle caption when the last reading predates the reset by a while",
+    "value": "last seen {duration} before reset"
+  },
+  "quota.resetHistory.legend.barHeight": {
+    "comment": "Legend entry explaining what a bar's height means in the reset history comparison",
+    "value": "bar height = remaining at reset"
+  },
+  "quota.resetHistory.legend.byDate": {
+    "comment": "Legend entry for the time axis: bars sit where they happened on a calendar",
+    "value": "placed by date"
+  },
+  "quota.resetHistory.legend.perCycle": {
+    "comment": "Legend entry for the cycle axis: columns are cycles, not dates",
+    "value": "one column per cycle"
+  },
+  "quota.resetHistory.legend.refilledEarly": {
+    "comment": "Legend entry for the dot marking a cycle that refilled before its window was up",
+    "value": "refilled early"
+  },
   "quota.resetHistory.reset.earlyClockRestarted": {
     "comment": "What the provider did to the clock on an early refill. This shape means a whole window lies ahead, so the extra capacity is usable.",
     "value": "refilled early, next window restarted"
@@ -1501,6 +2112,17 @@
   "quota.resetHistory.reset.earlyUnclear": {
     "comment": "An early refill that matches neither shape",
     "value": "refilled early, onto a different schedule"
+  },
+  "quota.resetHistory.retiredAccount": {
+    "comment": "Lane label for history kept from an account that is no longer signed in",
+    "value": "Signed-out account"
+  },
+  "quota.resetHistory.retiredAccountNumbered": {
+    "args": {
+      "number": "int"
+    },
+    "comment": "Lane label for one of several signed-out accounts on the same provider",
+    "value": "Signed-out account {number}"
   },
   "quota.resetHistory.spoken.allCycles": {
     "comment": "Spoken window name",
@@ -1537,6 +2159,30 @@
   "quota.resetHistory.title": {
     "comment": "Card title on a provider detail page",
     "value": "Reset History"
+  },
+  "quota.resetHistory.tooltip.completed": {
+    "args": {
+      "left": "int",
+      "used": "int"
+    },
+    "comment": "Tooltip figures for a finished cycle in the reset history comparison",
+    "value": "{left}% left at reset · {used}% used"
+  },
+  "quota.resetHistory.tooltip.current": {
+    "args": {
+      "left": "int",
+      "used": "int"
+    },
+    "comment": "Tooltip figures for the cycle still running",
+    "value": "Current cycle · {left}% left now · {used}% used so far"
+  },
+  "quota.resetHistory.tooltip.range": {
+    "comment": "Tooltip line naming the span a finished cycle covered",
+    "value": "{start} → {end} reset"
+  },
+  "quota.resetHistory.tooltip.rangeDue": {
+    "comment": "Tooltip line naming the span of the cycle still running and when it is due to reset",
+    "value": "{start} → {end} reset due"
   },
   "quota.resetHistory.totals.headline": {
     "args": {
@@ -1662,6 +2308,22 @@
   "quota.update.failed": {
     "comment": "Inline error row; reason is a provider message and is not translated",
     "value": "Update failed: {reason}"
+  },
+  "quota.window.dayOfDays": {
+    "args": {
+      "day": "int",
+      "total": "int"
+    },
+    "comment": "Window progress line for a window measured in whole days",
+    "value": "Day {day} of {total} · {value}"
+  },
+  "quota.window.elapsedOfWindow": {
+    "comment": "Window progress line for a sub-day window; window is its length, elapsed how much of it is gone",
+    "value": "{elapsed} of {window} · {value}"
+  },
+  "quota.window.resetsSoon": {
+    "comment": "Window progress line once the reset time has passed but no refresh has landed; value is the used/left figure",
+    "value": "Resets soon · {value}"
   },
   "settings.antigravityCookieEnabled": {
     "comment": "Hint under the Antigravity source picker",
@@ -3192,6 +3854,34 @@
     "comment": "Card title on the Overview's service-status tile row",
     "value": "Status"
   },
+  "usage.activity.a11y": {
+    "comment": "Accessibility label for the 7 by 24 activity grid",
+    "value": "Token usage by weekday and hour, 7 days by 24 hours"
+  },
+  "usage.activity.cellTooltip": {
+    "comment": "Tooltip on one cell of the activity grid",
+    "value": "{day} {hour} · {tokens}"
+  },
+  "usage.activity.heavy": {
+    "comment": "High end of the activity grid's intensity legend",
+    "value": "Heavy"
+  },
+  "usage.activity.peak": {
+    "comment": "Caption naming the busiest hour of the activity card when the peak hour and peak cell agree",
+    "value": "Peak {hour} · {day}"
+  },
+  "usage.activity.peakCell": {
+    "comment": "Caption naming the busiest hour overall and the busiest single cell when they differ",
+    "value": "Peak {hour} · {day} {cellHour}"
+  },
+  "usage.activity.quiet": {
+    "comment": "Low end of the activity grid's intensity legend",
+    "value": "Quiet"
+  },
+  "usage.activity.tokensShort": {
+    "comment": "A token count in the activity grid's tooltip; the number is already abbreviated at the call site",
+    "value": "{tokens} tok"
+  },
   "usage.breakdown.models": {
     "comment": "Tab over the Usage Stats breakdown table: one row per model.",
     "value": "Models"
@@ -3211,6 +3901,26 @@
   "usage.breakdown.requests": {
     "comment": "Tab over the Usage Stats breakdown table: one row per request. The all-caps hero metric of the same word is usage.hero.requests.",
     "value": "Requests"
+  },
+  "usage.chartNavigator.label": {
+    "comment": "Accessibility label for the brush strip under a pannable chart",
+    "value": "Chart range navigator"
+  },
+  "usage.chartNavigator.range": {
+    "comment": "Accessibility value of the chart range navigator; both ends are already formatted dates",
+    "value": "{start} to {end}"
+  },
+  "usage.chartNavigator.showFullRange": {
+    "comment": "Accessibility action that returns a chart to its whole domain",
+    "value": "Show Full Range"
+  },
+  "usage.chartNavigator.zoomIn": {
+    "comment": "Accessibility action on the chart range navigator",
+    "value": "Zoom In"
+  },
+  "usage.chartNavigator.zoomOut": {
+    "comment": "Accessibility action on the chart range navigator",
+    "value": "Zoom Out"
   },
   "usage.filters.allHarnesses": {
     "comment": "Chip that puts every harness into the Usage Stats query; 'harness' is the usage-axis unit and stays as spelled.",
@@ -3411,9 +4121,45 @@
     "comment": "Empty state when the local per-request ledger could not be opened",
     "value": "Usage ledger unavailable"
   },
+  "usage.mix.dimension.harnesses": {
+    "comment": "Usage Mix dimension: which local CLI or app produced the tokens; the harness names themselves are not translated",
+    "value": "Harnesses"
+  },
+  "usage.mix.dimension.models": {
+    "comment": "Usage Mix dimension: which model the tokens were spent on",
+    "value": "Models"
+  },
+  "usage.mix.dimension.projects": {
+    "comment": "Usage Mix dimension: which working directory the tokens came from",
+    "value": "Projects"
+  },
+  "usage.mix.dimension.tokenFlow": {
+    "comment": "Usage Mix dimension: fresh input against cache and output",
+    "value": "Token Flow"
+  },
   "usage.mix.donutUnit": {
     "comment": "Unit under the total in the middle of a donut card.",
     "value": "tokens"
+  },
+  "usage.mix.empty": {
+    "comment": "Usage Mix empty state when the range holds no local usage",
+    "value": "No local usage in this range."
+  },
+  "usage.mix.flow.cache": {
+    "comment": "Token Flow slice: cached tokens",
+    "value": "Cache"
+  },
+  "usage.mix.flow.cacheDetail": {
+    "comment": "Detail under the cache slice, naming the two cache token kinds it sums",
+    "value": "read + creation"
+  },
+  "usage.mix.flow.freshInput": {
+    "comment": "Token Flow slice: input tokens that were not served from cache",
+    "value": "Fresh input"
+  },
+  "usage.mix.flow.output": {
+    "comment": "Token Flow slice: tokens the model produced",
+    "value": "Output"
   },
   "usage.mix.harness.subtitle": {
     "comment": "Caption under the Harness Mix donut title.",
@@ -3422,6 +4168,14 @@
   "usage.mix.harness.title": {
     "comment": "Donut card on the Usage Stats distribution wall: tokens by harness. Title-case variant of the all-caps section label usage.harnessMix.title.",
     "value": "Harness Mix"
+  },
+  "usage.mix.lastThirtyDays": {
+    "comment": "Scope caption beside the Usage Mix title",
+    "value": "Last 30 days"
+  },
+  "usage.mix.ledgerUnreadable": {
+    "comment": "Usage Mix empty state when the per-request ledger could not be opened",
+    "value": "Usage ledger could not be read."
   },
   "usage.mix.model.empty": {
     "comment": "Empty state inside the Model Mix donut card.",
@@ -3434,6 +4188,13 @@
   "usage.mix.model.title": {
     "comment": "Donut card on the Usage Stats distribution wall: tokens by model.",
     "value": "Model Mix"
+  },
+  "usage.mix.moreSlices": {
+    "args": {
+      "count": "int"
+    },
+    "comment": "Detail on the Usage Mix slice that stands in for everything below the cut",
+    "value": "{count} more"
   },
   "usage.mix.other": {
     "comment": "Donut slice that collapses everything below the top five.",
@@ -3458,6 +4219,10 @@
     "comment": "Donut card on the Usage Stats distribution wall: tokens by project directory.",
     "value": "Project Mix"
   },
+  "usage.mix.projectsPending": {
+    "comment": "Usage Mix empty state on the Projects dimension before a cost refresh has attributed anything",
+    "value": "Project attribution appears after the next Codex or Claude cost refresh."
+  },
   "usage.mix.provider.empty": {
     "comment": "Empty state inside the Provider Mix donut card.",
     "value": "No provider traffic in this range"
@@ -3470,6 +4235,10 @@
     "comment": "Donut card on the Usage Stats distribution wall: tokens by L1 company.",
     "value": "Provider Mix"
   },
+  "usage.mix.title": {
+    "comment": "Title of the Overview card that splits recent tokens by project, harness, model or token kind",
+    "value": "Usage Mix"
+  },
   "usage.mix.tokenFlow.empty": {
     "comment": "Empty state inside the Token Flow donut card.",
     "value": "No token traffic in this range"
@@ -3481,6 +4250,10 @@
   "usage.mix.tokenFlow.title": {
     "comment": "Donut card on the Usage Stats distribution wall: tokens by kind.",
     "value": "Token Flow"
+  },
+  "usage.mix.tokensCaption": {
+    "comment": "Caption under the total in the middle of the Usage Mix donut",
+    "value": "tokens"
   },
   "usage.noHarnessSelected.detail": {
     "comment": "Empty state body explaining the All chip",
@@ -3801,9 +4574,40 @@
     "comment": "Heatmap title on the Google AI page",
     "value": "When you use Google AI"
   },
+  "usage.whenYouUse.provider": {
+    "comment": "Title of the weekday-by-hour activity card for one provider",
+    "value": "When you use {provider}"
+  },
   "usage.whenYouUse.spaceXAI": {
     "comment": "Heatmap title on the SpaceXAI page",
     "value": "When you use SpaceXAI"
+  },
+  "usage.yearHeatmap.a11y": {
+    "args": {
+      "count": "int"
+    },
+    "comment": "Accessibility label for the past-year grid; count is how many week columns it draws",
+    "value": "{provider} daily spend over the past year, {count, plural, one {1 week} other {# weeks}}"
+  },
+  "usage.yearHeatmap.less": {
+    "comment": "Low end of the past-year grid's intensity legend",
+    "value": "Less"
+  },
+  "usage.yearHeatmap.more": {
+    "comment": "High end of the past-year grid's intensity legend",
+    "value": "More"
+  },
+  "usage.yearHeatmap.title": {
+    "comment": "Title of the past-year contribution grid; provider is a name and is not translated",
+    "value": "{provider} — Past Year"
+  },
+  "usage.yearHeatmap.tooltip": {
+    "comment": "Tooltip on one day of the past-year grid",
+    "value": "{date} · {amount}"
+  },
+  "usage.yearHeatmap.total": {
+    "comment": "Caption beside the past-year grid's title; amount is already formatted currency",
+    "value": "{amount} total"
   },
   "workbench.appearance.useDark": {
     "comment": "Tooltip on the Workbench header button that switches the window to dark",

--- a/Resources/i18n/en.json
+++ b/Resources/i18n/en.json
@@ -1164,6 +1164,26 @@
     "comment": "Placeholder inside an empty reset-history strip, before any quota reading has landed",
     "value": "Waiting for the first quota observation"
   },
+  "quota.bridge.empty": {
+    "comment": "Empty state of the CodexBar bridge card when every bridged provider is one Vibe Bar already reads natively",
+    "value": "No enabled CodexBar-only provider returned a quota window. Overlapping providers remain on Vibe Bar's native cards."
+  },
+  "quota.bridge.refresh": {
+    "comment": "Tooltip on the CodexBar bridge card's refresh button",
+    "value": "Refresh CodexBar providers"
+  },
+  "quota.bridge.subtitle": {
+    "comment": "Subtitle of the CodexBar bridge card before its version is known",
+    "value": "Additional providers · read-only"
+  },
+  "quota.bridge.subtitleVersion": {
+    "comment": "Subtitle of the CodexBar bridge card once the installed version is known",
+    "value": "CodexBar {version} · read-only"
+  },
+  "quota.bridge.title": {
+    "comment": "Title of the card listing quota read from a CodexBar install; CodexBar is a product name",
+    "value": "CodexBar Bridge"
+  },
   "quota.bucket.noResetInfo": {
     "comment": "Caption under a quota bar when the provider reported no reset time",
     "value": "No reset info"
@@ -1872,6 +1892,67 @@
     },
     "comment": "Narrow form of the mini window surplus forecast line",
     "value": "surplus {percent}%"
+  },
+  "quota.mini.nextProvider": {
+    "comment": "Tooltip on the mini focus layout's button that pages to the next provider",
+    "value": "Next provider"
+  },
+  "quota.mini.noLiveData": {
+    "comment": "Mini window placeholder when none of the selected fields has a live reading yet",
+    "value": "No selected fields have live data"
+  },
+  "quota.mini.pageIndicator": {
+    "args": {
+      "index": "int",
+      "total": "int"
+    },
+    "comment": "Mini focus layout's page counter when there are too many providers for dots",
+    "value": "{index}/{total}"
+  },
+  "quota.mini.railEmpty": {
+    "comment": "Empty state of the mini window's refill rail; only the user's selected fields are considered",
+    "value": "Nothing selected refills in the next seven days."
+  },
+  "quota.mini.railTitle": {
+    "args": {
+      "days": "int"
+    },
+    "comment": "Heading of the mini window's refill rail, naming how far ahead it looks",
+    "value": "QUOTA RESETS · NEXT {days} DAYS"
+  },
+  "quota.mini.resets": {
+    "comment": "Mini window caption for when a bucket refills; countdown is a compact span",
+    "value": "resets {countdown}"
+  },
+  "quota.mini.rowHelp": {
+    "args": {
+      "percent": "int"
+    },
+    "comment": "Tooltip on a mini window row; subProvider and row are names, percent the current reading",
+    "value": "{subProvider} — {row}: {percent}%"
+  },
+  "quota.misc.independentCopies": {
+    "args": {
+      "count": "int"
+    },
+    "comment": "Caption under a misc provider that holds more than one independently configured account",
+    "value": "{count, plural, one {1 independent copy} other {# independent copies}}"
+  },
+  "quota.misc.notConfigured": {
+    "comment": "Body of a misc provider card that has no credential yet",
+    "value": "Not configured."
+  },
+  "quota.misc.refreshCopies": {
+    "comment": "Tooltip on the refresh button of a misc provider that has several configured copies",
+    "value": "Refresh {provider} copies"
+  },
+  "quota.misc.refreshProvider": {
+    "comment": "Tooltip on the refresh button of a misc provider's card",
+    "value": "Refresh {provider}"
+  },
+  "quota.misc.setUpInSettings": {
+    "comment": "Button on an unconfigured misc provider card that opens its settings",
+    "value": "Set up in Settings"
   },
   "quota.mode.remaining": {
     "comment": "Caption saying the bar shows what is left",

--- a/Resources/i18n/en.json
+++ b/Resources/i18n/en.json
@@ -1096,6 +1096,18 @@
     "comment": "Empty-state title while a sync is in flight",
     "value": "Checking the Relay…"
   },
+  "popover.machines.freshness.delayed": {
+    "comment": "Badge on a remote machine whose last report is later than expected",
+    "value": "Delayed"
+  },
+  "popover.machines.freshness.live": {
+    "comment": "Badge on a remote machine reporting on schedule",
+    "value": "Live"
+  },
+  "popover.machines.freshness.stale": {
+    "comment": "Badge on a remote machine that has not reported for a long time",
+    "value": "Stale"
+  },
   "popover.machines.includeInTotals": {
     "comment": "Toggle on a remote machine card",
     "value": "Include in totals"

--- a/Resources/i18n/en.json
+++ b/Resources/i18n/en.json
@@ -4133,17 +4133,9 @@
     "comment": "Usage Mix dimension: which working directory the tokens came from",
     "value": "Projects"
   },
-  "usage.mix.dimension.tokenFlow": {
-    "comment": "Usage Mix dimension: fresh input against cache and output",
-    "value": "Token Flow"
-  },
   "usage.mix.donutUnit": {
     "comment": "Unit under the total in the middle of a donut card.",
     "value": "tokens"
-  },
-  "usage.mix.empty": {
-    "comment": "Usage Mix empty state when the range holds no local usage",
-    "value": "No local usage in this range."
   },
   "usage.mix.flow.cache": {
     "comment": "Token Flow slice: cached tokens",
@@ -4189,13 +4181,6 @@
     "comment": "Donut card on the Usage Stats distribution wall: tokens by model.",
     "value": "Model Mix"
   },
-  "usage.mix.moreSlices": {
-    "args": {
-      "count": "int"
-    },
-    "comment": "Detail on the Usage Mix slice that stands in for everything below the cut",
-    "value": "{count} more"
-  },
   "usage.mix.other": {
     "comment": "Donut slice that collapses everything below the top five.",
     "value": "Other"
@@ -4218,10 +4203,6 @@
   "usage.mix.project.title": {
     "comment": "Donut card on the Usage Stats distribution wall: tokens by project directory.",
     "value": "Project Mix"
-  },
-  "usage.mix.projectsPending": {
-    "comment": "Usage Mix empty state on the Projects dimension before a cost refresh has attributed anything",
-    "value": "Project attribution appears after the next Codex or Claude cost refresh."
   },
   "usage.mix.provider.empty": {
     "comment": "Empty state inside the Provider Mix donut card.",
@@ -4250,10 +4231,6 @@
   "usage.mix.tokenFlow.title": {
     "comment": "Donut card on the Usage Stats distribution wall: tokens by kind.",
     "value": "Token Flow"
-  },
-  "usage.mix.tokensCaption": {
-    "comment": "Caption under the total in the middle of the Usage Mix donut",
-    "value": "tokens"
   },
   "usage.noHarnessSelected.detail": {
     "comment": "Empty state body explaining the All chip",

--- a/Resources/i18n/zh-Hans.json
+++ b/Resources/i18n/zh-Hans.json
@@ -821,6 +821,21 @@
   "quota.awaitingFirstObservation": {
     "value": "等待首次额度观测"
   },
+  "quota.bridge.empty": {
+    "value": "没有仅存在于 CodexBar 的厂商返回额度窗口。重叠的厂商仍显示在 Vibe Bar 自己的卡片上。"
+  },
+  "quota.bridge.refresh": {
+    "value": "刷新 CodexBar 厂商"
+  },
+  "quota.bridge.subtitle": {
+    "value": "额外厂商 · 只读"
+  },
+  "quota.bridge.subtitleVersion": {
+    "value": "CodexBar {version} · 只读"
+  },
+  "quota.bridge.title": {
+    "value": "CodexBar 桥接"
+  },
   "quota.bucket.noResetInfo": {
     "value": "无重置信息"
   },
@@ -1252,6 +1267,42 @@
   },
   "quota.mini.forecastSurplusCompact": {
     "value": "盈余 {percent}%"
+  },
+  "quota.mini.nextProvider": {
+    "value": "下一个厂商"
+  },
+  "quota.mini.noLiveData": {
+    "value": "所选字段暂无实时数据"
+  },
+  "quota.mini.pageIndicator": {
+    "value": "{index}/{total}"
+  },
+  "quota.mini.railEmpty": {
+    "value": "所选项目在未来 7 天内没有补额。"
+  },
+  "quota.mini.railTitle": {
+    "value": "额度重置 · 未来 {days} 天"
+  },
+  "quota.mini.resets": {
+    "value": "{countdown}重置"
+  },
+  "quota.mini.rowHelp": {
+    "value": "{subProvider} — {row}：{percent}%"
+  },
+  "quota.misc.independentCopies": {
+    "value": "{count, plural, other {# 份}}独立配置"
+  },
+  "quota.misc.notConfigured": {
+    "value": "尚未配置。"
+  },
+  "quota.misc.refreshCopies": {
+    "value": "刷新 {provider} 的全部副本"
+  },
+  "quota.misc.refreshProvider": {
+    "value": "刷新 {provider}"
+  },
+  "quota.misc.setUpInSettings": {
+    "value": "在设置中配置"
   },
   "quota.mode.remaining": {
     "value": "剩余"

--- a/Resources/i18n/zh-Hans.json
+++ b/Resources/i18n/zh-Hans.json
@@ -2852,14 +2852,8 @@
   "usage.mix.dimension.projects": {
     "value": "项目"
   },
-  "usage.mix.dimension.tokenFlow": {
-    "value": "Token 流向"
-  },
   "usage.mix.donutUnit": {
     "value": "token"
-  },
-  "usage.mix.empty": {
-    "value": "所选范围内没有本机用量。"
   },
   "usage.mix.flow.cache": {
     "value": "缓存"
@@ -2894,9 +2888,6 @@
   "usage.mix.model.title": {
     "value": "模型分布"
   },
-  "usage.mix.moreSlices": {
-    "value": "另有 {count} 项"
-  },
   "usage.mix.other": {
     "value": "其他"
   },
@@ -2911,9 +2902,6 @@
   },
   "usage.mix.project.title": {
     "value": "项目分布"
-  },
-  "usage.mix.projectsPending": {
-    "value": "项目归属会在下一次 Codex 或 Claude 花费刷新后出现。"
   },
   "usage.mix.provider.empty": {
     "value": "所选范围内没有厂商流量"
@@ -2935,9 +2923,6 @@
   },
   "usage.mix.tokenFlow.title": {
     "value": "Token 流向"
-  },
-  "usage.mix.tokensCaption": {
-    "value": "token"
   },
   "usage.noHarnessSelected.detail": {
     "value": "「全部 harness」是一个开关：再次点击即可将全部 harness 重新纳入查询。"

--- a/Resources/i18n/zh-Hans.json
+++ b/Resources/i18n/zh-Hans.json
@@ -770,6 +770,15 @@
   "popover.machines.checking": {
     "value": "正在检查 Relay…"
   },
+  "popover.machines.freshness.delayed": {
+    "value": "延迟"
+  },
+  "popover.machines.freshness.live": {
+    "value": "实时"
+  },
+  "popover.machines.freshness.stale": {
+    "value": "已过期"
+  },
   "popover.machines.includeInTotals": {
     "value": "计入总计"
   },

--- a/Resources/i18n/zh-Hans.json
+++ b/Resources/i18n/zh-Hans.json
@@ -98,6 +98,9 @@
   "common.name": {
     "value": "名称"
   },
+  "common.noData": {
+    "value": "无记录数据"
+  },
   "common.off": {
     "value": "已关闭"
   },
@@ -155,6 +158,15 @@
   "cost.allProviders": {
     "value": "全部厂商"
   },
+  "cost.chart.metricCostHelp": {
+    "value": "按美元绘制花费"
+  },
+  "cost.chart.metricTokens": {
+    "value": "Tok"
+  },
+  "cost.chart.metricTokensHelp": {
+    "value": "按 token 数量绘制"
+  },
   "cost.empty.antigravity": {
     "value": "暂未发现 Antigravity 会话的 token 元数据。"
   },
@@ -188,8 +200,80 @@
   "cost.googleAI.title": {
     "value": "Google AI 花费"
   },
+  "cost.granularity.auto": {
+    "value": "自动"
+  },
+  "cost.granularity.day": {
+    "value": "天"
+  },
+  "cost.granularity.hour": {
+    "value": "小时"
+  },
+  "cost.granularity.month": {
+    "value": "月"
+  },
+  "cost.granularity.week": {
+    "value": "周"
+  },
   "cost.history.allProviders": {
     "value": "全部厂商花费历史"
+  },
+  "cost.history.building": {
+    "value": "正在积累历史…"
+  },
+  "cost.history.buildingDetail": {
+    "value": "下一次本机扫描后会出现花费样本。"
+  },
+  "cost.history.clearModelSelection": {
+    "value": "清除模型选择"
+  },
+  "cost.history.emptyCost": {
+    "value": "所选范围内没有花费记录。"
+  },
+  "cost.history.emptyTokens": {
+    "value": "所选范围内没有 token 记录。"
+  },
+  "cost.history.extentNote": {
+    "value": "{span} · {start} – {end}"
+  },
+  "cost.history.granularityDisabled": {
+    "value": "{granularity}需要不同的缩放级别"
+  },
+  "cost.history.groupBy": {
+    "value": "按{granularity}聚合花费历史"
+  },
+  "cost.history.hourlyFallback": {
+    "value": "无按小时数据 · 改按天显示"
+  },
+  "cost.history.metricAverage": {
+    "value": "平均/{granularity}"
+  },
+  "cost.history.metricPeak": {
+    "value": "峰值"
+  },
+  "cost.history.metricTotal": {
+    "value": "合计"
+  },
+  "cost.history.modelDetailUnavailable": {
+    "value": "该历史区间没有保留按模型的明细。"
+  },
+  "cost.history.modelsAt": {
+    "value": "模型 · {when}"
+  },
+  "cost.history.moreModels": {
+    "value": "另有 {count} 项 · 点击查看"
+  },
+  "cost.history.navigator": {
+    "value": "花费历史范围导航"
+  },
+  "cost.history.title": {
+    "value": "花费历史"
+  },
+  "cost.history.weekOf": {
+    "value": "{date} 当周"
+  },
+  "cost.history.weekShortOf": {
+    "value": "{date} 当周"
   },
   "cost.metric.peakDay": {
     "value": "单日最高"
@@ -662,11 +746,26 @@
   "popover.header.machinesSubtitle": {
     "value": "端到端加密的远程用量"
   },
+  "popover.header.mini": {
+    "value": "迷你窗口"
+  },
   "popover.header.miscSubtitle": {
     "value": "仅用量 · 登录或粘贴密钥"
   },
+  "popover.header.openWorkbench": {
+    "value": "打开 Workbench"
+  },
   "popover.header.overviewSubtitle": {
     "value": "全部厂商 · 额度与花费"
+  },
+  "popover.header.refreshing": {
+    "value": "正在刷新…"
+  },
+  "popover.header.settings": {
+    "value": "设置"
+  },
+  "popover.header.updatedLine": {
+    "value": "{subtitle} · {updated}"
   },
   "popover.machines.checking": {
     "value": "正在检查 Relay…"
@@ -719,11 +818,17 @@
   "popover.tab.overview": {
     "value": "总览"
   },
+  "quota.awaitingFirstObservation": {
+    "value": "等待首次额度观测"
+  },
   "quota.bucket.noResetInfo": {
     "value": "无重置信息"
   },
   "quota.bucket.resetsIn": {
     "value": "距重置 {when}"
+  },
+  "quota.cycleRecordedOnRefill": {
+    "value": "额度补满时记录一个周期"
   },
   "quota.empty.needsLogin.detail": {
     "value": "在终端中运行 `{command} login`，然后刷新。"
@@ -764,6 +869,18 @@
   "quota.forecast.confidence.medium": {
     "value": "中等置信度"
   },
+  "quota.forecast.explain.footer": {
+    "value": "消耗量来自额度观测值。Token 历史只用于推断惯常工作时段的权重，不会换算成额度用量。"
+  },
+  "quota.forecast.explain.hide": {
+    "value": "隐藏预测计算过程"
+  },
+  "quota.forecast.explain.show": {
+    "value": "显示预测计算过程"
+  },
+  "quota.forecast.explain.title": {
+    "value": "该预测的计算方式"
+  },
   "quota.forecast.guidance.atRisk": {
     "value": "降低使用速度，或将任务转移至其他额度"
   },
@@ -787,6 +904,126 @@
   },
   "quota.forecast.guidance.withinTarget": {
     "value": "仍在 {target}% 的安全余量之内"
+  },
+  "quota.forecast.legend.item": {
+    "value": "{label} {value}"
+  },
+  "quota.forecast.metric.aboveTarget": {
+    "value": "高于目标 {percent}% 的额度"
+  },
+  "quota.forecast.metric.activityFallback": {
+    "value": "形成习惯数据前按自然时间兜底"
+  },
+  "quota.forecast.metric.activityTiming": {
+    "value": "活跃时段"
+  },
+  "quota.forecast.metric.activityWeighted": {
+    "value": "按星期与小时加权"
+  },
+  "quota.forecast.metric.behaviorDetail": {
+    "value": "在更强证据不足时使用"
+  },
+  "quota.forecast.metric.behaviorFallback": {
+    "value": "行为兜底"
+  },
+  "quota.forecast.metric.comparableCycles": {
+    "value": "{count, plural, other {# 个}}可比重置周期"
+  },
+  "quota.forecast.metric.coverage": {
+    "value": "覆盖度"
+  },
+  "quota.forecast.metric.coverageDetail": {
+    "value": "新鲜度 {fresh}% · 习惯 {habits}%"
+  },
+  "quota.forecast.metric.coverageValue": {
+    "value": "观测 {observations}% · 历史 {history}%"
+  },
+  "quota.forecast.metric.cyclesPending": {
+    "value": "完整周期会显示在这里"
+  },
+  "quota.forecast.metric.elapsed": {
+    "value": "已过 {percent}%"
+  },
+  "quota.forecast.metric.evidence": {
+    "value": "依据"
+  },
+  "quota.forecast.metric.evidenceDetail": {
+    "value": "{confidence} · 评分 {score}%"
+  },
+  "quota.forecast.metric.evidenceValue": {
+    "value": "{observations} 次观测 · {cycles} 个周期"
+  },
+  "quota.forecast.metric.expectedLeft": {
+    "value": "预计剩余 {percent}%"
+  },
+  "quota.forecast.metric.expectedUsed": {
+    "value": "预计已用 {percent}%"
+  },
+  "quota.forecast.metric.forecastAtReset": {
+    "value": "重置时预测"
+  },
+  "quota.forecast.metric.forecastRange": {
+    "value": "预测区间"
+  },
+  "quota.forecast.metric.insideTarget": {
+    "value": "在目标区间内"
+  },
+  "quota.forecast.metric.noComparison": {
+    "value": "尚无可比数据"
+  },
+  "quota.forecast.metric.plan": {
+    "value": "当前个人计划"
+  },
+  "quota.forecast.metric.planDetail": {
+    "value": "活跃时段 + {target}% 安全余量目标"
+  },
+  "quota.forecast.metric.rangeLeft": {
+    "value": "剩余 {lower}–{upper}%"
+  },
+  "quota.forecast.metric.rangeUsed": {
+    "value": "已用 {lower}–{upper}%"
+  },
+  "quota.forecast.metric.recentBurn": {
+    "value": "近期消耗"
+  },
+  "quota.forecast.metric.recentIntervals": {
+    "value": "{count, plural, other {# 段}}近期区间"
+  },
+  "quota.forecast.metric.recentMissing": {
+    "value": "至少需要两次有效观测"
+  },
+  "quota.forecast.metric.recentTrend": {
+    "value": "近期趋势"
+  },
+  "quota.forecast.metric.safetyTarget": {
+    "value": "安全余量目标"
+  },
+  "quota.forecast.metric.timePace": {
+    "value": "纯时间进度"
+  },
+  "quota.forecast.metric.timePaceDetail": {
+    "value": "按自然时间：{stage}"
+  },
+  "quota.forecast.metric.timePaceMissing": {
+    "value": "需要重置时间与窗口长度"
+  },
+  "quota.forecast.metric.trendDetail": {
+    "value": "最近 7 天对比之前 21 天"
+  },
+  "quota.forecast.metric.trendDetailMissing": {
+    "value": "需要更早的每日活跃数据"
+  },
+  "quota.forecast.metric.trendMissing": {
+    "value": "尚无基线"
+  },
+  "quota.forecast.metric.trendMultiplier": {
+    "value": "活跃度 {multiplier}×"
+  },
+  "quota.forecast.metric.unavailable": {
+    "value": "不可用"
+  },
+  "quota.forecast.metric.uncertaintyInterval": {
+    "value": "不确定区间"
   },
   "quota.forecast.reset.atRisk": {
     "value": "很可能在重置前耗尽"
@@ -832,6 +1069,12 @@
   },
   "quota.forecast.useUp.uncertain": {
     "value": "耗尽时间不确定 · 可能在重置前不足"
+  },
+  "quota.forecast.value.atReset": {
+    "value": "重置时{value}"
+  },
+  "quota.forecast.value.expectedNow": {
+    "value": "当前预期{value}"
   },
   "quota.forecast.value.left": {
     "value": "剩余 {percent}%"
@@ -917,6 +1160,63 @@
   "quota.group.weeklyCredits": {
     "value": "每周额度"
   },
+  "quota.history.allCurvesHidden": {
+    "value": "所有曲线均已隐藏 — 请从上方菜单中选择。"
+  },
+  "quota.history.buildingUp": {
+    "value": "额度历史会随刷新逐步积累。"
+  },
+  "quota.history.curveCount": {
+    "value": "{count, plural, other {# 条}}曲线"
+  },
+  "quota.history.curvePickerA11y": {
+    "value": "选择要显示的额度曲线"
+  },
+  "quota.history.curvesAll": {
+    "value": "全部 {total}"
+  },
+  "quota.history.curvesSome": {
+    "value": "{total} 中的 {shown}"
+  },
+  "quota.history.forecastLegend": {
+    "value": "预测"
+  },
+  "quota.history.moreBuckets": {
+    "value": "{names} +{count}"
+  },
+  "quota.history.moreReadings": {
+    "value": "另有 {count} 项"
+  },
+  "quota.history.navigatorAllProviders": {
+    "value": "全部厂商额度历史范围导航"
+  },
+  "quota.history.navigatorProvider": {
+    "value": "额度历史范围导航"
+  },
+  "quota.history.providerCount": {
+    "value": "{count, plural, other {# 家}}厂商"
+  },
+  "quota.history.scopeNote": {
+    "value": "{scope} · 已记录 {total}，显示 {visible}"
+  },
+  "quota.history.showAllCurves": {
+    "value": "显示全部曲线"
+  },
+  "quota.history.showBusiest": {
+    "value": "仅显示最活跃的"
+  },
+  "quota.history.title": {
+    "value": "额度历史"
+  },
+  "quota.history.tooltipAtReset": {
+    "value": "重置时"
+  },
+  "quota.history.tooltipPace": {
+    "value": "进度"
+  },
+  "quota.history.tooltipQuotaLeft": {
+    "value": "剩余额度"
+  },
   "quota.login.claude": {
     "value": "运行 claude login，然后刷新。"
   },
@@ -932,17 +1232,56 @@
   "quota.login.misc": {
     "value": "在「设置 → 其他厂商」中配置 {provider}。"
   },
+  "quota.mini.forecastLearning": {
+    "value": "学习中 · 剩余 {percent}%"
+  },
+  "quota.mini.forecastLearningCompact": {
+    "value": "约剩余 {percent}%"
+  },
+  "quota.mini.forecastLeft": {
+    "value": "剩余 {percent}%"
+  },
+  "quota.mini.forecastLeftCompact": {
+    "value": "剩余 {percent}%"
+  },
+  "quota.mini.forecastMayRunOut": {
+    "value": "可能 {countdown}耗尽"
+  },
+  "quota.mini.forecastSurplus": {
+    "value": "盈余 · 剩余 {percent}%"
+  },
+  "quota.mini.forecastSurplusCompact": {
+    "value": "盈余 {percent}%"
+  },
   "quota.mode.remaining": {
     "value": "剩余"
   },
   "quota.mode.used": {
     "value": "已用"
   },
+  "quota.pace.deficit": {
+    "value": "超支 {percent}%"
+  },
+  "quota.pace.deficitShort": {
+    "value": "超支 {percent}%"
+  },
   "quota.pace.lastsUntilReset": {
     "value": "可用到重置"
   },
+  "quota.pace.onTrack": {
+    "value": "进度正常"
+  },
+  "quota.pace.reserve": {
+    "value": "结余 {percent}%"
+  },
+  "quota.pace.reserveShort": {
+    "value": "结余 {percent}%"
+  },
   "quota.pace.runsOutIn": {
     "value": "{countdown}后耗尽"
+  },
+  "quota.pace.runsOutShort": {
+    "value": "{countdown}耗尽"
   },
   "quota.perModelLimits": {
     "value": "{count, plural, other {# 个}}按模型的限额 · 打开 {provider} 查看详情"
@@ -992,11 +1331,35 @@
   "quota.resetHistory.axis.timeHelp": {
     "value": "按实际发生时间排布在同一条日历上"
   },
+  "quota.resetHistory.axisCurrent": {
+    "value": "当前"
+  },
   "quota.resetHistory.axisCyclesBack": {
     "value": "−{count}"
   },
   "quota.resetHistory.axisNow": {
     "value": "现在"
+  },
+  "quota.resetHistory.barIsOneCycle": {
+    "value": "每根柱条代表一个额度周期"
+  },
+  "quota.resetHistory.compareEmpty": {
+    "value": "暂无可对比的数据 — 厂商上报按周或更长周期的额度后会显示在此。"
+  },
+  "quota.resetHistory.compareTitle": {
+    "value": "重置历史对比"
+  },
+  "quota.resetHistory.compareWindow": {
+    "value": "对比{window}"
+  },
+  "quota.resetHistory.currentCycleCaption": {
+    "value": "当前周期 · 已用 {used}% · 剩余 {left}%"
+  },
+  "quota.resetHistory.cycleCaption": {
+    "value": "{time} 重置 · 已用 {used}% · 剩余 {left}%"
+  },
+  "quota.resetHistory.earlyRefillCount": {
+    "value": "{count, plural, other {# 个周期}}在窗口结束前补额"
   },
   "quota.resetHistory.lane.emptyState": {
     "value": "尚无完整周期 — 额度补满时才会记录一个周期"
@@ -1013,6 +1376,21 @@
   "quota.resetHistory.lane.wasteSummary": {
     "value": "平均浪费 {percent}% · 最近 {count, plural, other {# 个周期}}"
   },
+  "quota.resetHistory.lastSeenBefore": {
+    "value": "重置前 {duration}最后一次观测"
+  },
+  "quota.resetHistory.legend.barHeight": {
+    "value": "柱高 = 重置时剩余"
+  },
+  "quota.resetHistory.legend.byDate": {
+    "value": "按日期排布"
+  },
+  "quota.resetHistory.legend.perCycle": {
+    "value": "每个周期一列"
+  },
+  "quota.resetHistory.legend.refilledEarly": {
+    "value": "提前补额"
+  },
   "quota.resetHistory.reset.earlyClockRestarted": {
     "value": "提前补额，下一周期重新计时"
   },
@@ -1021,6 +1399,12 @@
   },
   "quota.resetHistory.reset.earlyUnclear": {
     "value": "提前补额，重置节奏已改变"
+  },
+  "quota.resetHistory.retiredAccount": {
+    "value": "已登出的账号"
+  },
+  "quota.resetHistory.retiredAccountNumbered": {
+    "value": "已登出的账号 {number}"
   },
   "quota.resetHistory.spoken.allCycles": {
     "value": "全部已记录周期"
@@ -1048,6 +1432,18 @@
   },
   "quota.resetHistory.title": {
     "value": "重置历史"
+  },
+  "quota.resetHistory.tooltip.completed": {
+    "value": "重置时剩余 {left}% · 已用 {used}%"
+  },
+  "quota.resetHistory.tooltip.current": {
+    "value": "当前周期 · 当前剩余 {left}% · 已用 {used}%"
+  },
+  "quota.resetHistory.tooltip.range": {
+    "value": "{start} → {end} 重置"
+  },
+  "quota.resetHistory.tooltip.rangeDue": {
+    "value": "{start} → {end} 预计重置"
   },
   "quota.resetHistory.totals.headline": {
     "value": "已用 {used}% · 浪费 {wasted}% · {count, plural, other {# 个周期}}"
@@ -1117,6 +1513,15 @@
   },
   "quota.update.failed": {
     "value": "更新失败：{reason}"
+  },
+  "quota.window.dayOfDays": {
+    "value": "第 {day}/{total} 天 · {value}"
+  },
+  "quota.window.elapsedOfWindow": {
+    "value": "{window} 已过 {elapsed} · {value}"
+  },
+  "quota.window.resetsSoon": {
+    "value": "即将重置 · {value}"
   },
   "settings.antigravityCookieEnabled": {
     "value": "Antigravity 的 cookie 导入已启用 — 请先在 antigravity.google 登录。"
@@ -2249,6 +2654,27 @@
   "status.overview.title": {
     "value": "状态"
   },
+  "usage.activity.a11y": {
+    "value": "按星期与小时划分的 token 用量，7 天 × 24 小时"
+  },
+  "usage.activity.cellTooltip": {
+    "value": "{day} {hour} · {tokens}"
+  },
+  "usage.activity.heavy": {
+    "value": "繁忙"
+  },
+  "usage.activity.peak": {
+    "value": "高峰 {hour} · {day}"
+  },
+  "usage.activity.peakCell": {
+    "value": "高峰 {hour} · {day} {cellHour}"
+  },
+  "usage.activity.quiet": {
+    "value": "清闲"
+  },
+  "usage.activity.tokensShort": {
+    "value": "{tokens} tok"
+  },
   "usage.breakdown.models": {
     "value": "模型"
   },
@@ -2263,6 +2689,21 @@
   },
   "usage.breakdown.requests": {
     "value": "请求"
+  },
+  "usage.chartNavigator.label": {
+    "value": "图表范围导航"
+  },
+  "usage.chartNavigator.range": {
+    "value": "{start} 至 {end}"
+  },
+  "usage.chartNavigator.showFullRange": {
+    "value": "显示完整范围"
+  },
+  "usage.chartNavigator.zoomIn": {
+    "value": "放大"
+  },
+  "usage.chartNavigator.zoomOut": {
+    "value": "缩小"
   },
   "usage.filters.allHarnesses": {
     "value": "全部 harness"
@@ -2402,14 +2843,47 @@
   "usage.ledgerUnavailable.title": {
     "value": "用量账本不可用"
   },
+  "usage.mix.dimension.harnesses": {
+    "value": "Harness"
+  },
+  "usage.mix.dimension.models": {
+    "value": "模型"
+  },
+  "usage.mix.dimension.projects": {
+    "value": "项目"
+  },
+  "usage.mix.dimension.tokenFlow": {
+    "value": "Token 流向"
+  },
   "usage.mix.donutUnit": {
     "value": "token"
+  },
+  "usage.mix.empty": {
+    "value": "所选范围内没有本机用量。"
+  },
+  "usage.mix.flow.cache": {
+    "value": "缓存"
+  },
+  "usage.mix.flow.cacheDetail": {
+    "value": "读取 + 写入"
+  },
+  "usage.mix.flow.freshInput": {
+    "value": "新增输入"
+  },
+  "usage.mix.flow.output": {
+    "value": "输出"
   },
   "usage.mix.harness.subtitle": {
     "value": "请求的运行位置"
   },
   "usage.mix.harness.title": {
     "value": "Harness 分布"
+  },
+  "usage.mix.lastThirtyDays": {
+    "value": "最近 30 天"
+  },
+  "usage.mix.ledgerUnreadable": {
+    "value": "无法读取用量账本。"
   },
   "usage.mix.model.empty": {
     "value": "所选范围内没有模型流量"
@@ -2419,6 +2893,9 @@
   },
   "usage.mix.model.title": {
     "value": "模型分布"
+  },
+  "usage.mix.moreSlices": {
+    "value": "另有 {count} 项"
   },
   "usage.mix.other": {
     "value": "其他"
@@ -2435,6 +2912,9 @@
   "usage.mix.project.title": {
     "value": "项目分布"
   },
+  "usage.mix.projectsPending": {
+    "value": "项目归属会在下一次 Codex 或 Claude 花费刷新后出现。"
+  },
   "usage.mix.provider.empty": {
     "value": "所选范围内没有厂商流量"
   },
@@ -2444,6 +2924,9 @@
   "usage.mix.provider.title": {
     "value": "厂商分布"
   },
+  "usage.mix.title": {
+    "value": "用量构成"
+  },
   "usage.mix.tokenFlow.empty": {
     "value": "所选范围内没有 token 流量"
   },
@@ -2452,6 +2935,9 @@
   },
   "usage.mix.tokenFlow.title": {
     "value": "Token 流向"
+  },
+  "usage.mix.tokensCaption": {
+    "value": "token"
   },
   "usage.noHarnessSelected.detail": {
     "value": "「全部 harness」是一个开关：再次点击即可将全部 harness 重新纳入查询。"
@@ -2666,8 +3152,29 @@
   "usage.whenYouUse.googleAI": {
     "value": "Google AI 使用时段"
   },
+  "usage.whenYouUse.provider": {
+    "value": "{provider} 使用时段"
+  },
   "usage.whenYouUse.spaceXAI": {
     "value": "SpaceXAI 使用时段"
+  },
+  "usage.yearHeatmap.a11y": {
+    "value": "{provider} 过去一年的每日花费，共 {count, plural, other {# 周}}"
+  },
+  "usage.yearHeatmap.less": {
+    "value": "较少"
+  },
+  "usage.yearHeatmap.more": {
+    "value": "较多"
+  },
+  "usage.yearHeatmap.title": {
+    "value": "{provider} — 过去一年"
+  },
+  "usage.yearHeatmap.tooltip": {
+    "value": "{date} · {amount}"
+  },
+  "usage.yearHeatmap.total": {
+    "value": "合计 {amount}"
   },
   "workbench.appearance.useDark": {
     "value": "使用深色外观"

--- a/Scripts/lint_localization.py
+++ b/Scripts/lint_localization.py
@@ -113,6 +113,22 @@ MIGRATED = [
     "Sources/VibeBarCore/Models/PrimaryProviderSourcePlanner.swift",
     "Sources/VibeBarCore/Models/UpdateChannel.swift",
     "Sources/VibeBarApp/Views/RemoteMachinesPage.swift",
+    "Sources/VibeBarApp/Views/HeaderView.swift",
+    "Sources/VibeBarApp/Views/QuotaGroupCard.swift",
+    "Sources/VibeBarApp/Views/QuotaHistoryChartView.swift",
+    "Sources/VibeBarApp/Views/OverviewQuotaHistoryCard.swift",
+    "Sources/VibeBarApp/Views/OverviewUsageMixCard.swift",
+    "Sources/VibeBarApp/Views/ResetHistoryCompareView.swift",
+    "Sources/VibeBarApp/Views/FillTimelineChart.swift",
+    "Sources/VibeBarApp/Views/CostHistoryView.swift",
+    "Sources/VibeBarApp/Views/ChartBrushNavigator.swift",
+    "Sources/VibeBarApp/Views/UsageActivityView.swift",
+    "Sources/VibeBarApp/Views/YearlyContributionHeatmapView.swift",
+    "Sources/VibeBarApp/Views/MiniQuotaWindowView.swift",
+    "Sources/VibeBarCore/Services/UsagePace.swift",
+    "Sources/VibeBarCore/Services/SubscriptionWindowProgress.swift",
+    "Sources/VibeBarCore/Models/CostChartGranularity.swift",
+    "Sources/VibeBarCore/Models/UsageHeatmap+Activity.swift",
 ]
 
 
@@ -412,7 +428,12 @@ def derived_helpers(files) -> set:
             tail = source[index:index + 80]
             if "String" in parameters and VIEW_RETURNS.search(tail):
                 helpers.add(match.group(1))
-    return helpers
+    # A function *named* for an identifier builds identity, not copy, however
+    # much its signature looks like a label helper's. `OverviewQuotaCurve.id`
+    # takes three strings and returns one, so inferring from the shape alone
+    # made every `id("blank-\(n)")` in the manifest a finding. These are the
+    # same names `IDENTIFIER_ARGUMENTS` already trusts as an argument label.
+    return helpers - IDENTIFIER_ARGUMENTS
 
 
 LETTER = re.compile(r"[A-Za-z一-鿿]")

--- a/Scripts/lint_localization.py
+++ b/Scripts/lint_localization.py
@@ -112,7 +112,6 @@ MIGRATED = [
     "Sources/VibeBarCore/Models/PrimaryProviderRouteHealth.swift",
     "Sources/VibeBarCore/Models/PrimaryProviderSourcePlanner.swift",
     "Sources/VibeBarCore/Models/UpdateChannel.swift",
-    "Sources/VibeBarApp/Views/RemoteMachinesPage.swift",
     "Sources/VibeBarApp/Views/HeaderView.swift",
     "Sources/VibeBarApp/Views/QuotaGroupCard.swift",
     "Sources/VibeBarApp/Views/QuotaHistoryChartView.swift",
@@ -129,6 +128,10 @@ MIGRATED = [
     "Sources/VibeBarCore/Services/SubscriptionWindowProgress.swift",
     "Sources/VibeBarCore/Models/CostChartGranularity.swift",
     "Sources/VibeBarCore/Models/UsageHeatmap+Activity.swift",
+    "Sources/VibeBarApp/Views/MiniWindowAltLayouts.swift",
+    "Sources/VibeBarApp/Views/MiscProvidersPage.swift",
+    "Sources/VibeBarApp/Views/CodexBarProviderBridgeCard.swift",
+    "Sources/VibeBarApp/Views/RemoteMachinesPage.swift",
 ]
 
 

--- a/Scripts/lint_localization.py
+++ b/Scripts/lint_localization.py
@@ -132,6 +132,7 @@ MIGRATED = [
     "Sources/VibeBarApp/Views/MiscProvidersPage.swift",
     "Sources/VibeBarApp/Views/CodexBarProviderBridgeCard.swift",
     "Sources/VibeBarApp/Views/RemoteMachinesPage.swift",
+    "Sources/VibeBarApp/Views/RemoteMachinesPage.swift",
 ]
 
 
@@ -570,6 +571,92 @@ def formatting_findings(relative, source: str):
                 joined.count("\n", 0, match.start()) + 1,
                 "a number/percent/currency style without .locale(AppLocale.current)",
             ))
+    found += frozen_language_findings(joined)
+    return found
+
+
+# A stored `static` whose value comes out of the catalog is frozen in whatever
+# language the process launched in. `let` is the whole bug — the initializer
+# runs once, lazily, and never again — and `var` with an `=` is the same
+# storage. A computed `static var { ... }` is the fix and is deliberately not
+# matched, which is why this looks for the `=` rather than for the keyword.
+FROZEN_STATIC = re.compile(
+    r"\bstatic\s+(?:let|var)\s+[A-Za-z_]\w*\s*(?::[^=\n]+)?=", re.M
+)
+
+
+def _references_catalog_eagerly(initializer: str) -> bool:
+    """A catalog reference in `initializer` that runs when the static does.
+
+    Brace depth is the whole test: inside `{ ... }` the expression is a
+    closure body that runs per call, which is exactly how
+    `QuotaGroupLabelLocalizer.table` stays correct while looking like the bug.
+    """
+    depth = 0
+    index = 0
+    while index < len(initializer):
+        character = initializer[index]
+        if character == "{":
+            depth += 1
+        elif character == "}":
+            depth = max(0, depth - 1)
+        elif depth == 0:
+            if initializer.startswith("L10n.", index):
+                return True
+            if initializer.startswith(".displayName", index):
+                return True
+        index += 1
+    return False
+
+
+def frozen_language_findings(source: str):
+    """A `static let` holding a localized value: frozen at launch language.
+
+    `AppLocale` learned this once already — twenty `static let` formatters
+    kept the language they were built in until relaunch — and the same defect
+    reappears wherever a cache holds a *string* out of the catalog. Two of
+    those shipped in this batch (the chart's duration pills, the cost chart's
+    bucket-width labels) and neither was visible to any other rule here.
+
+    The span searched is the initializer, balanced by braces and brackets as
+    well as parentheses, because the values that actually do this are array
+    and dictionary literals spanning many lines.
+    """
+    found = []
+    opening = {"(": ")", "[": "]", "{": "}"}
+    for match in FROZEN_STATIC.finditer(source):
+        index = match.end()
+        # Walk to the end of the initializer: to the matching close of
+        # whatever bracket it opens with, or to the end of the line.
+        while index < len(source) and source[index] in " \t":
+            index += 1
+        end = index
+        if index < len(source) and source[index] in opening:
+            depth = 0
+            while end < len(source):
+                if source[end] in opening:
+                    depth += 1
+                elif source[end] in opening.values():
+                    depth -= 1
+                    if depth == 0:
+                        end += 1
+                        break
+                end += 1
+        else:
+            end = source.find("\n", index)
+            end = len(source) if end == -1 else end
+        initializer = source[index:end]
+        # A value wrapped in a closure is *deferred*, not frozen:
+        # `["weekly": { L10n.Quota.groupWeekly }]` resolves on every call and
+        # is the fix, not the bug. So only a catalog reference that is
+        # evaluated eagerly — outside any braces — counts.
+        if not _references_catalog_eagerly(initializer):
+            continue
+        found.append((
+            source.count("\n", 0, match.start()) + 1,
+            "a stored static holding a localized value — frozen at launch "
+            "language; derive it, or memoize on LanguageStamp",
+        ))
     return found
 
 

--- a/Sources/VibeBarApp/Views/ChartBrushNavigator.swift
+++ b/Sources/VibeBarApp/Views/ChartBrushNavigator.swift
@@ -406,12 +406,15 @@ struct ChartRangePills: View {
         let isSelected: Bool
     }
 
-    private static let spans: [(String, TimeInterval)] = [
+    /// Derived per render rather than cached. A `static let` here held the
+    /// labels in whatever language the process launched in — and four tuples
+    /// are cheaper to rebuild than a language-keyed cache is to reason about.
+    private static var spans: [(String, TimeInterval)] {[
         (L10n.Common.durationHours(hours: 6), 6 * 3_600),
         (L10n.Common.durationHours(hours: 24), 24 * 3_600),
         (L10n.Common.durationDays(days: 3), 3 * 86_400),
         (L10n.Common.durationDays(days: 7), 7 * 86_400)
-    ]
+    ]}
 
     private var options: [Option] {
         guard window.domainSpan > 0 else { return [] }

--- a/Sources/VibeBarApp/Views/ChartBrushNavigator.swift
+++ b/Sources/VibeBarApp/Views/ChartBrushNavigator.swift
@@ -60,7 +60,7 @@ struct ChartBrushNavigator<Mini: View>: View {
     /// purpose — the visible handle is a hairline, but a 10pt reach makes it
     /// catchable with a trackpad.
     var handleHitWidth: CGFloat = 10
-    var accessibilityDescription: String = "Chart range navigator"
+    var accessibilityDescription: String = L10n.Usage.chartNavigatorLabel
     @ViewBuilder var mini: (ChartBrushGeometry) -> Mini
 
     /// Which edge (if any) the in-flight drag grabbed. Classified once at the
@@ -119,13 +119,13 @@ struct ChartBrushNavigator<Mini: View>: View {
                 break
             }
         }
-        .accessibilityAction(named: "Zoom In") {
+        .accessibilityAction(named: L10n.Usage.chartNavigatorZoomIn) {
             window = window.zoomed(scale: 1.6, around: window.visibleMidpoint)
         }
-        .accessibilityAction(named: "Zoom Out") {
+        .accessibilityAction(named: L10n.Usage.chartNavigatorZoomOut) {
             window = window.zoomed(scale: 0.625, around: window.visibleMidpoint)
         }
-        .accessibilityAction(named: "Show Full Range") {
+        .accessibilityAction(named: L10n.Usage.chartNavigatorShowFullRange) {
             window = window.jumped(toSpan: window.domainSpan)
         }
     }
@@ -133,7 +133,7 @@ struct ChartBrushNavigator<Mini: View>: View {
     private var accessibilityRangeValue: String {
         let start = AppLocale.string(window.visibleStart, dateStyle: .medium, timeStyle: .short)
         let end = AppLocale.string(window.visibleEnd, dateStyle: .medium, timeStyle: .short)
-        return "\(start) to \(end)"
+        return L10n.Usage.chartNavigatorRange(start: start, end: end)
     }
 
     // MARK: - Overlay pieces
@@ -407,10 +407,10 @@ struct ChartRangePills: View {
     }
 
     private static let spans: [(String, TimeInterval)] = [
-        ("6h", 6 * 3_600),
-        ("24h", 24 * 3_600),
-        ("3d", 3 * 86_400),
-        ("7d", 7 * 86_400)
+        (L10n.Common.durationHours(hours: 6), 6 * 3_600),
+        (L10n.Common.durationHours(hours: 24), 24 * 3_600),
+        (L10n.Common.durationDays(days: 3), 3 * 86_400),
+        (L10n.Common.durationDays(days: 7), 7 * 86_400)
     ]
 
     private var options: [Option] {
@@ -427,7 +427,14 @@ struct ChartRangePills: View {
                         && abs(window.visibleSpan - span) <= span * 0.03
                 )
             }
-        result.append(Option(id: "all", label: "All", span: nil, isSelected: window.coversDomain))
+        result.append(
+            Option(
+                id: "all",
+                label: L10n.Cost.timeframeAll,
+                span: nil,
+                isSelected: window.coversDomain
+            )
+        )
         return result
     }
 

--- a/Sources/VibeBarApp/Views/CodexBarProviderBridgeCard.swift
+++ b/Sources/VibeBarApp/Views/CodexBarProviderBridgeCard.swift
@@ -29,16 +29,19 @@ struct CodexBarProviderBridgeCard: View {
                 .background(Circle().fill(Color.accentColor.opacity(0.12)))
                 .overlay(Circle().stroke(Color.accentColor.opacity(0.35), lineWidth: 0.7))
             VStack(alignment: .leading, spacing: 2) {
-                Text("CodexBar Bridge")
+                Text(L10n.Quota.bridgeTitle)
                     .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
-                Text(snapshot?.version.map { "CodexBar \($0) · read-only" } ?? "Additional providers · read-only")
+                Text(
+                    snapshot?.version.map { L10n.Quota.bridgeSubtitleVersion(version: $0) }
+                        ?? L10n.Quota.bridgeSubtitle
+                )
                     .font(.system(size: density.subtitleFontSize))
                     .foregroundStyle(.tertiary)
             }
             Spacer(minLength: 4)
             BorderlessIconButton(
                 systemImage: "arrow.clockwise",
-                help: "Refresh CodexBar providers",
+                help: L10n.Quota.bridgeRefresh,
                 size: density.subtitleFontSize
             ) {
                 Task { await refresh() }
@@ -69,7 +72,7 @@ struct CodexBarProviderBridgeCard: View {
                 .fixedSize(horizontal: false, vertical: true)
                 .padding(.vertical, 10)
         } else {
-            Text("No enabled CodexBar-only provider returned a quota window. Overlapping providers remain on Vibe Bar's native cards.")
+            Text(L10n.Quota.bridgeEmpty)
                 .font(.system(size: density.subtitleFontSize))
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
@@ -105,7 +108,7 @@ struct CodexBarProviderBridgeCard: View {
                     .font(.system(size: max(9, density.subtitleFontSize - 1)))
                     .lineLimit(1)
                 Spacer(minLength: 6)
-                Text("\(Int(percent.rounded()))%")
+                Text(L10n.Common.percent(value: Int(percent.rounded())))
                     .font(.system(size: density.subtitleFontSize, weight: .semibold,
                                   design: .rounded).monospacedDigit())
                     .foregroundStyle(Theme.barColor(percent: percent, mode: mode))
@@ -116,7 +119,7 @@ struct CodexBarProviderBridgeCard: View {
                 height: max(3, density.bucketBarHeight - 1)
             )
             if let countdown = ResetCountdownFormatter.stringWithAbsoluteTime(from: window.resetAt) {
-                Text("Resets \(countdown)")
+                Text(L10n.Quota.bucketResetsIn(when: countdown))
                     .font(.system(size: density.resetCountdownFontSize))
                     .foregroundStyle(.tertiary)
             }

--- a/Sources/VibeBarApp/Views/CostHistoryView.swift
+++ b/Sources/VibeBarApp/Views/CostHistoryView.swift
@@ -21,14 +21,14 @@ private enum CostChartMetric: String, CaseIterable, Identifiable {
     var label: String {
         switch self {
         case .cost: "$"
-        case .tokens: "Tok"
+        case .tokens: L10n.Cost.chartMetricTokens
         }
     }
 
     var help: String {
         switch self {
-        case .cost: "Plot spend in dollars"
-        case .tokens: "Plot token volume"
+        case .cost: L10n.Cost.chartMetricCostHelp
+        case .tokens: L10n.Cost.chartMetricTokensHelp
         }
     }
 }
@@ -57,7 +57,7 @@ private struct CostGranularityOption: Identifiable, Equatable {
     }
 
     static let all: [CostGranularityOption] = [
-        CostGranularityOption(mode: .auto, label: "Auto", granularity: nil),
+        CostGranularityOption(mode: .auto, label: L10n.Cost.granularityAuto, granularity: nil),
         CostGranularityOption(
             mode: .manual(.hour),
             label: CostChartGranularity.hour.displayName,
@@ -108,19 +108,19 @@ private enum CostRangePreset: String, CaseIterable, Identifiable {
 
     var shortLabel: String {
         switch self {
-        case .today: "Today"
-        case .week: "7d"
-        case .month: "30d"
-        case .all: "All"
+        case .today: L10n.Cost.timeframeToday
+        case .week: L10n.Cost.timeframeWeekShort
+        case .month: L10n.Cost.timeframeMonthShort
+        case .all: L10n.Cost.timeframeAll
         }
     }
 
     var label: String {
         switch self {
-        case .today: "Today"
-        case .week: "7 days"
-        case .month: "30 days"
-        case .all: "All"
+        case .today: L10n.Cost.timeframeToday
+        case .week: L10n.Cost.timeframeWeek
+        case .month: L10n.Cost.timeframeMonth
+        case .all: L10n.Cost.timeframeAll
         }
     }
 }
@@ -261,7 +261,7 @@ struct CostHistoryView: View {
     private func header(window: ChartTimeWindow?) -> some View {
         VStack(alignment: .trailing, spacing: 4) {
             HStack(alignment: .firstTextBaseline, spacing: 6) {
-                Text(titleOverride ?? "Cost History")
+                Text(titleOverride ?? L10n.Cost.historyTitle)
                     .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
                 Spacer(minLength: 8)
                 metricToggle
@@ -353,10 +353,10 @@ struct CostHistoryView: View {
 
     private var emptyNote: some View {
         VStack(spacing: 4) {
-            Text("Building history…")
+            Text(L10n.Cost.historyBuilding)
                 .font(.system(size: density.subtitleFontSize))
                 .foregroundStyle(.tertiary)
-            Text("Cost samples appear after the next local scan.")
+            Text(L10n.Cost.historyBuildingDetail)
                 .font(.system(size: density.resetCountdownFontSize))
                 .foregroundStyle(.tertiary)
         }
@@ -389,7 +389,7 @@ struct CostHistoryView: View {
                 window: binding,
                 accent: .accentColor,
                 height: density.chartBrushHeight,
-                accessibilityDescription: "Cost history range navigator"
+                accessibilityDescription: L10n.Cost.historyNavigator
             ) { geometry in
                 miniBars(in: geometry)
             }
@@ -439,8 +439,8 @@ struct CostHistoryView: View {
         .overlay {
             if points.isEmpty {
                 Text(chartMetric == .cost
-                    ? "No cost recorded in this range."
-                    : "No tokens recorded in this range.")
+                    ? L10n.Cost.historyEmptyCost
+                    : L10n.Cost.historyEmptyTokens)
                     .font(.system(size: density.resetCountdownFontSize))
                     .foregroundStyle(.tertiary)
                     .allowsHitTesting(false)
@@ -722,7 +722,7 @@ struct CostHistoryView: View {
                 modelRow(model)
             }
             if point.models.count > 3 {
-                Text("+\(point.models.count - 3) more · click to inspect")
+                Text(L10n.Cost.historyMoreModels(count: point.models.count - 3))
                     .font(.system(size: 8, weight: .medium))
                     .foregroundStyle(.secondary)
             }
@@ -743,7 +743,11 @@ struct CostHistoryView: View {
 
             if let point = inspectedPoint {
                 HStack(spacing: 8) {
-                    Text("Models · \(tooltipDate(point.date, granularity: granularity))")
+                    Text(
+                        L10n.Cost.historyModelsAt(
+                            when: tooltipDate(point.date, granularity: granularity)
+                        )
+                    )
                         .font(.system(size: 10, weight: .semibold))
                     Spacer(minLength: 8)
                     Button {
@@ -753,11 +757,11 @@ struct CostHistoryView: View {
                     }
                     .buttonStyle(.vibeBar)
                     .foregroundStyle(.secondary)
-                    .help("Clear model selection")
+                    .help(L10n.Cost.historyClearModelSelection)
                 }
 
                 if point.models.isEmpty {
-                    Text("Model detail is unavailable for this historical period.")
+                    Text(L10n.Cost.historyModelDetailUnavailable)
                         .font(.system(size: 9))
                         .foregroundStyle(.secondary)
                         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
@@ -886,13 +890,15 @@ struct CostHistoryView: View {
         resolved: CostResolvedGranularity
     ) -> some View {
         HStack(alignment: .top, spacing: spacing) {
-            metric(label: "Total", value: formatMetric(total))
+            metric(label: L10n.Cost.historyMetricTotal, value: formatMetric(total))
             metric(
-                label: "Avg/\(resolved.granularity.displayName.lowercased())",
+                label: L10n.Cost.historyMetricAverage(
+                    granularity: resolved.granularity.displayName.lowercased()
+                ),
                 value: formatMetric(average)
             )
             metric(
-                label: "Peak",
+                label: L10n.Cost.historyMetricPeak,
                 value: formatMetric(peak),
                 detail: peakDate.map { peakDetail($0, granularity: resolved.granularity) }
             )
@@ -909,7 +915,7 @@ struct CostHistoryView: View {
                 .font(.system(size: density.resetCountdownFontSize))
                 .foregroundStyle(.tertiary)
             if resolved.hourlyFallback {
-                Text("hourly n/a · showing daily")
+                Text(L10n.Cost.historyHourlyFallback)
                     .font(.system(size: max(8, density.resetCountdownFontSize - 1)))
                     .foregroundStyle(.tertiary)
             }
@@ -1089,10 +1095,12 @@ struct CostHistoryView: View {
                 .disabled(!enabled)
                 .help(
                     enabled
-                        ? "Group cost history by \(option.label.lowercased())"
-                        : "\(option.label) needs a different zoom level"
+                        ? L10n.Cost.historyGroupBy(granularity: option.label.lowercased())
+                        : L10n.Cost.historyGranularityDisabled(granularity: option.label)
                 )
-                .accessibilityLabel("Group cost history by \(option.label.lowercased())")
+                .accessibilityLabel(
+                    L10n.Cost.historyGroupBy(granularity: option.label.lowercased())
+                )
             }
         }
         .padding(2)
@@ -1471,16 +1479,20 @@ struct CostHistoryView: View {
             : Self.extentFormatter
         let start = formatter.string(from: window.visibleStart)
         let end = formatter.string(from: window.visibleEnd)
-        return "\(span) · \(start) – \(end)"
+        return L10n.Cost.historyExtentNote(span: span, start: start, end: end)
     }
 
     /// Past this the day-of-month stops disambiguating anything.
     private static let multiYearSpan: TimeInterval = 400 * dayInterval
 
     private static func spanLabel(_ seconds: TimeInterval) -> String {
-        if seconds < 90 * 60 { return "\(max(1, Int((seconds / 60).rounded())))m" }
-        if seconds < 48 * 3_600 { return "\(Int((seconds / 3_600).rounded()))h" }
-        return "\(Int((seconds / 86_400).rounded()))d"
+        if seconds < 90 * 60 {
+            return L10n.Common.durationMinutes(minutes: max(1, Int((seconds / 60).rounded())))
+        }
+        if seconds < 48 * 3_600 {
+            return L10n.Common.durationHours(hours: Int((seconds / 3_600).rounded()))
+        }
+        return L10n.Common.durationDays(days: Int((seconds / 86_400).rounded()))
     }
 
     private func formatCost(_ value: Double) -> String {
@@ -1494,10 +1506,15 @@ struct CostHistoryView: View {
     }
 
     private func formatTokens(_ tokens: Int) -> String {
-        if tokens < 1_000 { return "\(tokens) tok" }
-        if tokens < 1_000_000 { return String(format: "%.1fk tok", Double(tokens) / 1_000) }
-        if tokens < 1_000_000_000 { return String(format: "%.2fM tok", Double(tokens) / 1_000_000) }
-        return String(format: "%.2fB tok", Double(tokens) / 1_000_000_000)
+        let amount: String
+        if tokens < 1_000 { amount = "\(tokens)" }
+        else if tokens < 1_000_000 { amount = String(format: "%.1fk", Double(tokens) / 1_000) }
+        else if tokens < 1_000_000_000 {
+            amount = String(format: "%.2fM", Double(tokens) / 1_000_000)
+        } else {
+            amount = String(format: "%.2fB", Double(tokens) / 1_000_000_000)
+        }
+        return L10n.Usage.activityTokensShort(tokens: amount)
     }
 
     // MARK: - Metric plumbing
@@ -1560,7 +1577,7 @@ struct CostHistoryView: View {
         switch granularity {
         case .hour: Self.hourFormatter.string(from: date)
         case .day: Self.dayFormatter.string(from: date)
-        case .week: "Week of \(Self.dayFormatter.string(from: date))"
+        case .week: L10n.Cost.historyWeekOf(date: Self.dayFormatter.string(from: date))
         case .month: Self.monthFormatter.string(from: date)
         }
     }
@@ -1571,7 +1588,7 @@ struct CostHistoryView: View {
         switch granularity {
         case .hour: Self.peakHourFormatter.string(from: date)
         case .day: Self.extentFormatter.string(from: date)
-        case .week: "wk \(Self.extentFormatter.string(from: date))"
+        case .week: L10n.Cost.historyWeekShortOf(date: Self.extentFormatter.string(from: date))
         case .month: Self.monthFormatter.string(from: date)
         }
     }

--- a/Sources/VibeBarApp/Views/CostHistoryView.swift
+++ b/Sources/VibeBarApp/Views/CostHistoryView.swift
@@ -56,7 +56,12 @@ private struct CostGranularityOption: Identifiable, Equatable {
         return CostChartGranularity.survivesManualSelection(granularity, for: visibleSpan)
     }
 
-    static let all: [CostGranularityOption] = [
+    /// Derived per render rather than cached. As a `static let` this held the
+    /// five labels in whatever language the process launched in; five small
+    /// structs are cheaper to rebuild than a language-keyed cache is to
+    /// reason about. `count` is language-independent, so the control width
+    /// below can still be computed once.
+    static var all: [CostGranularityOption] {[
         CostGranularityOption(mode: .auto, label: L10n.Cost.granularityAuto, granularity: nil),
         CostGranularityOption(
             mode: .manual(.hour),
@@ -78,7 +83,7 @@ private struct CostGranularityOption: Identifiable, Equatable {
             label: CostChartGranularity.month.displayName,
             granularity: .month
         )
-    ]
+    ]}
 }
 
 /// Range presets the navigable cost chart offers.

--- a/Sources/VibeBarApp/Views/FillTimelineChart.swift
+++ b/Sources/VibeBarApp/Views/FillTimelineChart.swift
@@ -92,11 +92,11 @@ struct FillTimelineChart: View {
         let cycles = visibleCycles(series: series, limit: maxCycles(forWidth: stripWidth))
         VStack(alignment: .leading, spacing: 4) {
             HStack(alignment: .firstTextBaseline, spacing: 8) {
-                Text("Reset history")
+                Text(L10n.Quota.resetHistoryTitle)
                     .font(.system(size: max(9, density.subtitleFontSize - 2), weight: .medium))
                     .foregroundStyle(.tertiary)
                 Spacer(minLength: 8)
-                Text("Each bar is one quota cycle")
+                Text(L10n.Quota.resetHistoryBarIsOneCycle)
                     .font(.system(size: max(7.5, density.subtitleFontSize - 4)))
                     .foregroundStyle(.quaternary)
             }
@@ -149,7 +149,7 @@ struct FillTimelineChart: View {
             RoundedRectangle(cornerRadius: 4, style: .continuous)
                 .fill(Theme.barTrack.opacity(0.45))
                 .overlay {
-                    Text("Waiting for the first quota observation")
+                    Text(L10n.Quota.awaitingFirstObservation)
                         .font(.system(size: max(8, density.subtitleFontSize - 3)))
                         .foregroundStyle(.tertiary)
                 }
@@ -266,11 +266,7 @@ struct FillTimelineChart: View {
     private func earlyRefillNote(_ cycles: [SubscriptionWindowSample]) -> some View {
         let early = cycles.filter(\.refilledEarly).count
         if early > 0 {
-            Text(
-                early == 1
-                    ? "1 cycle refilled before the window was up"
-                    : "\(early) cycles refilled before the window was up"
-            )
+            Text(L10n.Quota.resetHistoryEarlyRefillCount(count: early))
             .font(.system(size: max(7.5, density.subtitleFontSize - 4), design: .rounded))
             .foregroundStyle(.quaternary)
         }
@@ -278,35 +274,42 @@ struct FillTimelineChart: View {
 
     /// What the provider did to the clock, when it did anything unusual. The
     /// two early shapes mean opposite things, so the caption says which.
-    private func resetDescription(_ cycle: SubscriptionWindowSample) -> String {
+    private func resetDescription(_ cycle: SubscriptionWindowSample) -> String? {
         switch cycle.resetKind {
-        case .earlyClockRestarted: " · refilled early, next window restarted"
-        case .earlyClockUnchanged: " · refilled early, next reset unchanged"
-        case .earlyUnclear: " · refilled early, onto a different schedule"
-        case .onSchedule, .unobserved, nil: ""
+        case .earlyClockRestarted: L10n.Quota.resetHistoryResetEarlyClockRestarted
+        case .earlyClockUnchanged: L10n.Quota.resetHistoryResetEarlyClockUnchanged
+        case .earlyUnclear: L10n.Quota.resetHistoryResetEarlyUnclear
+        case .onSchedule, .unobserved, nil: nil
         }
     }
 
     private func caption(_ cycles: [SubscriptionWindowSample]) -> String {
         guard !cycles.isEmpty else {
-            return "A cycle is recorded when the quota refills"
+            return L10n.Quota.cycleRecordedOnRefill
         }
         let index = hoveredIndex.map { min(max(0, $0), cycles.count - 1) } ?? cycles.count - 1
         let cycle = cycles[index]
         let used = Int(cycle.peakUsedPercent.rounded())
         let left = Int(cycle.remainingPercentAtReset.rounded())
-        if let completedAt = cycle.completedAt {
-            let samplingGap = completedAt.timeIntervalSince(cycle.lastSeenAt)
-            let gapText: String
-            if samplingGap >= 60,
-               let duration = ResetCountdownFormatter.string(from: completedAt, now: cycle.lastSeenAt) {
-                gapText = " · last seen \(duration) before reset"
-            } else {
-                gapText = ""
-            }
-            return "\(Self.timestampFormatter.string(from: completedAt)) reset · \(used)% used · \(left)% left\(resetDescription(cycle))\(gapText)"
+        guard let completedAt = cycle.completedAt else {
+            return L10n.Quota.resetHistoryCurrentCycleCaption(used: used, left: left)
         }
-        return "Current cycle · \(used)% used so far · \(left)% left"
+        // Each note is a whole localized clause; the caption is those clauses
+        // in a list, never an English sentence assembled from fragments.
+        var parts = [
+            L10n.Quota.resetHistoryCycleCaption(
+                time: Self.timestampFormatter.string(from: completedAt),
+                used: used,
+                left: left
+            )
+        ]
+        if let note = resetDescription(cycle) { parts.append(note) }
+        let samplingGap = completedAt.timeIntervalSince(cycle.lastSeenAt)
+        if samplingGap >= 60,
+           let duration = ResetCountdownFormatter.string(from: completedAt, now: cycle.lastSeenAt) {
+            parts.append(L10n.Quota.resetHistoryLastSeenBefore(duration: duration))
+        }
+        return parts.joined(separator: " · ")
     }
 
     @ViewBuilder
@@ -319,7 +322,11 @@ struct FillTimelineChart: View {
                     Text(axisLabel(cycles[cycles.count / 2]))
                     Spacer()
                 }
-                Text(cycles.last?.isCompleted == false ? "Current" : axisLabel(cycles[cycles.count - 1]))
+                Text(
+                    cycles.last?.isCompleted == false
+                        ? L10n.Quota.resetHistoryAxisCurrent
+                        : axisLabel(cycles[cycles.count - 1])
+                )
             }
             .font(.system(size: max(7.5, density.subtitleFontSize - 4), design: .rounded))
             .foregroundStyle(.tertiary)

--- a/Sources/VibeBarApp/Views/HeaderView.swift
+++ b/Sources/VibeBarApp/Views/HeaderView.swift
@@ -47,26 +47,26 @@ struct HeaderView: View {
             }
             BorderlessIconButton(
                 systemImage: "arrow.clockwise",
-                help: "Refresh",
+                help: L10n.Common.refresh,
                 rotation: rotation,
                 size: max(11, subtitleFontSize),
                 action: refreshTapped
             )
             BorderlessIconButton(
                 systemImage: "rectangle.on.rectangle",
-                help: "Mini",
+                help: L10n.Popover.headerMini,
                 size: max(11, subtitleFontSize),
                 action: onToggleMiniWindow
             )
             BorderlessIconButton(
                 systemImage: "macwindow",
-                help: "Open Workbench",
+                help: L10n.Popover.headerOpenWorkbench,
                 size: max(11, subtitleFontSize),
                 action: onShowWorkbench
             )
             BorderlessIconButton(
                 systemImage: "gearshape",
-                help: "Settings",
+                help: L10n.Popover.headerSettings,
                 size: max(11, subtitleFontSize),
                 action: onShowSettings
             )
@@ -83,10 +83,10 @@ struct HeaderView: View {
     }
 
     private func updatedSummary(now: Date) -> String {
-        if isRefreshing { return "Refreshing…" }
+        if isRefreshing { return L10n.Popover.headerRefreshing }
         let base = ResetCountdownFormatter.updatedAgo(from: lastUpdated, now: now)
         if let subtitle, !subtitle.isEmpty {
-            return "\(subtitle) · \(base)"
+            return L10n.Popover.headerUpdatedLine(subtitle: subtitle, updated: base)
         }
         return base
     }

--- a/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
+++ b/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
@@ -372,12 +372,12 @@ private struct MiniCell: Identifiable {
         if let bucket,
            let group = bucket.groupTitle,
            group.caseInsensitiveCompare(subProviderName) == .orderedSame {
-            return bucket.title
+            return QuotaGroupLabelLocalizer.display(bucket.title)
         }
         if let bucket, field.defaultLabel != bucket.shortLabel {
-            return bucket.shortLabel
+            return QuotaGroupLabelLocalizer.display(bucket.shortLabel)
         }
-        return field.defaultLabel
+        return QuotaGroupLabelLocalizer.display(field.defaultLabel)
     }
 }
 
@@ -402,7 +402,13 @@ private struct MiniBranchCell: Identifiable {
         return defaultTitle
     }
 
+    /// The contract label, with the generic window words translated on the
+    /// way to the screen; a model-named bucket comes back untouched.
     private var defaultTitle: String {
+        QuotaGroupLabelLocalizer.display(contractTitle)
+    }
+
+    private var contractTitle: String {
         switch bucket.id {
         case "gpt_5_3_codex_spark_five_hour": return "5 Hours"
         case "gpt_5_3_codex_spark_weekly": return "Weekly"
@@ -445,6 +451,10 @@ private struct MiniBranchCell: Identifiable {
     }
 
     var defaultGroupTitle: String {
+        QuotaGroupLabelLocalizer.display(contractGroupTitle)
+    }
+
+    private var contractGroupTitle: String {
         if let label = MiniWindowGroupLabelCatalog.defaultLabel(for: groupKey) {
             return label
         }
@@ -563,15 +573,26 @@ func miniForecastPlan(_ forecast: QuotaPaceForecast, mode: DisplayMode) -> Doubl
 func miniForecastLine(_ forecast: QuotaPaceForecast, now: Date, compact: Bool = false) -> String {
     if let runOutAt = forecast.runOutAt,
        let countdown = ResetCountdownFormatter.string(from: runOutAt, now: now) {
-        return forecast.verdict == .watch ? "may run out \(countdown)" : "out \(countdown)"
+        return forecast.verdict == .watch
+            ? L10n.Quota.miniForecastMayRunOut(countdown: countdown)
+            : L10n.Quota.paceRunsOutShort(countdown: countdown)
     }
     let left = Int(forecast.projectedRemainingPercent.rounded())
     switch forecast.verdict {
-    case .enough: return compact ? "left \(left)%" : "\(left)% left"
-    case .surplus: return compact ? "surplus \(left)%" : "surplus · \(left)% left"
-    case .watch: return "watch"
-    case .atRisk: return "risk"
-    case .learning: return compact ? "~\(left)% left" : "learning · \(left)% left"
+    case .enough:
+        return compact
+            ? L10n.Quota.miniForecastLeftCompact(percent: left)
+            : L10n.Quota.miniForecastLeft(percent: left)
+    case .surplus:
+        return compact
+            ? L10n.Quota.miniForecastSurplusCompact(percent: left)
+            : L10n.Quota.miniForecastSurplus(percent: left)
+    case .watch: return L10n.Quota.forecastVerdictWatch
+    case .atRisk: return L10n.Quota.forecastVerdictAtRisk
+    case .learning:
+        return compact
+            ? L10n.Quota.miniForecastLearningCompact(percent: left)
+            : L10n.Quota.miniForecastLearning(percent: left)
     }
 }
 
@@ -925,7 +946,7 @@ private struct MiniBranchRingCell: View {
                 .frame(height: MiniRingMetrics.resetHeight, alignment: .center)
         }
         .frame(width: MiniRingMetrics.cellWidth)
-        .help("\(providerTitle(for: cell.tool)) · \(cell.bucket.groupTitle ?? cell.bucket.shortLabel) · \(cell.bucket.title)")
+        .help(miniCellHelp(tool: cell.tool, bucket: cell.bucket))
     }
 
     private func centerText(percent: Double) -> String {
@@ -934,7 +955,7 @@ private struct MiniBranchRingCell: View {
             if label.contains("/") { return label }
             if cell.bucket.title.contains("--") { return "--" }
         }
-        return "\(Int(percent.rounded()))%"
+        return L10n.Common.percent(value: Int(percent.rounded()))
     }
 
     private func resetText(now: Date) -> String {
@@ -952,7 +973,8 @@ private struct MiniBranchRingCell: View {
             if pace.willLastToReset { return pace.stageSummary }
             guard let etaSeconds = pace.etaSeconds, etaSeconds > 0 else { return "" }
             let target = now.addingTimeInterval(etaSeconds)
-            return ResetCountdownFormatter.string(from: target, now: now).map { "out \($0)" } ?? ""
+            return ResetCountdownFormatter.string(from: target, now: now)
+                .map { L10n.Quota.paceRunsOutShort(countdown: $0) } ?? ""
         }
     }
 
@@ -1065,7 +1087,8 @@ private struct MiniRingCell: View {
             }
             guard let etaSeconds = pace.etaSeconds, etaSeconds > 0 else { return "" }
             let target = now.addingTimeInterval(etaSeconds)
-            return ResetCountdownFormatter.string(from: target, now: now).map { "out \($0)" } ?? ""
+            return ResetCountdownFormatter.string(from: target, now: now)
+                .map { L10n.Quota.paceRunsOutShort(countdown: $0) } ?? ""
         }
     }
 
@@ -1103,7 +1126,7 @@ private struct MiniRingCell: View {
                 size: MiniRingMetrics.ringSize,
                 lineWidth: MiniRingMetrics.ringLineWidth
             ) {
-                Text("\(Int(percent.rounded()))%")
+                Text(L10n.Common.percent(value: Int(percent.rounded())))
                     .font(.system(size: 12, weight: .bold, design: .rounded).monospacedDigit())
                     .foregroundStyle(color)
                     .minimumScaleFactor(0.7)
@@ -1269,7 +1292,7 @@ private struct MiniCompactPrimaryGroup: View {
                             tool: cell.tool,
                             title: cell.resolvedLabel,
                             bucket: cell.bucket,
-                            help: "\(providerTitle(for: cell.tool)) · \(cell.resolvedLabel)"
+                            help: miniCellHelp(tool: cell.tool, label: cell.resolvedLabel)
                         ),
                         now: now
                     )
@@ -1298,7 +1321,7 @@ private struct MiniCompactBranchGroup: View {
                             tool: cell.tool,
                             title: cell.title,
                             bucket: cell.bucket,
-                            help: "\(providerTitle(for: cell.tool)) · \(cell.bucket.groupTitle ?? cell.bucket.shortLabel) · \(cell.bucket.title)"
+                            help: miniCellHelp(tool: cell.tool, bucket: cell.bucket)
                         ),
                         now: now
                     )
@@ -1434,7 +1457,7 @@ private struct MiniCompactBarCell: View {
             if label.contains("/") { return label }
             if bucket.title.contains("--") { return "--" }
         }
-        return "\(Int(percent.rounded()))%"
+        return L10n.Common.percent(value: Int(percent.rounded()))
     }
 
     private func resetText(now: Date) -> String {
@@ -1446,18 +1469,17 @@ private struct MiniCompactBarCell: View {
         guard let pace else { return "" }
         switch pace.stage {
         case .onTrack:
-            return "On pace"
+            return L10n.Quota.paceOnTrack
         case .slightlyBehind, .behind, .farBehind:
-            return pace.stageSummary
-                .replacingOccurrences(of: " in reserve", with: " reserve")
+            return pace.stageSummaryCompact
         case .slightlyAhead, .ahead, .farAhead:
             if pace.willLastToReset {
-                return pace.stageSummary
-                    .replacingOccurrences(of: " in deficit", with: " deficit")
+                return pace.stageSummaryCompact
             }
             guard let etaSeconds = pace.etaSeconds, etaSeconds > 0 else { return "" }
             let target = now.addingTimeInterval(etaSeconds)
-            return ResetCountdownFormatter.string(from: target, now: now).map { "out \($0)" } ?? ""
+            return ResetCountdownFormatter.string(from: target, now: now)
+                .map { L10n.Quota.paceRunsOutShort(countdown: $0) } ?? ""
         }
     }
 
@@ -1570,4 +1592,18 @@ struct RingGauge<CenterLabel: View>: View {
         }
         .frame(width: size, height: size)
     }
+}
+
+/// Provider · label, where the label has already been resolved (and, where it
+/// is a generic window word, translated) by the cell that owns it.
+private func miniCellHelp(tool: ToolType, label: String) -> String {
+    "\(providerTitle(for: tool)) · \(label)"
+}
+
+/// Provider · group · bucket, with the generic window words translated and
+/// every name left exactly as its owner spells it.
+private func miniCellHelp(tool: ToolType, bucket: QuotaBucket) -> String {
+    let group = QuotaGroupLabelLocalizer.display(bucket.groupTitle ?? bucket.shortLabel)
+    let title = QuotaGroupLabelLocalizer.display(bucket.title)
+    return "\(providerTitle(for: tool)) · \(group) · \(title)"
 }

--- a/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
+++ b/Sources/VibeBarApp/Views/MiniQuotaWindowView.swift
@@ -372,12 +372,12 @@ private struct MiniCell: Identifiable {
         if let bucket,
            let group = bucket.groupTitle,
            group.caseInsensitiveCompare(subProviderName) == .orderedSame {
-            return QuotaGroupLabelLocalizer.display(bucket.title)
+            return QuotaGroupLabelLocalizer.displayComposed(bucket.title)
         }
         if let bucket, field.defaultLabel != bucket.shortLabel {
-            return QuotaGroupLabelLocalizer.display(bucket.shortLabel)
+            return QuotaGroupLabelLocalizer.displayComposed(bucket.shortLabel)
         }
-        return QuotaGroupLabelLocalizer.display(field.defaultLabel)
+        return QuotaGroupLabelLocalizer.displayComposed(field.defaultLabel)
     }
 }
 
@@ -405,7 +405,7 @@ private struct MiniBranchCell: Identifiable {
     /// The contract label, with the generic window words translated on the
     /// way to the screen; a model-named bucket comes back untouched.
     private var defaultTitle: String {
-        QuotaGroupLabelLocalizer.display(contractTitle)
+        QuotaGroupLabelLocalizer.displayComposed(contractTitle)
     }
 
     private var contractTitle: String {
@@ -451,7 +451,7 @@ private struct MiniBranchCell: Identifiable {
     }
 
     var defaultGroupTitle: String {
-        QuotaGroupLabelLocalizer.display(contractGroupTitle)
+        QuotaGroupLabelLocalizer.displayComposed(contractGroupTitle)
     }
 
     private var contractGroupTitle: String {
@@ -1603,7 +1603,7 @@ private func miniCellHelp(tool: ToolType, label: String) -> String {
 /// Provider · group · bucket, with the generic window words translated and
 /// every name left exactly as its owner spells it.
 private func miniCellHelp(tool: ToolType, bucket: QuotaBucket) -> String {
-    let group = QuotaGroupLabelLocalizer.display(bucket.groupTitle ?? bucket.shortLabel)
-    let title = QuotaGroupLabelLocalizer.display(bucket.title)
+    let group = QuotaGroupLabelLocalizer.displayComposed(bucket.groupTitle ?? bucket.shortLabel)
+    let title = QuotaGroupLabelLocalizer.displayComposed(bucket.title)
     return "\(providerTitle(for: tool)) · \(group) · \(title)"
 }

--- a/Sources/VibeBarApp/Views/MiniWindowAltLayouts.swift
+++ b/Sources/VibeBarApp/Views/MiniWindowAltLayouts.swift
@@ -28,7 +28,7 @@ struct MiniEntry: Identifiable {
         if let customLabel, !customLabel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             return customLabel
         }
-        return QuotaGroupLabelLocalizer.display(bucket.title)
+        return QuotaGroupLabelLocalizer.displayComposed(bucket.title)
     }
 
     /// Row label for list-style layouts: always the quota-axis path, with a
@@ -38,7 +38,7 @@ struct MiniEntry: Identifiable {
     /// group made every row identical.
     var rowLabel: String {
         if let groupLabel {
-            return "\(QuotaGroupLabelLocalizer.display(groupLabel)) · \(bucketDisplayName)"
+            return "\(QuotaGroupLabelLocalizer.displayComposed(groupLabel)) · \(bucketDisplayName)"
         }
         return bucketDisplayName
     }
@@ -939,10 +939,10 @@ private extension Array {
 /// Provider · group · bucket for a mini entry's tooltip, with the generic
 /// window words translated and every name left as its owner spells it.
 private func miniEntryHelp(_ entry: MiniEntry) -> String {
-    let group = QuotaGroupLabelLocalizer.display(
+    let group = QuotaGroupLabelLocalizer.displayComposed(
         entry.bucket.groupTitle ?? entry.subProviderDisplayName
     )
-    let title = QuotaGroupLabelLocalizer.display(entry.bucket.title)
+    let title = QuotaGroupLabelLocalizer.displayComposed(entry.bucket.title)
     return "\(providerTitle(for: entry.tool)) · \(group) · \(title)"
 }
 
@@ -950,7 +950,7 @@ private func miniEntryHelp(_ entry: MiniEntry) -> String {
 /// interpolation at the call site: the join happens once, and every part that
 /// can be a generic window word goes through the localizer on the way.
 private func miniTileHelp(_ entry: MiniEntry) -> String {
-    let title = QuotaGroupLabelLocalizer.display(entry.bucket.title)
+    let title = QuotaGroupLabelLocalizer.displayComposed(entry.bucket.title)
     return "\(providerTitle(for: entry.tool)) · \(entry.rowLabel) · \(title)"
 }
 

--- a/Sources/VibeBarApp/Views/MiniWindowAltLayouts.swift
+++ b/Sources/VibeBarApp/Views/MiniWindowAltLayouts.swift
@@ -28,7 +28,7 @@ struct MiniEntry: Identifiable {
         if let customLabel, !customLabel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             return customLabel
         }
-        return bucket.title
+        return QuotaGroupLabelLocalizer.display(bucket.title)
     }
 
     /// Row label for list-style layouts: always the quota-axis path, with a
@@ -38,7 +38,7 @@ struct MiniEntry: Identifiable {
     /// group made every row identical.
     var rowLabel: String {
         if let groupLabel {
-            return "\(groupLabel) · \(bucketDisplayName)"
+            return "\(QuotaGroupLabelLocalizer.display(groupLabel)) · \(bucketDisplayName)"
         }
         return bucketDisplayName
     }
@@ -162,7 +162,7 @@ private func remainingPercent(_ entry: MiniEntry) -> Double {
 
 private struct MiniEmptyHint: View {
     var body: some View {
-        Text("No selected fields have live data")
+        Text(L10n.Quota.miniNoLiveData)
             .font(.system(size: 10, weight: .medium, design: .rounded))
             .foregroundStyle(.secondary)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -318,7 +318,7 @@ struct MiniLedgerLayout: View {
                 }
             }
             .frame(height: 4)
-            Text("\(Int(percent.rounded()))%")
+            Text(L10n.Common.percent(value: Int(percent.rounded())))
                 .font(.system(size: 10.5, weight: .bold, design: .rounded).monospacedDigit())
                 .foregroundStyle(color)
                 .frame(width: 34, alignment: .trailing)
@@ -331,7 +331,7 @@ struct MiniLedgerLayout: View {
         }
         .padding(.leading, MiniLedgerMetrics.rowIndent)
         .frame(height: MiniLedgerMetrics.rowHeight)
-        .help("\(providerTitle(for: entry.tool)) · \(entry.bucket.groupTitle ?? entry.subProviderDisplayName) · \(entry.bucket.title)")
+        .help(miniEntryHelp(entry))
     }
 }
 
@@ -497,11 +497,17 @@ struct MiniStripLayout: View {
                 .foregroundStyle(.primary)
                 .lineLimit(1)
                 .minimumScaleFactor(0.6)
-            Text("\(Int(percent.rounded()))%")
+            Text(L10n.Common.percent(value: Int(percent.rounded())))
                 .font(.system(size: 10.5, weight: .bold, design: .rounded).monospacedDigit())
                 .foregroundStyle(color)
         }
-        .help("\(entry.subProviderDisplayName) — \(entry.rowLabel): \(Int(percent.rounded()))%")
+        .help(
+            L10n.Quota.miniRowHelp(
+                subProvider: entry.subProviderDisplayName,
+                row: entry.rowLabel,
+                percent: Int(percent.rounded())
+            )
+        )
     }
 
     /// The menu bar's single-line style, one cell per bucket: full label
@@ -518,12 +524,18 @@ struct MiniStripLayout: View {
                 .foregroundStyle(.primary)
                 .lineLimit(1)
                 .minimumScaleFactor(0.5)
-            Text("\(Int(percent.rounded()))%")
+            Text(L10n.Common.percent(value: Int(percent.rounded())))
                 .font(.system(size: size, weight: .bold, design: .rounded).monospacedDigit())
                 .foregroundStyle(color)
         }
         .frame(width: width, alignment: .leading)
-        .help("\(entry.subProviderDisplayName) — \(entry.rowLabel): \(Int(percent.rounded()))%")
+        .help(
+            L10n.Quota.miniRowHelp(
+                subProvider: entry.subProviderDisplayName,
+                row: entry.rowLabel,
+                percent: Int(percent.rounded())
+            )
+        )
     }
 }
 
@@ -622,7 +634,7 @@ struct MiniTileLayout: View {
                         .lineLimit(1)
                         .minimumScaleFactor(0.6)
                     HStack(spacing: 6) {
-                        Text("\(Int(percent.rounded()))%")
+                        Text(L10n.Common.percent(value: Int(percent.rounded())))
                             .font(.system(size: 15, weight: .bold, design: .rounded).monospacedDigit())
                             .foregroundStyle(color)
                         GeometryReader { proxy in
@@ -642,7 +654,7 @@ struct MiniTileLayout: View {
             .padding(.leading, 4)
         }
         .frame(width: MiniTileMetrics.tileWidth, height: MiniTileMetrics.tileHeight)
-        .help("\(providerTitle(for: entry.tool)) · \(entry.rowLabel) · \(entry.bucket.title)")
+        .help(miniTileHelp(entry))
     }
 }
 
@@ -705,7 +717,7 @@ struct MiniFocusLayout: View {
                         .font(.system(size: 10, weight: .semibold, design: .rounded))
                         .foregroundStyle(.primary.opacity(0.86))
                 }
-                Text("\(headline.subProviderDisplayName.uppercased()) · \(headline.rowLabel.uppercased())")
+                Text(miniFocusPath(headline))
                     .font(.system(size: 8, weight: .semibold, design: .rounded))
                     .foregroundStyle(.secondary)
                     .tracking(1.2)
@@ -720,7 +732,7 @@ struct MiniFocusLayout: View {
                     size: MiniFocusMetrics.ringSize,
                     lineWidth: MiniFocusMetrics.ringLineWidth
                 ) {
-                    Text("\(Int(percent.rounded()))%")
+                    Text(L10n.Common.percent(value: Int(percent.rounded())))
                         .font(.system(size: 19, weight: .bold, design: .rounded).monospacedDigit())
                         .foregroundStyle(color)
                 }
@@ -744,7 +756,11 @@ struct MiniFocusLayout: View {
                                 .onTapGesture { pageIndex = dot }
                         }
                     } else {
-                        Text("\(index + 1)/\(pages.count)")
+                        Text(
+                            L10n.Quota.miniPageIndicator(
+                                index: index + 1, total: pages.count
+                            )
+                        )
                             .font(.system(size: 8.5, weight: .semibold, design: .rounded).monospacedDigit())
                             .foregroundStyle(.secondary)
                     }
@@ -757,7 +773,7 @@ struct MiniFocusLayout: View {
                                 .foregroundStyle(.secondary)
                         }
                         .buttonStyle(.vibeBar)
-                        .help("Next provider")
+                        .help(L10n.Quota.miniNextProvider)
                     }
                 }
                 .padding(.top, 3)
@@ -776,7 +792,11 @@ struct MiniFocusLayout: View {
                     Text(entry.rowLabel)
                         .font(.system(size: 8.5, weight: .medium, design: .rounded))
                         .foregroundStyle(.secondary)
-                    Text("\(Int(entryPercent(entry, mode: mode).rounded()))%")
+                    Text(
+                        L10n.Common.percent(
+                            value: Int(entryPercent(entry, mode: mode).rounded())
+                        )
+                    )
                         .font(.system(size: 8.5, weight: .bold, design: .rounded).monospacedDigit())
                         .foregroundStyle(entryColor(entry, mode: mode))
                 }
@@ -791,7 +811,7 @@ struct MiniFocusLayout: View {
         guard let countdown = ResetCountdownFormatter.string(from: entry.bucket.resetAt, now: now) else {
             return " "
         }
-        return "resets \(countdown)"
+        return L10n.Quota.miniResets(countdown: countdown)
     }
 }
 
@@ -852,13 +872,13 @@ struct MiniRailLayout: View {
     private func content(now: Date) -> some View {
         let events = events(now: now)
         VStack(spacing: 4) {
-            Text("QUOTA RESETS · NEXT \(Int(MiniRailMetrics.horizonDays)) DAYS")
+            Text(L10n.Quota.miniRailTitle(days: Int(MiniRailMetrics.horizonDays)))
                 .font(.system(size: 8.5, weight: .semibold, design: .rounded))
                 .foregroundStyle(.secondary)
                 .tracking(1.6)
                 .padding(.top, 12)
             if events.isEmpty {
-                Text("Nothing selected refills in the next seven days.")
+                Text(L10n.Quota.miniRailEmpty)
                     .font(.system(size: 10, weight: .medium, design: .rounded))
                     .foregroundStyle(.secondary)
                     .frame(maxHeight: .infinity)
@@ -894,7 +914,7 @@ struct MiniRailLayout: View {
                 .lineLimit(1)
                 .minimumScaleFactor(0.7)
             Spacer(minLength: 6)
-            Text("+\(Int(event.gainPercent.rounded()))%")
+            Text(L10n.Quota.upcomingGain(gain: Int(event.gainPercent.rounded())))
                 .font(.system(size: 9.5, weight: .bold, design: .rounded).monospacedDigit())
                 .foregroundStyle(Theme.barColor(percent: event.remainingPercent, mode: .remaining))
             Text(ResetCountdownFormatter.string(from: event.resetAt, now: now) ?? "—")
@@ -914,4 +934,28 @@ private extension Array {
             Array(self[$0..<Swift.min($0 + size, count)])
         }
     }
+}
+
+/// Provider · group · bucket for a mini entry's tooltip, with the generic
+/// window words translated and every name left as its owner spells it.
+private func miniEntryHelp(_ entry: MiniEntry) -> String {
+    let group = QuotaGroupLabelLocalizer.display(
+        entry.bucket.groupTitle ?? entry.subProviderDisplayName
+    )
+    let title = QuotaGroupLabelLocalizer.display(entry.bucket.title)
+    return "\(providerTitle(for: entry.tool)) · \(group) · \(title)"
+}
+
+/// Provider · row · bucket for a tile's tooltip. A named helper rather than an
+/// interpolation at the call site: the join happens once, and every part that
+/// can be a generic window word goes through the localizer on the way.
+private func miniTileHelp(_ entry: MiniEntry) -> String {
+    let title = QuotaGroupLabelLocalizer.display(entry.bucket.title)
+    return "\(providerTitle(for: entry.tool)) · \(entry.rowLabel) · \(title)"
+}
+
+/// SubProvider · row, upper-cased, for the focus layout's path line. The
+/// case change is applied to the resolved labels, never to a catalog key.
+private func miniFocusPath(_ entry: MiniEntry) -> String {
+    "\(entry.subProviderDisplayName.uppercased()) · \(entry.rowLabel.uppercased())"
 }

--- a/Sources/VibeBarApp/Views/MiscProvidersPage.swift
+++ b/Sources/VibeBarApp/Views/MiscProvidersPage.swift
@@ -93,7 +93,7 @@ private struct MiscProviderCard: View {
             Spacer(minLength: 4)
             BorderlessIconButton(
                 systemImage: "arrow.clockwise",
-                help: "Refresh \(tool.menuTitle)",
+                help: L10n.Quota.miscRefreshProvider(provider: tool.menuTitle),
                 size: density.subtitleFontSize
             ) {
                 environment.refresh(instance)
@@ -196,7 +196,7 @@ private struct MiscProviderGroupCard: View {
                 Text(group.tool.menuTitle)
                     .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
                     .lineLimit(1)
-                Text("\(group.instances.count) independent copies")
+                Text(L10n.Quota.miscIndependentCopies(count: group.instances.count))
                     .font(.system(size: density.subtitleFontSize))
                     .foregroundStyle(.tertiary)
                     .lineLimit(1)
@@ -204,7 +204,7 @@ private struct MiscProviderGroupCard: View {
             Spacer(minLength: 4)
             BorderlessIconButton(
                 systemImage: "arrow.clockwise",
-                help: "Refresh \(group.tool.menuTitle) copies",
+                help: L10n.Quota.miscRefreshCopies(provider: group.tool.menuTitle),
                 size: density.subtitleFontSize
             ) {
                 for instance in group.instances {
@@ -278,7 +278,7 @@ private struct MiscProviderInstanceStatusRow: View {
                 Spacer(minLength: 4)
                 BorderlessIconButton(
                     systemImage: "arrow.clockwise",
-                    help: "Refresh \(refreshTitle)",
+                    help: L10n.Quota.miscRefreshProvider(provider: refreshTitle),
                     size: max(9, density.subtitleFontSize - 1)
                 ) {
                     environment.refresh(instance)
@@ -341,7 +341,9 @@ private struct MiscQuotaBody: View {
                         .foregroundStyle(.tertiary)
                 }
                 if let visibleError {
-                    compactErrorText("Update failed: \(visibleError.userFacingMessage)")
+                    compactErrorText(
+                        L10n.Quota.updateFailed(reason: visibleError.userFacingMessage)
+                    )
                 }
             }
         } else if let visibleError, visibleError != .noCredential {
@@ -380,13 +382,13 @@ private struct MiscQuotaBody: View {
         }
         return VStack(alignment: .leading, spacing: 4) {
             HStack(alignment: .firstTextBaseline) {
-                Text(bucket.title)
+                Text(QuotaGroupLabelLocalizer.display(bucket.title))
                     .font(.system(
                         size: density.bucketTitleFontSize - (isCompact ? 2 : 1),
                         weight: .medium
                     ))
                 Spacer()
-                Text("\(Int(percent.rounded()))%")
+                Text(L10n.Common.percent(value: Int(percent.rounded())))
                     .font(.system(
                         size: density.bucketPercentFontSize - (isCompact ? 2 : 0),
                         weight: .semibold
@@ -416,12 +418,12 @@ private struct MiscQuotaBody: View {
                 )
             }
             if let group = bucket.groupTitle, !group.isEmpty, group != bucket.title {
-                Text(group)
+                Text(QuotaGroupLabelLocalizer.display(group))
                     .font(.system(size: density.resetCountdownFontSize))
                     .foregroundStyle(.tertiary)
             }
             if let countdown = ResetCountdownFormatter.stringWithAbsoluteTime(from: bucket.resetAt) {
-                Text("Resets \(countdown)")
+                Text(L10n.Quota.bucketResetsIn(when: countdown))
                     .font(.system(size: density.resetCountdownFontSize))
                     .foregroundStyle(.tertiary)
             }
@@ -440,7 +442,7 @@ private struct MiscQuotaBody: View {
 
     private var setupState: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("Not configured.")
+            Text(L10n.Quota.miscNotConfigured)
                 .font(.system(size: density.subtitleFontSize))
                 .foregroundStyle(.secondary)
             Button {
@@ -448,7 +450,7 @@ private struct MiscQuotaBody: View {
             } label: {
                 HStack(spacing: 4) {
                     Image(systemName: "gearshape")
-                    Text("Set up in Settings")
+                    Text(L10n.Quota.miscSetUpInSettings)
                 }
                 .font(.system(size: density.subtitleFontSize, weight: .medium))
             }
@@ -473,7 +475,7 @@ private struct MiscQuotaBody: View {
             } label: {
                 HStack(spacing: 4) {
                     Image(systemName: "gearshape")
-                    Text("Open Settings")
+                    Text(L10n.Common.openSettings)
                 }
                 .font(.system(size: density.resetCountdownFontSize))
             }

--- a/Sources/VibeBarApp/Views/MiscProvidersPage.swift
+++ b/Sources/VibeBarApp/Views/MiscProvidersPage.swift
@@ -382,7 +382,7 @@ private struct MiscQuotaBody: View {
         }
         return VStack(alignment: .leading, spacing: 4) {
             HStack(alignment: .firstTextBaseline) {
-                Text(QuotaGroupLabelLocalizer.display(bucket.title))
+                Text(QuotaGroupLabelLocalizer.displayComposed(bucket.title))
                     .font(.system(
                         size: density.bucketTitleFontSize - (isCompact ? 2 : 1),
                         weight: .medium
@@ -418,7 +418,7 @@ private struct MiscQuotaBody: View {
                 )
             }
             if let group = bucket.groupTitle, !group.isEmpty, group != bucket.title {
-                Text(QuotaGroupLabelLocalizer.display(group))
+                Text(QuotaGroupLabelLocalizer.displayComposed(group))
                     .font(.system(size: density.resetCountdownFontSize))
                     .foregroundStyle(.tertiary)
             }

--- a/Sources/VibeBarApp/Views/OverviewQuotaHistoryCard.swift
+++ b/Sources/VibeBarApp/Views/OverviewQuotaHistoryCard.swift
@@ -598,12 +598,14 @@ struct OverviewQuotaHistoryCard: View {
     /// where the label is composed: a generic window word is translated and a
     /// model name ("Sonnet") comes back exactly as the contract spells it.
     private func bucketTitle(_ bucket: QuotaBucket) -> String {
-        let title = QuotaGroupLabelLocalizer.display(bucket.title)
+        let title = QuotaGroupLabelLocalizer.displayComposed(bucket.title)
         guard let group = bucket.groupTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
               !group.isEmpty
         else { return title }
-        guard group != bucket.title else { return QuotaGroupLabelLocalizer.display(group) }
-        return "\(QuotaGroupLabelLocalizer.display(group)) \(title)"
+        guard group != bucket.title else {
+            return QuotaGroupLabelLocalizer.displayComposed(group)
+        }
+        return "\(QuotaGroupLabelLocalizer.displayComposed(group)) \(title)"
     }
 
     /// Short, non-identifying account hint. Aliases are the user's own words so

--- a/Sources/VibeBarApp/Views/OverviewQuotaHistoryCard.swift
+++ b/Sources/VibeBarApp/Views/OverviewQuotaHistoryCard.swift
@@ -62,6 +62,11 @@ private struct OverviewSeriesSignature: Equatable {
     }
 
     var entries: [Entry]
+    /// The entries carry localized titles, so today a language change already
+    /// moves this signature. Stating it outright means the next person to
+    /// make `title` the raw contract value — which is otherwise a reasonable
+    /// thing to do — does not silently freeze the rebuild with it.
+    var language: LanguageStamp
 }
 
 /// What building one lane produced, plus everything that decides whether the
@@ -385,7 +390,8 @@ struct OverviewQuotaHistoryCard: View {
 
     private var seriesSignature: OverviewSeriesSignature {
         OverviewSeriesSignature(
-            entries: candidateLanes.map { signatureEntry(account: $0.account, bucket: $0.bucket) }
+            entries: candidateLanes.map { signatureEntry(account: $0.account, bucket: $0.bucket) },
+            language: .current
         )
     }
 
@@ -706,7 +712,13 @@ private struct OverviewQuotaChartBody: View, Equatable {
             && lhs.initialSpan == rhs.initialSpan
             && lhs.resetToken == rhs.resetToken
             && lhs.curves.elementsEqual(rhs.curves) { $0.id == $1.id }
+            // A curve's `id` is tool|account|bucket, so it cannot notice a
+            // language change — while the legend and the tooltip both draw
+            // `label`, which is localized.
+            && lhs.language == rhs.language
     }
+
+    private let language = LanguageStamp.current
 
     /// Shared across every visible curve, so a provider with nine quotas
     /// cannot starve the rest of the chart of detail. It is a *chart* budget:

--- a/Sources/VibeBarApp/Views/OverviewQuotaHistoryCard.swift
+++ b/Sources/VibeBarApp/Views/OverviewQuotaHistoryCard.swift
@@ -168,9 +168,9 @@ struct OverviewQuotaHistoryCard: View {
                 )
                 .equatable()
             } else if curves.isEmpty {
-                note("Quota history builds up as refreshes come in.")
+                note(L10n.Quota.historyBuildingUp)
             } else {
-                note("Every curve is hidden — pick one from the menu above.")
+                note(L10n.Quota.historyAllCurvesHidden)
             }
         }
         .padding(density.cardPadding)
@@ -191,9 +191,9 @@ struct OverviewQuotaHistoryCard: View {
 
     private var header: some View {
         HStack(alignment: .firstTextBaseline, spacing: 6) {
-            Text("Quota history")
+            Text(L10n.Quota.historyTitle)
                 .font(.system(size: density.titleFontSize, weight: .semibold))
-            Text("All providers")
+            Text(L10n.Cost.allProviders)
                 .font(.system(size: density.subtitleFontSize))
                 .foregroundStyle(.tertiary)
             Spacer(minLength: 8)
@@ -224,17 +224,20 @@ struct OverviewQuotaHistoryCard: View {
 
     private var curvePicker: some View {
         Menu {
-            Button("Show all curves") { setHidden([]) }
+            Button(L10n.Quota.historyShowAllCurves) { setHidden([]) }
             if visibleCurves.count > 1 {
-                Button("Show only the busiest") { showOnlyBusiest() }
+                Button(L10n.Quota.historyShowBusiest) { showOnlyBusiest() }
             }
             Divider()
             ForEach(curvesByTool, id: \.0) { tool, toolCurves in
                 Section(displayTitle(for: tool)) {
                     ForEach(toolCurves) { curve in
                         Toggle(isOn: binding(for: curve)) {
-                            Text(curve.accountQualifier.map { "\(curve.bucketTitle) · \($0)" }
-                                ?? curve.bucketTitle)
+                            Text(
+                                curve.accountQualifier
+                                    .map { "\(curve.bucketTitle) · \($0)" }
+                                    ?? curve.bucketTitle
+                            )
                         }
                     }
                 }
@@ -261,13 +264,15 @@ struct OverviewQuotaHistoryCard: View {
         .menuStyle(.borderlessButton)
         .menuIndicator(.hidden)
         .fixedSize()
-        .accessibilityLabel("Choose which quota curves to show")
+        .accessibilityLabel(L10n.Quota.historyCurvePickerA11y)
     }
 
     private var selectionSummary: String {
         let shown = visibleCurves.count
         let total = curves.count
-        return shown == total ? "All \(total)" : "\(shown) of \(total)"
+        return shown == total
+            ? L10n.Quota.historyCurvesAll(total: total)
+            : L10n.Quota.historyCurvesSome(shown: shown, total: total)
     }
 
     private func binding(for curve: OverviewQuotaCurve) -> Binding<Bool> {
@@ -588,11 +593,17 @@ struct OverviewQuotaHistoryCard: View {
     /// Claude titles six different quotas "Weekly" and only the group name
     /// tells them apart, so the group wins when there is one — matching the
     /// section headings in Subscription Utilization.
+    ///
+    /// Both halves go through `QuotaGroupLabelLocalizer`, because this is
+    /// where the label is composed: a generic window word is translated and a
+    /// model name ("Sonnet") comes back exactly as the contract spells it.
     private func bucketTitle(_ bucket: QuotaBucket) -> String {
+        let title = QuotaGroupLabelLocalizer.display(bucket.title)
         guard let group = bucket.groupTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
               !group.isEmpty
-        else { return bucket.title }
-        return group == bucket.title ? group : "\(group) \(bucket.title)"
+        else { return title }
+        guard group != bucket.title else { return QuotaGroupLabelLocalizer.display(group) }
+        return "\(QuotaGroupLabelLocalizer.display(group)) \(title)"
     }
 
     /// Short, non-identifying account hint. Aliases are the user's own words so
@@ -837,7 +848,7 @@ private struct OverviewQuotaChartBody: View, Equatable {
                     AxisGridLine().foregroundStyle(.secondary.opacity(0.15))
                     AxisValueLabel {
                         if let raw = value.as(Double.self) {
-                            Text("\(Int(raw))%")
+                            Text(L10n.Common.percent(value: Int(raw)))
                                 .font(.system(size: 9, design: .rounded).monospacedDigit())
                         }
                     }
@@ -869,7 +880,7 @@ private struct OverviewQuotaChartBody: View, Equatable {
                 window: binding,
                 accent: Color.secondary,
                 height: density.chartBrushHeight,
-                accessibilityDescription: "All-providers quota history range navigator"
+                accessibilityDescription: L10n.Quota.historyNavigatorAllProviders
             ) { geometry in
                 miniPaths(in: geometry)
             }
@@ -951,16 +962,25 @@ private struct OverviewQuotaChartBody: View, Equatable {
 
     private var scopeNote: String {
         let providers = Set(curves.map(\.tool)).count
-        let curveWord = curves.count == 1 ? "curve" : "curves"
-        let providerWord = providers == 1 ? "provider" : "providers"
-        return "\(curves.count) \(curveWord) · \(providers) \(providerWord) · showing "
-            + "\(Self.spanLabel(window.visibleSpan)) of \(Self.spanLabel(window.domainSpan)) recorded"
+        let scope = [
+            L10n.Quota.historyCurveCount(count: curves.count),
+            L10n.Quota.historyProviderCount(count: providers),
+        ].joined(separator: " · ")
+        return L10n.Quota.historyScopeNote(
+            scope: scope,
+            visible: Self.spanLabel(window.visibleSpan),
+            total: Self.spanLabel(window.domainSpan)
+        )
     }
 
     private static func spanLabel(_ seconds: TimeInterval) -> String {
-        if seconds < 90 * 60 { return "\(max(1, Int((seconds / 60).rounded())))m" }
-        if seconds < 48 * 3_600 { return "\(Int((seconds / 3_600).rounded()))h" }
-        return "\(Int((seconds / 86_400).rounded()))d"
+        if seconds < 90 * 60 {
+            return L10n.Common.durationMinutes(minutes: max(1, Int((seconds / 60).rounded())))
+        }
+        if seconds < 48 * 3_600 {
+            return L10n.Common.durationHours(hours: Int((seconds / 3_600).rounded()))
+        }
+        return L10n.Common.durationDays(days: Int((seconds / 86_400).rounded()))
     }
 }
 
@@ -1085,7 +1105,7 @@ private struct OverviewQuotaHoverOverlay: View {
                 // Same wording as the per-group chart's empty row, and for the
                 // same reason: an absent sample says the app was not watching,
                 // not that the quota was between windows.
-                Text("No data recorded")
+                Text(L10n.Common.noData)
                     .font(.system(size: 9))
                     .foregroundStyle(.white.opacity(0.7))
             } else {
@@ -1100,7 +1120,7 @@ private struct OverviewQuotaHoverOverlay: View {
                             .lineLimit(1)
                             .truncationMode(.middle)
                         Spacer(minLength: 6)
-                        Text("\(Int(reading.value.rounded()))%")
+                        Text(L10n.Common.percent(value: Int(reading.value.rounded())))
                             .font(
                                 .system(size: 9, weight: .semibold, design: .rounded)
                                     .monospacedDigit()
@@ -1108,7 +1128,11 @@ private struct OverviewQuotaHoverOverlay: View {
                     }
                 }
                 if readings.count > Self.tooltipRowLimit {
-                    Text("+\(readings.count - Self.tooltipRowLimit) more")
+                    Text(
+                        L10n.Quota.historyMoreReadings(
+                            count: readings.count - Self.tooltipRowLimit
+                        )
+                    )
                         .font(.system(size: 9))
                         .foregroundStyle(.white.opacity(0.55))
                 }

--- a/Sources/VibeBarApp/Views/OverviewUsageMixCard.swift
+++ b/Sources/VibeBarApp/Views/OverviewUsageMixCard.swift
@@ -30,10 +30,10 @@ struct OverviewUsageMixCard: View {
 
         var title: String {
             switch self {
-            case .projects: "Projects"
-            case .harnesses: "Harnesses"
-            case .models: "Models"
-            case .flow: "Token Flow"
+            case .projects: L10n.Usage.mixDimensionProjects
+            case .harnesses: L10n.Usage.mixDimensionHarnesses
+            case .models: L10n.Usage.mixDimensionModels
+            case .flow: L10n.Usage.mixDimensionTokenFlow
             }
         }
     }
@@ -87,10 +87,10 @@ struct OverviewUsageMixCard: View {
 
     private var header: some View {
         HStack(alignment: .firstTextBaseline, spacing: 8) {
-            Text("Usage Mix")
+            Text(L10n.Usage.mixTitle)
                 .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
             Spacer(minLength: 6)
-            Text("Last 30 days")
+            Text(L10n.Usage.mixLastThirtyDays)
                 .font(.system(size: density.resetCountdownFontSize))
                 .foregroundStyle(.tertiary)
             SectionRefreshButton(isRefreshing: costService.isRefreshing || isLoading) {
@@ -178,7 +178,7 @@ struct OverviewUsageMixCard: View {
                         Text(UsageFormatting.compactTokens(total))
                             .font(.system(size: density.bucketTitleFontSize, weight: .bold,
                                           design: .rounded).monospacedDigit())
-                        Text("tokens")
+                        Text(L10n.Usage.mixTokensCaption)
                             .font(.system(size: max(8, density.resetCountdownFontSize - 1)))
                             .foregroundStyle(.tertiary)
                     }
@@ -269,13 +269,14 @@ struct OverviewUsageMixCard: View {
         case .flow:
             let summary = snapshot.summary
             raw = [
-                Slice(id: "fresh", label: "Fresh input", detail: nil,
+                Slice(id: "fresh", label: L10n.Usage.mixFlowFreshInput, detail: nil,
                       tokens: summary.freshInput, costMicros: 0,
                       color: Color(red: 0.30, green: 0.78, blue: 0.74)),
-                Slice(id: "cache", label: "Cache", detail: "read + creation",
+                Slice(id: "cache", label: L10n.Usage.mixFlowCache,
+                      detail: L10n.Usage.mixFlowCacheDetail,
                       tokens: summary.cacheRead + summary.cacheCreation, costMicros: 0,
                       color: Color(red: 0.55, green: 0.40, blue: 0.92)),
-                Slice(id: "output", label: "Output", detail: nil,
+                Slice(id: "output", label: L10n.Usage.mixFlowOutput, detail: nil,
                       tokens: summary.output, costMicros: 0,
                       color: Color(red: 0.96, green: 0.62, blue: 0.20)),
             ]
@@ -290,8 +291,8 @@ struct OverviewUsageMixCard: View {
         let tail = sorted.dropFirst(visibleCount)
         let other = Slice(
             id: "other:\(dimension.rawValue)",
-            label: "Other",
-            detail: "\(tail.count) more",
+            label: L10n.Quota.groupOther,
+            detail: L10n.Usage.mixMoreSlices(count: tail.count),
             tokens: tail.reduce(Int64(0)) { $0 + $1.tokens },
             costMicros: tail.reduce(Int64(0)) { $0 + $1.costMicros },
             color: Color.secondary.opacity(0.55)
@@ -307,11 +308,11 @@ struct OverviewUsageMixCard: View {
     }
 
     private var emptyMessage: String {
-        if loadFailed { return "Usage ledger could not be read." }
+        if loadFailed { return L10n.Usage.mixLedgerUnreadable }
         if dimension == .projects {
-            return "Project attribution appears after the next Codex or Claude cost refresh."
+            return L10n.Usage.mixProjectsPending
         }
-        return "No local usage in this range."
+        return L10n.Usage.mixEmpty
     }
 
     @MainActor

--- a/Sources/VibeBarApp/Views/OverviewUsageMixCard.swift
+++ b/Sources/VibeBarApp/Views/OverviewUsageMixCard.swift
@@ -33,7 +33,7 @@ struct OverviewUsageMixCard: View {
             case .projects: L10n.Usage.mixDimensionProjects
             case .harnesses: L10n.Usage.mixDimensionHarnesses
             case .models: L10n.Usage.mixDimensionModels
-            case .flow: L10n.Usage.mixDimensionTokenFlow
+            case .flow: L10n.Usage.mixTokenFlowTitle
             }
         }
     }
@@ -178,7 +178,7 @@ struct OverviewUsageMixCard: View {
                         Text(UsageFormatting.compactTokens(total))
                             .font(.system(size: density.bucketTitleFontSize, weight: .bold,
                                           design: .rounded).monospacedDigit())
-                        Text(L10n.Usage.mixTokensCaption)
+                        Text(L10n.Usage.mixDonutUnit)
                             .font(.system(size: max(8, density.resetCountdownFontSize - 1)))
                             .foregroundStyle(.tertiary)
                     }
@@ -291,8 +291,8 @@ struct OverviewUsageMixCard: View {
         let tail = sorted.dropFirst(visibleCount)
         let other = Slice(
             id: "other:\(dimension.rawValue)",
-            label: L10n.Quota.groupOther,
-            detail: L10n.Usage.mixMoreSlices(count: tail.count),
+            label: L10n.Usage.mixOther,
+            detail: L10n.Usage.mixOtherCount(count: tail.count),
             tokens: tail.reduce(Int64(0)) { $0 + $1.tokens },
             costMicros: tail.reduce(Int64(0)) { $0 + $1.costMicros },
             color: Color.secondary.opacity(0.55)
@@ -309,10 +309,15 @@ struct OverviewUsageMixCard: View {
 
     private var emptyMessage: String {
         if loadFailed { return L10n.Usage.mixLedgerUnreadable }
-        if dimension == .projects {
-            return L10n.Usage.mixProjectsPending
+        // The Workbench's distribution dashboard says these four things
+        // already; a second wording of "nothing here" is how two screens
+        // start disagreeing about what empty means.
+        switch dimension {
+        case .projects: return L10n.Usage.mixProjectEmpty
+        case .harnesses: return L10n.Usage.harnessMixEmpty
+        case .models: return L10n.Usage.mixModelEmpty
+        case .flow: return L10n.Usage.mixTokenFlowEmpty
         }
-        return L10n.Usage.mixEmpty
     }
 
     @MainActor

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -2303,7 +2303,7 @@ private struct ProviderBucketRow: View {
         let isExpired = resetStatus?.isExpired ?? false
         VStack(alignment: .leading, spacing: density.bucketRowSpacing) {
             HStack(alignment: .firstTextBaseline) {
-                Text(QuotaGroupLabelLocalizer.display(bucket.title))
+                Text(QuotaGroupLabelLocalizer.displayComposed(bucket.title))
                     .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
                 if let resetStatus {
                     // Same size and scale floor as the primary bucket rows —

--- a/Sources/VibeBarApp/Views/QuotaBucketView.swift
+++ b/Sources/VibeBarApp/Views/QuotaBucketView.swift
@@ -10,7 +10,7 @@ struct QuotaBucketView: View {
         let percent = bucket.displayPercent(mode)
         VStack(alignment: .leading, spacing: 8) {
             HStack(alignment: .firstTextBaseline) {
-                Text(QuotaGroupLabelLocalizer.display(bucket.title))
+                Text(QuotaGroupLabelLocalizer.displayComposed(bucket.title))
                     .font(.system(size: 15, weight: .semibold))
                     .foregroundStyle(.primary)
                 Spacer(minLength: 8)

--- a/Sources/VibeBarApp/Views/QuotaGroupCard.swift
+++ b/Sources/VibeBarApp/Views/QuotaGroupCard.swift
@@ -409,7 +409,7 @@ struct QuotaGroupCard: View {
         let isExpired = resetStatus?.isExpired ?? false
         VStack(alignment: .leading, spacing: density.bucketRowSpacing) {
             HStack(alignment: .firstTextBaseline) {
-                Text(bucket.title)
+                Text(QuotaGroupLabelLocalizer.displayComposed(bucket.title))
                     .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
                     .lineLimit(1)
                 if let resetStatus {

--- a/Sources/VibeBarApp/Views/QuotaGroupCard.swift
+++ b/Sources/VibeBarApp/Views/QuotaGroupCard.swift
@@ -517,7 +517,7 @@ struct QuotaGroupCard: View {
     private var percentageAxis: some View {
         HStack(spacing: 0) {
             ForEach([0, 25, 50, 75, 100], id: \.self) { value in
-                Text("\(value)%")
+                Text(L10n.Common.percent(value: value))
                     .font(.system(size: max(8, density.subtitleFontSize - 3), design: .rounded).monospacedDigit())
                     .foregroundStyle(.tertiary)
                     .fixedSize(horizontal: true, vertical: false)
@@ -587,16 +587,16 @@ struct QuotaGroupCard: View {
             referenceLegendItem(
                 color: .secondary,
                 markerStyle: .timePace,
-                label: "Time-only pace",
-                value: "\(Int(timeExpected.rounded()))% \(mode == .remaining ? "left" : "used")"
+                label: L10n.Quota.forecastMetricTimePace,
+                value: modeValue(percent: Int(timeExpected.rounded()))
             )
         }
         if let forecastExpected, let forecastColor {
             referenceLegendItem(
                 color: forecastColor,
                 markerStyle: .forecast,
-                label: "Forecast at reset",
-                value: "\(Int(forecastExpected.rounded()))% \(mode == .remaining ? "left" : "used")"
+                label: L10n.Quota.forecastMetricForecastAtReset,
+                value: modeValue(percent: Int(forecastExpected.rounded()))
             )
         }
     }
@@ -614,7 +614,7 @@ struct QuotaGroupCard: View {
     ) -> some View {
         HStack(spacing: 5) {
             referenceMarker(style: markerStyle, color: color)
-            Text("\(label) \(value)")
+            Text(L10n.Quota.forecastLegendItem(label: label, value: value))
                 .font(.system(size: max(8, density.subtitleFontSize - 1), weight: .medium))
                 .foregroundStyle(color)
                 .fixedSize(horizontal: true, vertical: false)
@@ -674,7 +674,7 @@ struct QuotaGroupCard: View {
                 }
             } label: {
                 HStack(spacing: 6) {
-                    Text("How this forecast was calculated")
+                    Text(L10n.Quota.forecastExplainTitle)
                         .font(.system(size: density.subtitleFontSize, weight: .semibold))
                     Spacer(minLength: 6)
                     Image(systemName: "chevron.right")
@@ -685,7 +685,11 @@ struct QuotaGroupCard: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.vibeBar)
-            .accessibilityLabel(isExpanded ? "Hide forecast calculation" : "Show forecast calculation")
+            .accessibilityLabel(
+                isExpanded
+                    ? L10n.Quota.forecastExplainHide
+                    : L10n.Quota.forecastExplainShow
+            )
 
             if isExpanded {
                 LazyVGrid(
@@ -724,7 +728,7 @@ struct QuotaGroupCard: View {
                         )
                     }
                 }
-                Text("Quota observations drive consumption. Token history only weights when you tend to work; it is never converted into quota usage.")
+                Text(L10n.Quota.forecastExplainFooter)
                     .font(.system(size: max(8, density.subtitleFontSize - 1)))
                     .foregroundStyle(.tertiary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -747,27 +751,37 @@ struct QuotaGroupCard: View {
         pace: UsagePace?
     ) -> [ForecastMetric] {
         let diagnostics = forecast.diagnostics
-        let timePaceValue = pace.map { quotaValue(fromUsed: $0.expectedUsedPercent, suffix: "expected now") } ?? "Unavailable"
-        let timePaceDetail = pace.map { "\($0.stageSummary) by wall clock" } ?? "Needs reset time and window length"
+        let timePaceValue = pace
+            .map { atNow(quotaValue(fromUsed: $0.expectedUsedPercent)) }
+            ?? L10n.Quota.forecastMetricUnavailable
+        let timePaceDetail = pace
+            .map { L10n.Quota.forecastMetricTimePaceDetail(stage: $0.stageSummary) }
+            ?? L10n.Quota.forecastMetricTimePaceMissing
         let recentValue = diagnostics.recentProjectionUsedPercent
-            .map { quotaValue(fromUsed: $0, suffix: "at reset") } ?? "Learning"
+            .map { atReset(quotaValue(fromUsed: $0)) }
+            ?? L10n.Quota.forecastConfidenceLearning
         let recentDetail = diagnostics.recentSampleCount > 0
-            ? "\(diagnostics.recentSampleCount) recent intervals"
-            : "Needs at least two useful observations"
+            ? L10n.Quota.forecastMetricRecentIntervals(count: diagnostics.recentSampleCount)
+            : L10n.Quota.forecastMetricRecentMissing
         let historyValue = diagnostics.historicalProjectionUsedPercent
-            .map { quotaValue(fromUsed: $0, suffix: "at reset") } ?? "No comparison yet"
+            .map { atReset(quotaValue(fromUsed: $0)) }
+            ?? L10n.Quota.forecastMetricNoComparison
         let historyDetail = diagnostics.comparableCycleCount > 0
-            ? "\(diagnostics.comparableCycleCount) comparable reset cycles"
-            : "Completed cycles will appear here"
+            ? L10n.Quota.forecastMetricComparableCycles(count: diagnostics.comparableCycleCount)
+            : L10n.Quota.forecastMetricCyclesPending
         let activityDetail = diagnostics.activityCoveragePercent > 0
-            ? "weekday and hour weighted"
-            : "wall-clock fallback until habits exist"
+            ? L10n.Quota.forecastMetricActivityWeighted
+            : L10n.Quota.forecastMetricActivityFallback
         let trendValue = diagnostics.hasActivityTrendBaseline
-            ? String(format: "%.2f× activity", diagnostics.activityTrendMultiplier)
-            : "No baseline yet"
+            ? L10n.Quota.forecastMetricTrendMultiplier(
+                multiplier: diagnostics.activityTrendMultiplier.formatted(
+                    .number.precision(.fractionLength(2)).locale(AppLocale.current)
+                )
+            )
+            : L10n.Quota.forecastMetricTrendMissing
         let trendDetail = diagnostics.hasActivityTrendBaseline
-            ? "last 7 days versus prior 21 days"
-            : "needs prior daily activity"
+            ? L10n.Quota.forecastMetricTrendDetail
+            : L10n.Quota.forecastMetricTrendDetailMissing
         let range = mode == .used
             ? forecast.projectedUsedLowerPercent...forecast.projectedUsedUpperPercent
             : forecast.projectedRemainingRange
@@ -776,79 +790,113 @@ struct QuotaGroupCard: View {
         return [
             ForecastMetric(
                 id: "time",
-                label: "Time-only pace",
+                label: L10n.Quota.forecastMetricTimePace,
                 value: timePaceValue,
                 detail: timePaceDetail
             ),
             ForecastMetric(
                 id: "plan",
-                label: "Personal plan now",
+                label: L10n.Quota.forecastMetricPlan,
                 value: quotaValue(fromUsed: forecast.plannedUsedPercent),
-                detail: "activity timing + \(whole(forecast.targetRemainingPercent))% safety target"
+                detail: L10n.Quota.forecastMetricPlanDetail(
+                    target: whole(forecast.targetRemainingPercent)
+                )
             ),
             ForecastMetric(
                 id: "recent",
-                label: "Recent burn",
+                label: L10n.Quota.forecastMetricRecentBurn,
                 value: recentValue,
                 detail: recentDetail
             ),
             ForecastMetric(
                 id: "history",
-                label: "Reset history",
+                label: L10n.Quota.resetHistoryTitle,
                 value: historyValue,
                 detail: historyDetail
             ),
             ForecastMetric(
                 id: "activity",
-                label: "Activity timing",
-                value: "\(whole(diagnostics.behavioralProgressPercent))% elapsed",
+                label: L10n.Quota.forecastMetricActivityTiming,
+                value: L10n.Quota.forecastMetricElapsed(
+                    percent: whole(diagnostics.behavioralProgressPercent)
+                ),
                 detail: activityDetail
             ),
             ForecastMetric(
                 id: "trend",
-                label: "Recent trend",
+                label: L10n.Quota.forecastMetricRecentTrend,
                 value: trendValue,
                 detail: trendDetail
             ),
             ForecastMetric(
                 id: "forecast",
-                label: "Forecast at reset",
+                label: L10n.Quota.forecastMetricForecastAtReset,
                 value: quotaValue(fromUsed: forecast.projectedUsedPercent),
                 detail: mode == .used
-                    ? "\(whole(forecast.projectedRemainingPercent))% expected left"
-                    : "\(whole(forecast.projectedUsedPercent))% expected used"
+                    ? L10n.Quota.forecastMetricExpectedLeft(
+                        percent: whole(forecast.projectedRemainingPercent)
+                    )
+                    : L10n.Quota.forecastMetricExpectedUsed(
+                        percent: whole(forecast.projectedUsedPercent)
+                    )
             ),
             ForecastMetric(
                 id: "range",
-                label: "Forecast range",
-                value: "\(whole(range.lowerBound))–\(whole(range.upperBound))% \(mode == .used ? "used" : "left")",
-                detail: "uncertainty interval"
+                label: L10n.Quota.forecastMetricForecastRange,
+                value: mode == .used
+                    ? L10n.Quota.forecastMetricRangeUsed(
+                        lower: whole(range.lowerBound), upper: whole(range.upperBound)
+                    )
+                    : L10n.Quota.forecastMetricRangeLeft(
+                        lower: whole(range.lowerBound), upper: whole(range.upperBound)
+                    ),
+                detail: L10n.Quota.forecastMetricUncertaintyInterval
             ),
             ForecastMetric(
                 id: "target",
-                label: "Safety target",
+                label: L10n.Quota.forecastMetricSafetyTarget,
                 value: mode == .remaining
-                    ? "\(whole(forecast.targetRemainingPercent))% left"
-                    : "\(whole(100 - forecast.targetRemainingPercent))% used",
-                detail: unused >= 3 ? "\(unused)% capacity above target" : "inside the target range"
+                    ? L10n.Quota.forecastValueLeft(
+                        percent: whole(forecast.targetRemainingPercent)
+                    )
+                    : L10n.Quota.forecastValueUsed(
+                        percent: whole(100 - forecast.targetRemainingPercent)
+                    ),
+                detail: unused >= 3
+                    ? L10n.Quota.forecastMetricAboveTarget(percent: unused)
+                    : L10n.Quota.forecastMetricInsideTarget
             ),
             ForecastMetric(
                 id: "evidence",
-                label: "Evidence",
-                value: "\(forecast.currentObservationCount) obs · \(forecast.completedCycleCount) cycles",
-                detail: "\(forecast.confidenceLabel) · score \(whole(forecast.confidenceScore * 100))%"
+                label: L10n.Quota.forecastMetricEvidence,
+                value: L10n.Quota.forecastMetricEvidenceValue(
+                    observations: forecast.currentObservationCount,
+                    cycles: forecast.completedCycleCount
+                ),
+                detail: L10n.Quota.forecastMetricEvidenceDetail(
+                    confidence: forecast.confidenceLabel,
+                    score: whole(forecast.confidenceScore * 100)
+                )
             ),
             ForecastMetric(
                 id: "coverage",
-                label: "Coverage",
-                value: "obs \(whole(diagnostics.observationCoveragePercent))% · history \(whole(diagnostics.historyCoveragePercent))%",
-                detail: "fresh \(whole(diagnostics.freshnessPercent))% · habits \(whole(diagnostics.activityCoveragePercent))%"
+                label: L10n.Quota.forecastMetricCoverage,
+                value: L10n.Quota.forecastMetricCoverageValue(
+                    observations: whole(diagnostics.observationCoveragePercent),
+                    history: whole(diagnostics.historyCoveragePercent)
+                ),
+                detail: L10n.Quota.forecastMetricCoverageDetail(
+                    fresh: whole(diagnostics.freshnessPercent),
+                    habits: whole(diagnostics.activityCoveragePercent)
+                )
             ),
             ForecastMetric(
                 id: "behavior",
-                label: "Behavior fallback",
-                value: quotaValue(fromUsed: diagnostics.behavioralProjectionUsedPercent, suffix: "at reset"),
-                detail: "used when stronger evidence is sparse"
+                label: L10n.Quota.forecastMetricBehaviorFallback,
+                value: atReset(
+                    quotaValue(fromUsed: diagnostics.behavioralProjectionUsedPercent)
+                ),
+                detail: L10n.Quota.forecastMetricBehaviorDetail
             ),
         ]
     }
@@ -866,10 +914,24 @@ struct QuotaGroupCard: View {
         }
     }
 
-    private func quotaValue(fromUsed used: Double, suffix: String? = nil) -> String {
-        let base = "\(whole(displayedPercent(fromUsed: used)))% \(mode == .used ? "used" : "left")"
-        guard let suffix else { return base }
-        return "\(base) \(suffix)"
+    private func quotaValue(fromUsed used: Double) -> String {
+        modeValue(percent: whole(displayedPercent(fromUsed: used)))
+    }
+
+    /// "42% used" / "42% left", in whichever direction the card is showing.
+    private func modeValue(percent: Int) -> String {
+        switch mode {
+        case .used: L10n.Quota.forecastValueUsed(percent: percent)
+        case .remaining: L10n.Quota.forecastValueLeft(percent: percent)
+        }
+    }
+
+    private func atReset(_ value: String) -> String {
+        L10n.Quota.forecastValueAtReset(value: value)
+    }
+
+    private func atNow(_ value: String) -> String {
+        L10n.Quota.forecastValueExpectedNow(value: value)
     }
 
     private func historySeries(for item: QuotaGroupModule.Row) -> FillTimelineSeries? {
@@ -885,16 +947,14 @@ struct QuotaGroupCard: View {
     }
 
     private func percentLabel(used: Double) -> String {
-        switch mode {
-        case .used:      return "\(Int(used.rounded()))% used"
-        case .remaining: return "\(Int((100 - used).rounded()))% left"
-        }
+        modeValue(percent: whole(displayedPercent(fromUsed: used)))
     }
 
     private func etaText(pace: UsagePace) -> String {
-        if pace.willLastToReset { return "lasts until reset" }
+        if pace.willLastToReset { return L10n.Quota.paceLastsUntilReset }
         guard let etaSeconds = pace.etaSeconds, etaSeconds > 0 else { return "—" }
         let target = now.addingTimeInterval(etaSeconds)
-        return ResetCountdownFormatter.string(from: target, now: now).map { "runs out in \($0)" } ?? "—"
+        return ResetCountdownFormatter.string(from: target, now: now)
+            .map { L10n.Quota.paceRunsOutIn(countdown: $0) } ?? "—"
     }
 }

--- a/Sources/VibeBarApp/Views/QuotaHistoryChartView.swift
+++ b/Sources/VibeBarApp/Views/QuotaHistoryChartView.swift
@@ -412,7 +412,7 @@ struct QuotaHistoryChartView: View, Equatable {
                 if showsGroupTitle, let groupTitle = group.title {
                     // Same treatment as the group heading in Subscription
                     // Utilization, so the two surfaces read as one section.
-                    Text(QuotaGroupLabelLocalizer.display(groupTitle))
+                    Text(QuotaGroupLabelLocalizer.displayComposed(groupTitle))
                         .font(.system(size: max(9, density.subtitleFontSize - 1), weight: .semibold))
                         .foregroundStyle(.tertiary)
                         .textCase(.uppercase)
@@ -725,7 +725,7 @@ struct QuotaHistoryChartView: View, Equatable {
                 id: "bucket-\(bucket.id)",
                 stroke: .solid,
                 color: color(at: index),
-                label: QuotaGroupLabelLocalizer.display(bucket.title),
+                label: QuotaGroupLabelLocalizer.displayComposed(bucket.title),
                 value: currentRemainingLabel(bucket: bucket),
                 detail: currentForecastLabel(bucket: bucket)
                     .map { L10n.Quota.forecastValueAtReset(value: $0) }
@@ -965,7 +965,7 @@ struct QuotaHistoryChartView: View, Equatable {
             let series = built[bucket.id] ?? .empty
             return QuotaHoverLane(
                 id: bucket.id,
-                title: bucket.title,
+                title: QuotaGroupLabelLocalizer.displayComposed(bucket.title),
                 color: color(at: index),
                 windowSeconds: bucket.rawWindowSeconds,
                 actual: series.actual.flatMap { $0 },
@@ -1294,13 +1294,13 @@ struct QuotaHistoryChartView: View, Equatable {
         let span = Self.spanLabel(window.visibleSpan)
         let total = Self.spanLabel(window.domainSpan)
         let shown = buckets.prefix(3)
-            .map { QuotaGroupLabelLocalizer.display($0.title) }
+            .map { QuotaGroupLabelLocalizer.displayComposed($0.title) }
             .joined(separator: " + ")
         let names = buckets.count > 3
             ? L10n.Quota.historyMoreBuckets(names: shown, count: buckets.count - 3)
             : shown
         let scope = group.title
-            .map { "\(QuotaGroupLabelLocalizer.display($0)) · \(names)" } ?? names
+            .map { "\(QuotaGroupLabelLocalizer.displayComposed($0)) · \(names)" } ?? names
         return L10n.Quota.historyScopeNote(scope: scope, visible: span, total: total)
     }
 

--- a/Sources/VibeBarApp/Views/QuotaHistoryChartView.swift
+++ b/Sources/VibeBarApp/Views/QuotaHistoryChartView.swift
@@ -186,7 +186,7 @@ private struct QuotaHoverLane {
 /// Shared by the legend and by the hover tooltip, which live in two different
 /// views now and have to print a percentage the same way.
 private func quotaPercentLabel(_ value: Double) -> String {
-    "\(Int(value.rounded()))%"
+    L10n.Common.percent(value: Int(value.rounded()))
 }
 
 /// Everything that decides the shape of the chart. Rebuilding is keyed on this
@@ -396,7 +396,7 @@ struct QuotaHistoryChartView: View, Equatable {
     /// competing with the section heading.
     private var embeddedHeader: some View {
         HStack(alignment: .firstTextBaseline, spacing: 8) {
-            Text("Quota history")
+            Text(L10n.Quota.historyTitle)
                 .font(.system(size: max(9, density.subtitleFontSize - 2), weight: .medium))
                 .foregroundStyle(.tertiary)
             Spacer(minLength: 8)
@@ -407,12 +407,12 @@ struct QuotaHistoryChartView: View, Equatable {
     private var cardHeader: some View {
         HStack(alignment: .firstTextBaseline, spacing: 6) {
             VStack(alignment: .leading, spacing: 1) {
-                Text(titleOverride ?? "Quota history")
+                Text(titleOverride ?? L10n.Quota.historyTitle)
                     .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
                 if showsGroupTitle, let groupTitle = group.title {
                     // Same treatment as the group heading in Subscription
                     // Utilization, so the two surfaces read as one section.
-                    Text(groupTitle)
+                    Text(QuotaGroupLabelLocalizer.display(groupTitle))
                         .font(.system(size: max(9, density.subtitleFontSize - 1), weight: .semibold))
                         .foregroundStyle(.tertiary)
                         .textCase(.uppercase)
@@ -426,7 +426,7 @@ struct QuotaHistoryChartView: View, Equatable {
     }
 
     private var emptyNote: some View {
-        Text("Quota history builds up as refreshes come in.")
+        Text(L10n.Quota.historyBuildingUp)
             .font(.system(size: density.subtitleFontSize))
             .foregroundStyle(.tertiary)
             .fixedSize(horizontal: false, vertical: true)
@@ -548,7 +548,7 @@ struct QuotaHistoryChartView: View, Equatable {
                     AxisGridLine().foregroundStyle(.secondary.opacity(0.15))
                     AxisValueLabel {
                         if let raw = value.as(Double.self) {
-                            Text("\(Int(raw))%")
+                            Text(L10n.Common.percent(value: Int(raw)))
                                 .font(.system(size: 9, design: .rounded).monospacedDigit())
                         }
                     }
@@ -580,7 +580,7 @@ struct QuotaHistoryChartView: View, Equatable {
                 window: binding,
                 accent: Self.bucketPalette[0],
                 height: density.chartBrushHeight,
-                accessibilityDescription: "Quota history range navigator"
+                accessibilityDescription: L10n.Quota.historyNavigatorProvider
             ) { geometry in
                 miniPath(in: geometry)
             }
@@ -725,9 +725,10 @@ struct QuotaHistoryChartView: View, Equatable {
                 id: "bucket-\(bucket.id)",
                 stroke: .solid,
                 color: color(at: index),
-                label: bucket.title,
+                label: QuotaGroupLabelLocalizer.display(bucket.title),
                 value: currentRemainingLabel(bucket: bucket),
-                detail: currentForecastLabel(bucket: bucket).map { "\($0) at reset" }
+                detail: currentForecastLabel(bucket: bucket)
+                    .map { L10n.Quota.forecastValueAtReset(value: $0) }
             )
         }
         // The wall-clock reference only gets a line (and therefore a legend
@@ -738,7 +739,7 @@ struct QuotaHistoryChartView: View, Equatable {
                     id: "pace",
                     stroke: .dashed,
                     color: Self.paceColor,
-                    label: "Time-only pace",
+                    label: L10n.Quota.forecastMetricTimePace,
                     value: pace,
                     detail: nil
                 )
@@ -752,7 +753,7 @@ struct QuotaHistoryChartView: View, Equatable {
         if blocks.contains(where: { $0.detail != nil }) {
             HStack(spacing: 4) {
                 legendSwatch(stroke: .dotted, color: .secondary)
-                Text("forecast")
+                Text(L10n.Quota.historyForecastLegend)
                     .font(.system(size: max(8, density.resetCountdownFontSize - 1)))
                     .foregroundStyle(.tertiary)
             }
@@ -1292,16 +1293,25 @@ struct QuotaHistoryChartView: View, Equatable {
     private func scopeNote(buckets: [QuotaBucket], window: ChartTimeWindow) -> String {
         let span = Self.spanLabel(window.visibleSpan)
         let total = Self.spanLabel(window.domainSpan)
-        let shown = buckets.prefix(3).map(\.title).joined(separator: " + ")
-        let names = buckets.count > 3 ? "\(shown) +\(buckets.count - 3)" : shown
-        let scope = group.title.map { "\($0) · \(names)" } ?? names
-        return "\(scope) · showing \(span) of \(total) recorded"
+        let shown = buckets.prefix(3)
+            .map { QuotaGroupLabelLocalizer.display($0.title) }
+            .joined(separator: " + ")
+        let names = buckets.count > 3
+            ? L10n.Quota.historyMoreBuckets(names: shown, count: buckets.count - 3)
+            : shown
+        let scope = group.title
+            .map { "\(QuotaGroupLabelLocalizer.display($0)) · \(names)" } ?? names
+        return L10n.Quota.historyScopeNote(scope: scope, visible: span, total: total)
     }
 
     private static func spanLabel(_ seconds: TimeInterval) -> String {
-        if seconds < 90 * 60 { return "\(max(1, Int((seconds / 60).rounded())))m" }
-        if seconds < 48 * 3_600 { return "\(Int((seconds / 3_600).rounded()))h" }
-        return "\(Int((seconds / 86_400).rounded()))d"
+        if seconds < 90 * 60 {
+            return L10n.Common.durationMinutes(minutes: max(1, Int((seconds / 60).rounded())))
+        }
+        if seconds < 48 * 3_600 {
+            return L10n.Common.durationHours(hours: Int((seconds / 3_600).rounded()))
+        }
+        return L10n.Common.durationDays(days: Int((seconds / 86_400).rounded()))
     }
 }
 
@@ -1514,19 +1524,27 @@ private struct QuotaChartHoverOverlay: View {
                     // and nothing in a fill lane can tell the two apart, so
                     // claiming there was no active window was a guess dressed
                     // up as a reading.
-                    Text("No data recorded")
+                    Text(L10n.Common.noData)
                         .font(.system(size: 9))
                         .foregroundStyle(.white.opacity(0.7))
                 } else {
                     if let actual = bucket.actual {
-                        tooltipRow("Quota left", quotaPercentLabel(actual), color: bucket.color)
+                        tooltipRow(
+                            L10n.Quota.historyTooltipQuotaLeft,
+                            quotaPercentLabel(actual),
+                            color: bucket.color
+                        )
                     }
                     if let pace = bucket.pace {
-                        tooltipRow("Pace", quotaPercentLabel(pace), color: .white.opacity(0.8))
+                        tooltipRow(
+                            L10n.Quota.historyTooltipPace,
+                            quotaPercentLabel(pace),
+                            color: .white.opacity(0.8)
+                        )
                     }
                     if let forecast = bucket.forecast {
                         tooltipRow(
-                            "At reset",
+                            L10n.Quota.historyTooltipAtReset,
                             quotaPercentLabel(forecast),
                             color: bucket.color.opacity(0.75)
                         )

--- a/Sources/VibeBarApp/Views/QuotaHistoryChartView.swift
+++ b/Sources/VibeBarApp/Views/QuotaHistoryChartView.swift
@@ -203,6 +203,10 @@ private struct QuotaSeriesSignature: Equatable {
     }
 
     var entries: [Entry]
+    /// `rebuild()` fills `hoverLanes`, whose titles are localized, so the
+    /// language is part of what makes the built state current. Without it a
+    /// language change moved no data and therefore invalidated nothing.
+    var language: LanguageStamp
 }
 
 /// Quota history over time for one group of quotas: what was left, what an even
@@ -281,7 +285,15 @@ struct QuotaHistoryChartView: View, Equatable {
             && lhs.titleOverride == rhs.titleOverride
             && lhs.showsGroupTitle == rhs.showsGroupTitle
             && lhs.isEmbedded == rhs.isEmbedded
+            // The card draws its own title, its legend and its tooltip out of
+            // the catalog. Without this the guard keeps doing its job — and
+            // keeps being wrong the moment the language changes.
+            && lhs.language == rhs.language
     }
+
+    /// Held rather than read inside `==` so the comparison stays a value
+    /// compare; taken when the view is created, which is per render pass.
+    private let language = LanguageStamp.current
 
     @State private var forecastByBucket: [String: [ForecastTimelinePoint]] = [:]
     @State private var seriesByBucket: [String: QuotaHistorySeries] = [:]
@@ -930,7 +942,8 @@ struct QuotaHistoryChartView: View, Equatable {
                     forecastCount: forecasts.count,
                     forecastEnd: forecasts.last?.sampledAt
                 )
-            }
+            },
+            language: .current
         )
     }
 

--- a/Sources/VibeBarApp/Views/RemoteMachinesPage.swift
+++ b/Sources/VibeBarApp/Views/RemoteMachinesPage.swift
@@ -38,6 +38,18 @@ enum RemoteSyncStatusCopy {
     }
 }
 
+/// A compact token count and a dollar amount in the *app's* language rather
+/// than the process locale — "1.2K" against "1.2万". A bare
+/// `.number.notation(.compactName)` asks `Locale.current`, which is the
+/// machine's language and not `AppSettings.language`.
+private var tokenFormat: IntegerFormatStyle<Int> {
+    .number.notation(.compactName).locale(AppLocale.current)
+}
+
+private var costFormat: FloatingPointFormatStyle<Double>.Currency {
+    .currency(code: "USD").locale(AppLocale.current)
+}
+
 struct RemoteMachinesPage: View {
     let density: Theme.Density
 
@@ -124,13 +136,16 @@ struct RemoteMachinesPage: View {
 
     private func metrics(_ machine: RemoteMachineSummary) -> some View {
         HStack(alignment: .top, spacing: 0) {
-            metric(L10n.Cost.timeframeToday, Text(machine.todayTokens, format: .number.notation(.compactName)))
+            metric(L10n.Cost.timeframeToday, Text(machine.todayTokens, format: tokenFormat))
             metricDivider
-            metric(L10n.Cost.timeframeWeek, Text(machine.last7DaysTokens, format: .number.notation(.compactName)))
+            metric(L10n.Cost.timeframeWeek, Text(machine.last7DaysTokens, format: tokenFormat))
             metricDivider
-            metric(L10n.Cost.timeframeMonth, Text(machine.last30DaysTokens, format: .number.notation(.compactName)))
+            metric(L10n.Cost.timeframeMonth, Text(machine.last30DaysTokens, format: tokenFormat))
             metricDivider
-            metric(L10n.Popover.machinesThirtyDayCost, Text(machine.last30DaysCostUSD, format: .currency(code: "USD")))
+            metric(
+                L10n.Popover.machinesThirtyDayCost,
+                Text(machine.last30DaysCostUSD, format: costFormat)
+            )
         }
     }
 
@@ -190,7 +205,7 @@ struct RemoteMachinesPage: View {
                     .lineLimit(1)
             }
             HStack(alignment: .firstTextBaseline, spacing: 4) {
-                Text(usage.tokens, format: .number.notation(.compactName))
+                Text(usage.tokens, format: tokenFormat)
                     .font(.system(
                         size: density.subtitleFontSize,
                         weight: .semibold,
@@ -198,7 +213,7 @@ struct RemoteMachinesPage: View {
                     ).monospacedDigit())
                     .foregroundStyle(accent ?? Color.primary)
                 if usage.costUSD > 0 {
-                    Text(usage.costUSD, format: .currency(code: "USD"))
+                    Text(usage.costUSD, format: costFormat)
                         .font(.system(
                             size: max(8, density.subtitleFontSize - 2),
                             design: .rounded
@@ -267,13 +282,13 @@ struct RemoteMachinesPage: View {
         let color: Color
         switch freshness {
         case .live:
-            label = "Live"
+            label = L10n.Popover.machinesFreshnessLive
             color = .green
         case .delayed:
-            label = "Delayed"
+            label = L10n.Popover.machinesFreshnessDelayed
             color = .orange
         case .stale:
-            label = "Stale"
+            label = L10n.Popover.machinesFreshnessStale
             color = .red
         }
         return HStack(spacing: 5) {

--- a/Sources/VibeBarApp/Views/ResetHistoryCompareView.swift
+++ b/Sources/VibeBarApp/Views/ResetHistoryCompareView.swift
@@ -950,8 +950,15 @@ private struct ResetHistoryLanesCanvas: View, Equatable {
     let layout: ResetHistoryCompareLayout
 
     static func == (lhs: ResetHistoryLanesCanvas, rhs: ResetHistoryLanesCanvas) -> Bool {
-        lhs.layout == rhs.layout && lhs.comparison == rhs.comparison
+        lhs.layout == rhs.layout
+            && lhs.comparison == rhs.comparison
+            // `Lane.label` is a computed property — correctly, so it is never
+            // a stored localized string — which means `comparison ==` is
+            // blind to the language while `drawLabels` is not.
+            && lhs.language == rhs.language
     }
+
+    private let language = LanguageStamp.current
 
     var body: some View {
         Canvas(opaque: false, rendersAsynchronously: false) { context, size in

--- a/Sources/VibeBarApp/Views/ResetHistoryCompareView.swift
+++ b/Sources/VibeBarApp/Views/ResetHistoryCompareView.swift
@@ -171,8 +171,8 @@ enum ResetHistoryLanes {
                 // Numbered only when a provider has more than one former
                 // identity, so the ordinary case reads plainly.
                 let label = accountIds.count > 1
-                    ? "Signed-out account \(position + 1)"
-                    : "Signed-out account"
+                    ? L10n.Quota.resetHistoryRetiredAccountNumbered(number: position + 1)
+                    : L10n.Quota.resetHistoryRetiredAccount
                 for key in (accounts[accountId] ?? []).sorted(by: { $0.bucketId < $1.bucketId }) {
                     guard let samples = history[key], !samples.isEmpty else { continue }
                     out.append(
@@ -381,7 +381,7 @@ struct ResetHistoryCompareCard: View {
                     cardWidth = width
                 }
             if comparison.isEmpty {
-                Text("Nothing to compare yet — weekly and longer quotas appear here once a provider reports one.")
+                Text(L10n.Quota.resetHistoryCompareEmpty)
                     .font(.system(size: density.subtitleFontSize))
                     .foregroundStyle(.tertiary)
                     .padding(.vertical, 14)
@@ -392,7 +392,7 @@ struct ResetHistoryCompareCard: View {
         }
     }
 
-    private var title: String { titleOverride ?? "Reset History Compare" }
+    private var title: String { titleOverride ?? L10n.Quota.resetHistoryCompareTitle }
 
     private var header: some View {
         HStack(alignment: .firstTextBaseline, spacing: 8) {
@@ -465,8 +465,10 @@ struct ResetHistoryCompareCard: View {
                         }
                 }
                 .buttonStyle(.vibeBar(cornerRadius: 5))
-                .help("Compare the \(option.spokenTitle(for: axis))")
-                .accessibilityLabel("Compare the \(option.spokenTitle(for: axis))")
+                .help(L10n.Quota.resetHistoryCompareWindow(window: option.spokenTitle(for: axis)))
+                .accessibilityLabel(
+                    L10n.Quota.resetHistoryCompareWindow(window: option.spokenTitle(for: axis))
+                )
                 // The fill is the only sighted cue for which span is showing;
                 // VoiceOver needs the selection stated outright.
                 .accessibilityAddTraits(window == option ? [.isSelected] : [])
@@ -773,22 +775,26 @@ struct ResetHistoryCompareView: View {
                         .fill(Color.secondary)
                         .frame(width: 6, height: 6)
                 }
-                Text("bar height = remaining at reset")
+                Text(L10n.Quota.resetHistoryLegendBarHeight)
             }
             // What the x position means, which is the one thing the axis
             // toggle changes about how to read the chart.
-            Text(comparison.axis == .cycle ? "one column per cycle" : "placed by date")
+            Text(
+                comparison.axis == .cycle
+                    ? L10n.Quota.resetHistoryLegendPerCycle
+                    : L10n.Quota.resetHistoryLegendByDate
+            )
             HStack(spacing: 4) {
                 RoundedRectangle(cornerRadius: 1.5, style: .continuous)
                     .stroke(Color.secondary, style: StrokeStyle(lineWidth: 0.8, dash: [2, 1.5]))
                     .frame(width: 6, height: 9)
-                Text("now")
+                Text(L10n.Quota.resetHistoryAxisNow)
             }
             HStack(spacing: 3) {
                 Circle()
                     .fill(Color.secondary)
                     .frame(width: 3, height: 3)
-                Text("refilled early")
+                Text(L10n.Quota.resetHistoryLegendRefilledEarly)
             }
             Spacer(minLength: 0)
         }
@@ -888,8 +894,14 @@ struct ResetHistoryCompareView: View {
                 .foregroundStyle(.secondary)
             Text(
                 cycle.isCompleted
-                    ? "\(Int(cycle.wastedPercent.rounded()))% left at reset · \(Int(cycle.usedPercent.rounded()))% used"
-                    : "Current cycle · \(Int(cycle.wastedPercent.rounded()))% left now · \(Int(cycle.usedPercent.rounded()))% used so far"
+                    ? L10n.Quota.resetHistoryTooltipCompleted(
+                        left: Int(cycle.wastedPercent.rounded()),
+                        used: Int(cycle.usedPercent.rounded())
+                    )
+                    : L10n.Quota.resetHistoryTooltipCurrent(
+                        left: Int(cycle.wastedPercent.rounded()),
+                        used: Int(cycle.usedPercent.rounded())
+                    )
             )
             .font(.system(size: 9, design: .rounded).monospacedDigit())
             .foregroundStyle(.primary.opacity(0.85))
@@ -919,7 +931,9 @@ struct ResetHistoryCompareView: View {
     private func dateRange(_ cycle: ResetHistoryComparison.Cycle) -> String {
         let start = ResetHistoryCompareFormatters.tooltip.string(from: cycle.start)
         let end = ResetHistoryCompareFormatters.tooltip.string(from: cycle.end)
-        return cycle.isCompleted ? "\(start) → \(end) reset" : "\(start) → \(end) reset due"
+        return cycle.isCompleted
+            ? L10n.Quota.resetHistoryTooltipRange(start: start, end: end)
+            : L10n.Quota.resetHistoryTooltipRangeDue(start: start, end: end)
     }
 }
 

--- a/Sources/VibeBarApp/Views/UpcomingResets.swift
+++ b/Sources/VibeBarApp/Views/UpcomingResets.swift
@@ -30,10 +30,10 @@ struct UpcomingResetEvent: Identifiable {
         // SubProvider is a name, the L3 group and bucket may be generic
         // window words the reader should meet in their own language.
         if let groupTitle {
-            base = "\(subProviderName) · \(QuotaGroupLabelLocalizer.display(groupTitle))"
-                + " · \(QuotaGroupLabelLocalizer.display(bucketTitle))"
+            base = "\(subProviderName) · \(QuotaGroupLabelLocalizer.displayComposed(groupTitle))"
+                + " · \(QuotaGroupLabelLocalizer.displayComposed(bucketTitle))"
         } else {
-            base = "\(subProviderName) · \(QuotaGroupLabelLocalizer.display(bucketTitle))"
+            base = "\(subProviderName) · \(QuotaGroupLabelLocalizer.displayComposed(bucketTitle))"
         }
         if let accountLabel {
             base += " · \(accountLabel)"

--- a/Sources/VibeBarApp/Views/UsageActivityView.swift
+++ b/Sources/VibeBarApp/Views/UsageActivityView.swift
@@ -13,7 +13,7 @@ struct UsageActivityView: View {
     /// derived from `heatmap.tool`.
     var titleOverride: String? = nil
 
-    private let weekdayLabels = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+    private var weekdayLabels: [String] { AppLocale.shortWeekdaySymbols }
     private var barRowHeight: CGFloat { density.activityBarHeight }
 
     @State private var measuredGridWidth: CGFloat = 0
@@ -40,7 +40,7 @@ struct UsageActivityView: View {
 
     private var header: some View {
         HStack(alignment: .firstTextBaseline) {
-            Text(titleOverride ?? "When you use \(toolName)")
+            Text(titleOverride ?? L10n.Usage.whenYouUseProvider(provider: toolName))
                 .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
             Spacer()
             if heatmap.totalTokens > 0 {
@@ -70,9 +70,9 @@ struct UsageActivityView: View {
         let cellHourStr = UsageHeatmap.formatHourLabel(cell.hour)
         let dayStr = weekdayLabels[cell.weekday]
         if peakH == cell.hour {
-            return "Peak \(hourStr) · \(dayStr)"
+            return L10n.Usage.activityPeak(hour: hourStr, day: dayStr)
         }
-        return "Peak \(hourStr) · \(dayStr) \(cellHourStr)"
+        return L10n.Usage.activityPeakCell(hour: hourStr, day: dayStr, cellHour: cellHourStr)
     }
 
     // MARK: - Content
@@ -80,7 +80,7 @@ struct UsageActivityView: View {
     @ViewBuilder
     private var content: some View {
         if heatmap.totalTokens == 0 {
-            Text("No data yet")
+            Text(L10n.Cost.noUsageYet)
                 .font(.system(size: density.subtitleFontSize))
                 .foregroundStyle(.tertiary)
                 .frame(maxWidth: .infinity, alignment: .center)
@@ -220,7 +220,7 @@ struct UsageActivityView: View {
 
     private var legend: some View {
         HStack(spacing: 6) {
-            Text("Quiet")
+            Text(L10n.Usage.activityQuiet)
                 .font(.system(size: density.resetCountdownFontSize))
                 .foregroundStyle(.tertiary)
             ForEach(0..<6, id: \.self) { step in
@@ -228,7 +228,7 @@ struct UsageActivityView: View {
                     .fill(intensityColor(intensity: Double(step) / 5.0))
                     .frame(width: 16, height: 8)
             }
-            Text("Heavy")
+            Text(L10n.Usage.activityHeavy)
                 .font(.system(size: density.resetCountdownFontSize))
                 .foregroundStyle(.tertiary)
             Spacer()
@@ -299,7 +299,7 @@ private struct UsageHeatmapCanvas: View {
         .help(hoveredTooltip ?? "")
         // The individual cell views are gone, so the grid speaks for itself.
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel("Token usage by weekday and hour, 7 days by 24 hours")
+        .accessibilityLabel(L10n.Usage.activityA11y)
     }
 
     private func cellColor(value: Int) -> Color {
@@ -327,11 +327,13 @@ private struct UsageHeatmapCanvas: View {
         let value = cells[weekday][hour]
         let day = weekdayLabels[weekday]
         let hourStr = UsageHeatmap.formatHourLabel(hour)
-        let label: String
-        if value < 1_000 { label = "\(value) tok" }
-        else if value < 1_000_000 { label = String(format: "%.1fk tok", Double(value) / 1_000) }
-        else if value < 1_000_000_000 { label = String(format: "%.2fM tok", Double(value) / 1_000_000) }
-        else { label = String(format: "%.2fB tok", Double(value) / 1_000_000_000) }
-        return "\(day) \(hourStr) · \(label)"
+        let amount: String
+        if value < 1_000 { amount = "\(value)" }
+        else if value < 1_000_000 { amount = String(format: "%.1fk", Double(value) / 1_000) }
+        else if value < 1_000_000_000 { amount = String(format: "%.2fM", Double(value) / 1_000_000) }
+        else { amount = String(format: "%.2fB", Double(value) / 1_000_000_000) }
+        return L10n.Usage.activityCellTooltip(
+            day: day, hour: hourStr, tokens: L10n.Usage.activityTokensShort(tokens: amount)
+        )
     }
 }

--- a/Sources/VibeBarApp/Views/YearlyContributionHeatmapView.swift
+++ b/Sources/VibeBarApp/Views/YearlyContributionHeatmapView.swift
@@ -19,7 +19,7 @@ struct YearlyContributionHeatmapView: View {
         case .spacious: 2.5
         }
     }
-    private let weekdayLabels = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+    private var weekdayLabels: [String] { AppLocale.shortWeekdaySymbols }
     @State private var measuredGridWidth: CGFloat = 0
     @EnvironmentObject var environment: AppEnvironment
 
@@ -83,7 +83,7 @@ struct YearlyContributionHeatmapView: View {
 
         VStack(alignment: .leading, spacing: density.cardSpacing) {
             HStack(alignment: .firstTextBaseline) {
-                Text("\(toolName) — Past Year")
+                Text(L10n.Usage.yearHeatmapTitle(provider: toolName))
                     .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
                 Spacer()
                 if let total = cachedTotalLabel {
@@ -109,7 +109,7 @@ struct YearlyContributionHeatmapView: View {
                 }
             }
             HStack(spacing: 6) {
-                Text("Less")
+                Text(L10n.Usage.yearHeatmapLess)
                     .font(.system(size: density.resetCountdownFontSize))
                     .foregroundStyle(.tertiary)
                 ForEach(0..<5, id: \.self) { step in
@@ -117,7 +117,7 @@ struct YearlyContributionHeatmapView: View {
                         .fill(yearlyLevelColor(step))
                         .frame(width: metrics.cellSize, height: metrics.cellSize)
                 }
-                Text("More")
+                Text(L10n.Usage.yearHeatmapMore)
                     .font(.system(size: density.resetCountdownFontSize))
                     .foregroundStyle(.tertiary)
                 Spacer()
@@ -186,7 +186,9 @@ struct YearlyContributionHeatmapView: View {
                     columns: columns,
                     metrics: metrics,
                     thresholds: thresholds,
-                    accessibilityLabel: "\(toolName) daily spend over the past year, \(columns.count) weeks"
+                    accessibilityLabel: L10n.Usage.yearHeatmapA11y(
+                        provider: toolName, count: columns.count
+                    )
                 )
             }
         }
@@ -283,8 +285,10 @@ struct YearlyContributionHeatmapView: View {
     private var totalLabel: String? {
         let total = history.reduce(0) { $0 + $1.costUSD }
         guard total > 0 else { return nil }
-        if total < 100 { return String(format: "$%.2f total", total) }
-        return String(format: "$%.0f total", total)
+        let amount = total < 100
+            ? String(format: "$%.2f", total)
+            : String(format: "$%.0f", total)
+        return L10n.Usage.yearHeatmapTotal(amount: amount)
     }
 
     /// Per-tool quartile thresholds computed from the history's non-zero days.
@@ -398,7 +402,9 @@ private func yearlyCellTooltip(for entry: DailyCostPoint) -> String {
     let cost: String = entry.costUSD < 0.01 ? "$0.00"
         : entry.costUSD < 100 ? String(format: "$%.2f", entry.costUSD)
         : String(format: "$%.0f", entry.costUSD)
-    return "\(yearlyTooltipFormatter.string(from: entry.date)) · \(cost)"
+    return L10n.Usage.yearHeatmapTooltip(
+        date: yearlyTooltipFormatter.string(from: entry.date), amount: cost
+    )
 }
 
 /// Discrete level 0…4. 0 = no usage, 1…4 increase in saturation.

--- a/Sources/VibeBarApp/Views/YearlyContributionHeatmapView.swift
+++ b/Sources/VibeBarApp/Views/YearlyContributionHeatmapView.swift
@@ -32,7 +32,10 @@ struct YearlyContributionHeatmapView: View {
         var columns: [WeekColumn] = []
         var markers: [MonthMarker] = []
         var thresholds: (p25: Double, p50: Double, p75: Double) = (0, 0, 0)
-        var totalLabel: String?
+        /// The *number*, not the sentence. "{amount} total" is a rendering of
+        /// this and is derived at draw time, so a language change needs no
+        /// cache entry of its own.
+        var total: Double?
     }
 
     private struct GridStamp: Equatable {
@@ -41,6 +44,10 @@ struct YearlyContributionHeatmapView: View {
         /// The walk groups by `Calendar.current`; a calendar or zone change
         /// mid-flight must invalidate even when today's start looks equal.
         let calendarIdentity: String
+        /// The month markers are localized month *names*, so the language is
+        /// part of what makes this cache entry valid — for exactly the same
+        /// reason the calendar identity is.
+        let language: LanguageStamp
     }
 
     @State private var gridCache = GridCache()
@@ -49,27 +56,28 @@ struct YearlyContributionHeatmapView: View {
         columns: [WeekColumn],
         markers: [MonthMarker],
         thresholds: (p25: Double, p50: Double, p75: Double),
-        totalLabel: String?
+        total: Double?
     )
 
     private func cachedGrid() -> CachedGrid {
         let stamp = GridStamp(
             history: history,
             today: Calendar.current.startOfDay(for: Date()),
-            calendarIdentity: "\(Calendar.current.identifier)|\(TimeZone.current.identifier)"
+            calendarIdentity: "\(Calendar.current.identifier)|\(TimeZone.current.identifier)",
+            language: .current
         )
         if gridCache.historyStamp == stamp {
-            return (gridCache.columns, gridCache.markers, gridCache.thresholds, gridCache.totalLabel)
+            return (gridCache.columns, gridCache.markers, gridCache.thresholds, gridCache.total)
         }
         let columns = makeColumns()
         let markers = monthLabelPositions(columns: columns)
         let levels = thresholds
-        let total = totalLabel
+        let total = totalSpend
         gridCache.historyStamp = stamp
         gridCache.columns = columns
         gridCache.markers = markers
         gridCache.thresholds = levels
-        gridCache.totalLabel = total
+        gridCache.total = total
         return (columns, markers, levels, total)
     }
 
@@ -78,7 +86,7 @@ struct YearlyContributionHeatmapView: View {
         // month markers, the quartile sort behind `thresholds`, and the
         // header total — is memoized on the history generation, so a redraw
         // of the card (hover, resize, refresh tick) costs a stamp compare.
-        let (columns, cachedMonthMarkers, cachedThresholds, cachedTotalLabel) = cachedGrid()
+        let (columns, cachedMonthMarkers, cachedThresholds, cachedTotal) = cachedGrid()
         let metrics = gridMetrics(columnCount: columns.count, measuredWidth: measuredGridWidth)
 
         VStack(alignment: .leading, spacing: density.cardSpacing) {
@@ -86,7 +94,7 @@ struct YearlyContributionHeatmapView: View {
                 Text(L10n.Usage.yearHeatmapTitle(provider: toolName))
                     .font(.system(size: density.bucketTitleFontSize, weight: .semibold))
                 Spacer()
-                if let total = cachedTotalLabel {
+                if let total = totalLabel(cachedTotal) {
                     Text(total)
                         .font(.system(size: density.subtitleFontSize))
                         .foregroundStyle(.secondary)
@@ -282,9 +290,17 @@ struct YearlyContributionHeatmapView: View {
         return markers
     }
 
-    private var totalLabel: String? {
+    /// The figure behind the header caption. Data, so it is what the grid
+    /// cache holds.
+    private var totalSpend: Double? {
         let total = history.reduce(0) { $0 + $1.costUSD }
-        guard total > 0 else { return nil }
+        return total > 0 ? total : nil
+    }
+
+    /// The caption itself, derived from the cached figure at draw time — the
+    /// sentence is a rendering of the number, not another thing to cache.
+    private func totalLabel(_ total: Double?) -> String? {
+        guard let total else { return nil }
         let amount = total < 100
             ? String(format: "$%.2f", total)
             : String(format: "$%.0f", total)

--- a/Sources/VibeBarCore/Localization/AppLocale.swift
+++ b/Sources/VibeBarCore/Localization/AppLocale.swift
@@ -103,6 +103,13 @@ public enum AppLocale {
         }
     }
 
+    /// Abbreviated weekday names, Sunday first, in the app's language —
+    /// "Sun" / "周日". The heatmaps index straight into this by a 0-based
+    /// weekday, which is the order `DateFormatter` uses.
+    public static var shortWeekdaySymbols: [String] {
+        dateFormatter(template: "EEE").shortWeekdaySymbols ?? []
+    }
+
     // MARK: - Numbers
 
     /// A grouped integer — "1,234" / "1,234" — in the app's language.

--- a/Sources/VibeBarCore/Localization/L10n+Generated.swift
+++ b/Sources/VibeBarCore/Localization/L10n+Generated.swift
@@ -1126,6 +1126,26 @@ extension L10n {
         public static var awaitingFirstObservation: String {
             L10n.string("quota.awaitingFirstObservation")
         }
+        /// `quota.bridge.empty` — No enabled CodexBar-only provider returned a quota window. Overlapping providers remain on Vibe Bar's native cards.
+        public static var bridgeEmpty: String {
+            L10n.string("quota.bridge.empty")
+        }
+        /// `quota.bridge.refresh` — Refresh CodexBar providers
+        public static var bridgeRefresh: String {
+            L10n.string("quota.bridge.refresh")
+        }
+        /// `quota.bridge.subtitle` — Additional providers · read-only
+        public static var bridgeSubtitle: String {
+            L10n.string("quota.bridge.subtitle")
+        }
+        /// `quota.bridge.subtitleVersion` — CodexBar {version} · read-only
+        public static func bridgeSubtitleVersion(version: String) -> String {
+            L10n.string("quota.bridge.subtitleVersion", version)
+        }
+        /// `quota.bridge.title` — CodexBar Bridge
+        public static var bridgeTitle: String {
+            L10n.string("quota.bridge.title")
+        }
         /// `quota.bucket.noResetInfo` — No reset info
         public static var bucketNoResetInfo: String {
             L10n.string("quota.bucket.noResetInfo")
@@ -1701,6 +1721,54 @@ extension L10n {
         /// `quota.mini.forecastSurplusCompact` — surplus {percent}%
         public static func miniForecastSurplusCompact(percent: Int) -> String {
             L10n.string("quota.mini.forecastSurplusCompact", percent)
+        }
+        /// `quota.mini.nextProvider` — Next provider
+        public static var miniNextProvider: String {
+            L10n.string("quota.mini.nextProvider")
+        }
+        /// `quota.mini.noLiveData` — No selected fields have live data
+        public static var miniNoLiveData: String {
+            L10n.string("quota.mini.noLiveData")
+        }
+        /// `quota.mini.pageIndicator` — {index}/{total}
+        public static func miniPageIndicator(index: Int, total: Int) -> String {
+            L10n.string("quota.mini.pageIndicator", index, total)
+        }
+        /// `quota.mini.railEmpty` — Nothing selected refills in the next seven days.
+        public static var miniRailEmpty: String {
+            L10n.string("quota.mini.railEmpty")
+        }
+        /// `quota.mini.railTitle` — QUOTA RESETS · NEXT {days} DAYS
+        public static func miniRailTitle(days: Int) -> String {
+            L10n.string("quota.mini.railTitle", days)
+        }
+        /// `quota.mini.resets` — resets {countdown}
+        public static func miniResets(countdown: String) -> String {
+            L10n.string("quota.mini.resets", countdown)
+        }
+        /// `quota.mini.rowHelp` — {subProvider} — {row}: {percent}%
+        public static func miniRowHelp(subProvider: String, row: String, percent: Int) -> String {
+            L10n.string("quota.mini.rowHelp", subProvider, row, percent)
+        }
+        /// `quota.misc.independentCopies` — {count, plural, one {1 independent copy} other {# independent copies}}
+        public static func miscIndependentCopies(count: Int) -> String {
+            L10n.string("quota.misc.independentCopies", count)
+        }
+        /// `quota.misc.notConfigured` — Not configured.
+        public static var miscNotConfigured: String {
+            L10n.string("quota.misc.notConfigured")
+        }
+        /// `quota.misc.refreshCopies` — Refresh {provider} copies
+        public static func miscRefreshCopies(provider: String) -> String {
+            L10n.string("quota.misc.refreshCopies", provider)
+        }
+        /// `quota.misc.refreshProvider` — Refresh {provider}
+        public static func miscRefreshProvider(provider: String) -> String {
+            L10n.string("quota.misc.refreshProvider", provider)
+        }
+        /// `quota.misc.setUpInSettings` — Set up in Settings
+        public static var miscSetUpInSettings: String {
+            L10n.string("quota.misc.setUpInSettings")
         }
         /// `quota.mode.remaining` — remaining
         public static var modeRemaining: String {
@@ -5923,6 +5991,11 @@ extension L10n {
         "popover.tab.miscShort",
         "popover.tab.overview",
         "quota.awaitingFirstObservation",
+        "quota.bridge.empty",
+        "quota.bridge.refresh",
+        "quota.bridge.subtitle",
+        "quota.bridge.subtitleVersion",
+        "quota.bridge.title",
         "quota.bucket.noResetInfo",
         "quota.bucket.resetsIn",
         "quota.cycleRecordedOnRefill",
@@ -6067,6 +6140,18 @@ extension L10n {
         "quota.mini.forecastMayRunOut",
         "quota.mini.forecastSurplus",
         "quota.mini.forecastSurplusCompact",
+        "quota.mini.nextProvider",
+        "quota.mini.noLiveData",
+        "quota.mini.pageIndicator",
+        "quota.mini.railEmpty",
+        "quota.mini.railTitle",
+        "quota.mini.resets",
+        "quota.mini.rowHelp",
+        "quota.misc.independentCopies",
+        "quota.misc.notConfigured",
+        "quota.misc.refreshCopies",
+        "quota.misc.refreshProvider",
+        "quota.misc.setUpInSettings",
         "quota.mode.remaining",
         "quota.mode.used",
         "quota.pace.deficit",
@@ -7061,6 +7146,7 @@ extension L10n {
         "quota.forecast.metric.recentIntervals",
         "quota.history.curveCount",
         "quota.history.providerCount",
+        "quota.misc.independentCopies",
         "quota.perModelLimits",
         "quota.resetCredits.available",
         "quota.resetHistory.earlyRefillCount",

--- a/Sources/VibeBarCore/Localization/L10n+Generated.swift
+++ b/Sources/VibeBarCore/Localization/L10n+Generated.swift
@@ -144,6 +144,10 @@ extension L10n {
         public static var name: String {
             L10n.string("common.name")
         }
+        /// `common.noData` — No data recorded
+        public static var noData: String {
+            L10n.string("common.noData")
+        }
         /// `common.off` — Off
         public static var off: String {
             L10n.string("common.off")
@@ -223,6 +227,18 @@ extension L10n {
         public static var allProviders: String {
             L10n.string("cost.allProviders")
         }
+        /// `cost.chart.metricCostHelp` — Plot spend in dollars
+        public static var chartMetricCostHelp: String {
+            L10n.string("cost.chart.metricCostHelp")
+        }
+        /// `cost.chart.metricTokens` — Tok
+        public static var chartMetricTokens: String {
+            L10n.string("cost.chart.metricTokens")
+        }
+        /// `cost.chart.metricTokensHelp` — Plot token volume
+        public static var chartMetricTokensHelp: String {
+            L10n.string("cost.chart.metricTokensHelp")
+        }
         /// `cost.empty.antigravity` — No Antigravity conversation token metadata found yet.
         public static var emptyAntigravity: String {
             L10n.string("cost.empty.antigravity")
@@ -267,9 +283,105 @@ extension L10n {
         public static var googleAITitle: String {
             L10n.string("cost.googleAI.title")
         }
+        /// `cost.granularity.auto` — Auto
+        public static var granularityAuto: String {
+            L10n.string("cost.granularity.auto")
+        }
+        /// `cost.granularity.day` — Day
+        public static var granularityDay: String {
+            L10n.string("cost.granularity.day")
+        }
+        /// `cost.granularity.hour` — Hour
+        public static var granularityHour: String {
+            L10n.string("cost.granularity.hour")
+        }
+        /// `cost.granularity.month` — Month
+        public static var granularityMonth: String {
+            L10n.string("cost.granularity.month")
+        }
+        /// `cost.granularity.week` — Week
+        public static var granularityWeek: String {
+            L10n.string("cost.granularity.week")
+        }
         /// `cost.history.allProviders` — All Providers Cost History
         public static var historyAllProviders: String {
             L10n.string("cost.history.allProviders")
+        }
+        /// `cost.history.building` — Building history…
+        public static var historyBuilding: String {
+            L10n.string("cost.history.building")
+        }
+        /// `cost.history.buildingDetail` — Cost samples appear after the next local scan.
+        public static var historyBuildingDetail: String {
+            L10n.string("cost.history.buildingDetail")
+        }
+        /// `cost.history.clearModelSelection` — Clear model selection
+        public static var historyClearModelSelection: String {
+            L10n.string("cost.history.clearModelSelection")
+        }
+        /// `cost.history.emptyCost` — No cost recorded in this range.
+        public static var historyEmptyCost: String {
+            L10n.string("cost.history.emptyCost")
+        }
+        /// `cost.history.emptyTokens` — No tokens recorded in this range.
+        public static var historyEmptyTokens: String {
+            L10n.string("cost.history.emptyTokens")
+        }
+        /// `cost.history.extentNote` — {span} · {start} – {end}
+        public static func historyExtentNote(span: String, start: String, end: String) -> String {
+            L10n.string("cost.history.extentNote", span, start, end)
+        }
+        /// `cost.history.granularityDisabled` — {granularity} needs a different zoom level
+        public static func historyGranularityDisabled(granularity: String) -> String {
+            L10n.string("cost.history.granularityDisabled", granularity)
+        }
+        /// `cost.history.groupBy` — Group cost history by {granularity}
+        public static func historyGroupBy(granularity: String) -> String {
+            L10n.string("cost.history.groupBy", granularity)
+        }
+        /// `cost.history.hourlyFallback` — hourly n/a · showing daily
+        public static var historyHourlyFallback: String {
+            L10n.string("cost.history.hourlyFallback")
+        }
+        /// `cost.history.metricAverage` — Avg/{granularity}
+        public static func historyMetricAverage(granularity: String) -> String {
+            L10n.string("cost.history.metricAverage", granularity)
+        }
+        /// `cost.history.metricPeak` — Peak
+        public static var historyMetricPeak: String {
+            L10n.string("cost.history.metricPeak")
+        }
+        /// `cost.history.metricTotal` — Total
+        public static var historyMetricTotal: String {
+            L10n.string("cost.history.metricTotal")
+        }
+        /// `cost.history.modelDetailUnavailable` — Model detail is unavailable for this historical period.
+        public static var historyModelDetailUnavailable: String {
+            L10n.string("cost.history.modelDetailUnavailable")
+        }
+        /// `cost.history.modelsAt` — Models · {when}
+        public static func historyModelsAt(when: String) -> String {
+            L10n.string("cost.history.modelsAt", when)
+        }
+        /// `cost.history.moreModels` — +{count} more · click to inspect
+        public static func historyMoreModels(count: Int) -> String {
+            L10n.string("cost.history.moreModels", count)
+        }
+        /// `cost.history.navigator` — Cost history range navigator
+        public static var historyNavigator: String {
+            L10n.string("cost.history.navigator")
+        }
+        /// `cost.history.title` — Cost History
+        public static var historyTitle: String {
+            L10n.string("cost.history.title")
+        }
+        /// `cost.history.weekOf` — Week of {date}
+        public static func historyWeekOf(date: String) -> String {
+            L10n.string("cost.history.weekOf", date)
+        }
+        /// `cost.history.weekShortOf` — wk {date}
+        public static func historyWeekShortOf(date: String) -> String {
+            L10n.string("cost.history.weekShortOf", date)
         }
         /// `cost.metric.peakDay` — PEAK DAY
         public static var metricPeakDay: String {
@@ -911,13 +1023,33 @@ extension L10n {
         public static var headerMachinesSubtitle: String {
             L10n.string("popover.header.machinesSubtitle")
         }
+        /// `popover.header.mini` — Mini
+        public static var headerMini: String {
+            L10n.string("popover.header.mini")
+        }
         /// `popover.header.miscSubtitle` — Usage-only · sign in or paste a key
         public static var headerMiscSubtitle: String {
             L10n.string("popover.header.miscSubtitle")
         }
+        /// `popover.header.openWorkbench` — Open Workbench
+        public static var headerOpenWorkbench: String {
+            L10n.string("popover.header.openWorkbench")
+        }
         /// `popover.header.overviewSubtitle` — All providers · quota & cost
         public static var headerOverviewSubtitle: String {
             L10n.string("popover.header.overviewSubtitle")
+        }
+        /// `popover.header.refreshing` — Refreshing…
+        public static var headerRefreshing: String {
+            L10n.string("popover.header.refreshing")
+        }
+        /// `popover.header.settings` — Settings
+        public static var headerSettings: String {
+            L10n.string("popover.header.settings")
+        }
+        /// `popover.header.updatedLine` — {subtitle} · {updated}
+        public static func headerUpdatedLine(subtitle: String, updated: String) -> String {
+            L10n.string("popover.header.updatedLine", subtitle, updated)
         }
         /// `popover.machines.checking` — Checking the Relay…
         public static var machinesChecking: String {
@@ -990,6 +1122,10 @@ extension L10n {
     }
 
     public enum Quota {
+        /// `quota.awaitingFirstObservation` — Waiting for the first quota observation
+        public static var awaitingFirstObservation: String {
+            L10n.string("quota.awaitingFirstObservation")
+        }
         /// `quota.bucket.noResetInfo` — No reset info
         public static var bucketNoResetInfo: String {
             L10n.string("quota.bucket.noResetInfo")
@@ -997,6 +1133,10 @@ extension L10n {
         /// `quota.bucket.resetsIn` — Resets in {when}
         public static func bucketResetsIn(when: String) -> String {
             L10n.string("quota.bucket.resetsIn", when)
+        }
+        /// `quota.cycleRecordedOnRefill` — A cycle is recorded when the quota refills
+        public static var cycleRecordedOnRefill: String {
+            L10n.string("quota.cycleRecordedOnRefill")
         }
         /// `quota.empty.needsLogin.detail` — Run `{command} login` in your terminal, then refresh.
         public static func emptyNeedsLoginDetail(command: String) -> String {
@@ -1050,6 +1190,22 @@ extension L10n {
         public static var forecastConfidenceMedium: String {
             L10n.string("quota.forecast.confidence.medium")
         }
+        /// `quota.forecast.explain.footer` — Quota observations drive consumption. Token history only weights when you tend to work; it is never converted into quota usage.
+        public static var forecastExplainFooter: String {
+            L10n.string("quota.forecast.explain.footer")
+        }
+        /// `quota.forecast.explain.hide` — Hide forecast calculation
+        public static var forecastExplainHide: String {
+            L10n.string("quota.forecast.explain.hide")
+        }
+        /// `quota.forecast.explain.show` — Show forecast calculation
+        public static var forecastExplainShow: String {
+            L10n.string("quota.forecast.explain.show")
+        }
+        /// `quota.forecast.explain.title` — How this forecast was calculated
+        public static var forecastExplainTitle: String {
+            L10n.string("quota.forecast.explain.title")
+        }
         /// `quota.forecast.guidance.atRisk` — Slow down or shift work to another quota
         public static var forecastGuidanceAtRisk: String {
             L10n.string("quota.forecast.guidance.atRisk")
@@ -1081,6 +1237,166 @@ extension L10n {
         /// `quota.forecast.guidance.withinTarget` — Within the {target}% safety target
         public static func forecastGuidanceWithinTarget(target: Int) -> String {
             L10n.string("quota.forecast.guidance.withinTarget", target)
+        }
+        /// `quota.forecast.legend.item` — {label} {value}
+        public static func forecastLegendItem(label: String, value: String) -> String {
+            L10n.string("quota.forecast.legend.item", label, value)
+        }
+        /// `quota.forecast.metric.aboveTarget` — {percent}% capacity above target
+        public static func forecastMetricAboveTarget(percent: Int) -> String {
+            L10n.string("quota.forecast.metric.aboveTarget", percent)
+        }
+        /// `quota.forecast.metric.activityFallback` — wall-clock fallback until habits exist
+        public static var forecastMetricActivityFallback: String {
+            L10n.string("quota.forecast.metric.activityFallback")
+        }
+        /// `quota.forecast.metric.activityTiming` — Activity timing
+        public static var forecastMetricActivityTiming: String {
+            L10n.string("quota.forecast.metric.activityTiming")
+        }
+        /// `quota.forecast.metric.activityWeighted` — weekday and hour weighted
+        public static var forecastMetricActivityWeighted: String {
+            L10n.string("quota.forecast.metric.activityWeighted")
+        }
+        /// `quota.forecast.metric.behaviorDetail` — used when stronger evidence is sparse
+        public static var forecastMetricBehaviorDetail: String {
+            L10n.string("quota.forecast.metric.behaviorDetail")
+        }
+        /// `quota.forecast.metric.behaviorFallback` — Behavior fallback
+        public static var forecastMetricBehaviorFallback: String {
+            L10n.string("quota.forecast.metric.behaviorFallback")
+        }
+        /// `quota.forecast.metric.comparableCycles` — {count, plural, one {1 comparable reset cycle} other {# comparable reset cycles}}
+        public static func forecastMetricComparableCycles(count: Int) -> String {
+            L10n.string("quota.forecast.metric.comparableCycles", count)
+        }
+        /// `quota.forecast.metric.coverage` — Coverage
+        public static var forecastMetricCoverage: String {
+            L10n.string("quota.forecast.metric.coverage")
+        }
+        /// `quota.forecast.metric.coverageDetail` — fresh {fresh}% · habits {habits}%
+        public static func forecastMetricCoverageDetail(fresh: Int, habits: Int) -> String {
+            L10n.string("quota.forecast.metric.coverageDetail", fresh, habits)
+        }
+        /// `quota.forecast.metric.coverageValue` — obs {observations}% · history {history}%
+        public static func forecastMetricCoverageValue(observations: Int, history: Int) -> String {
+            L10n.string("quota.forecast.metric.coverageValue", observations, history)
+        }
+        /// `quota.forecast.metric.cyclesPending` — Completed cycles will appear here
+        public static var forecastMetricCyclesPending: String {
+            L10n.string("quota.forecast.metric.cyclesPending")
+        }
+        /// `quota.forecast.metric.elapsed` — {percent}% elapsed
+        public static func forecastMetricElapsed(percent: Int) -> String {
+            L10n.string("quota.forecast.metric.elapsed", percent)
+        }
+        /// `quota.forecast.metric.evidence` — Evidence
+        public static var forecastMetricEvidence: String {
+            L10n.string("quota.forecast.metric.evidence")
+        }
+        /// `quota.forecast.metric.evidenceDetail` — {confidence} · score {score}%
+        public static func forecastMetricEvidenceDetail(confidence: String, score: Int) -> String {
+            L10n.string("quota.forecast.metric.evidenceDetail", confidence, score)
+        }
+        /// `quota.forecast.metric.evidenceValue` — {observations} obs · {cycles} cycles
+        public static func forecastMetricEvidenceValue(observations: Int, cycles: Int) -> String {
+            L10n.string("quota.forecast.metric.evidenceValue", observations, cycles)
+        }
+        /// `quota.forecast.metric.expectedLeft` — {percent}% expected left
+        public static func forecastMetricExpectedLeft(percent: Int) -> String {
+            L10n.string("quota.forecast.metric.expectedLeft", percent)
+        }
+        /// `quota.forecast.metric.expectedUsed` — {percent}% expected used
+        public static func forecastMetricExpectedUsed(percent: Int) -> String {
+            L10n.string("quota.forecast.metric.expectedUsed", percent)
+        }
+        /// `quota.forecast.metric.forecastAtReset` — Forecast at reset
+        public static var forecastMetricForecastAtReset: String {
+            L10n.string("quota.forecast.metric.forecastAtReset")
+        }
+        /// `quota.forecast.metric.forecastRange` — Forecast range
+        public static var forecastMetricForecastRange: String {
+            L10n.string("quota.forecast.metric.forecastRange")
+        }
+        /// `quota.forecast.metric.insideTarget` — inside the target range
+        public static var forecastMetricInsideTarget: String {
+            L10n.string("quota.forecast.metric.insideTarget")
+        }
+        /// `quota.forecast.metric.noComparison` — No comparison yet
+        public static var forecastMetricNoComparison: String {
+            L10n.string("quota.forecast.metric.noComparison")
+        }
+        /// `quota.forecast.metric.plan` — Personal plan now
+        public static var forecastMetricPlan: String {
+            L10n.string("quota.forecast.metric.plan")
+        }
+        /// `quota.forecast.metric.planDetail` — activity timing + {target}% safety target
+        public static func forecastMetricPlanDetail(target: Int) -> String {
+            L10n.string("quota.forecast.metric.planDetail", target)
+        }
+        /// `quota.forecast.metric.rangeLeft` — {lower}–{upper}% left
+        public static func forecastMetricRangeLeft(lower: Int, upper: Int) -> String {
+            L10n.string("quota.forecast.metric.rangeLeft", lower, upper)
+        }
+        /// `quota.forecast.metric.rangeUsed` — {lower}–{upper}% used
+        public static func forecastMetricRangeUsed(lower: Int, upper: Int) -> String {
+            L10n.string("quota.forecast.metric.rangeUsed", lower, upper)
+        }
+        /// `quota.forecast.metric.recentBurn` — Recent burn
+        public static var forecastMetricRecentBurn: String {
+            L10n.string("quota.forecast.metric.recentBurn")
+        }
+        /// `quota.forecast.metric.recentIntervals` — {count, plural, one {1 recent interval} other {# recent intervals}}
+        public static func forecastMetricRecentIntervals(count: Int) -> String {
+            L10n.string("quota.forecast.metric.recentIntervals", count)
+        }
+        /// `quota.forecast.metric.recentMissing` — Needs at least two useful observations
+        public static var forecastMetricRecentMissing: String {
+            L10n.string("quota.forecast.metric.recentMissing")
+        }
+        /// `quota.forecast.metric.recentTrend` — Recent trend
+        public static var forecastMetricRecentTrend: String {
+            L10n.string("quota.forecast.metric.recentTrend")
+        }
+        /// `quota.forecast.metric.safetyTarget` — Safety target
+        public static var forecastMetricSafetyTarget: String {
+            L10n.string("quota.forecast.metric.safetyTarget")
+        }
+        /// `quota.forecast.metric.timePace` — Time-only pace
+        public static var forecastMetricTimePace: String {
+            L10n.string("quota.forecast.metric.timePace")
+        }
+        /// `quota.forecast.metric.timePaceDetail` — {stage} by wall clock
+        public static func forecastMetricTimePaceDetail(stage: String) -> String {
+            L10n.string("quota.forecast.metric.timePaceDetail", stage)
+        }
+        /// `quota.forecast.metric.timePaceMissing` — Needs reset time and window length
+        public static var forecastMetricTimePaceMissing: String {
+            L10n.string("quota.forecast.metric.timePaceMissing")
+        }
+        /// `quota.forecast.metric.trendDetail` — last 7 days versus prior 21 days
+        public static var forecastMetricTrendDetail: String {
+            L10n.string("quota.forecast.metric.trendDetail")
+        }
+        /// `quota.forecast.metric.trendDetailMissing` — needs prior daily activity
+        public static var forecastMetricTrendDetailMissing: String {
+            L10n.string("quota.forecast.metric.trendDetailMissing")
+        }
+        /// `quota.forecast.metric.trendMissing` — No baseline yet
+        public static var forecastMetricTrendMissing: String {
+            L10n.string("quota.forecast.metric.trendMissing")
+        }
+        /// `quota.forecast.metric.trendMultiplier` — {multiplier}× activity
+        public static func forecastMetricTrendMultiplier(multiplier: String) -> String {
+            L10n.string("quota.forecast.metric.trendMultiplier", multiplier)
+        }
+        /// `quota.forecast.metric.unavailable` — Unavailable
+        public static var forecastMetricUnavailable: String {
+            L10n.string("quota.forecast.metric.unavailable")
+        }
+        /// `quota.forecast.metric.uncertaintyInterval` — uncertainty interval
+        public static var forecastMetricUncertaintyInterval: String {
+            L10n.string("quota.forecast.metric.uncertaintyInterval")
         }
         /// `quota.forecast.reset.atRisk` — Likely to run out before reset
         public static var forecastResetAtRisk: String {
@@ -1141,6 +1457,14 @@ extension L10n {
         /// `quota.forecast.useUp.uncertain` — Use-up time uncertain · may run short before reset
         public static var forecastUseUpUncertain: String {
             L10n.string("quota.forecast.useUp.uncertain")
+        }
+        /// `quota.forecast.value.atReset` — {value} at reset
+        public static func forecastValueAtReset(value: String) -> String {
+            L10n.string("quota.forecast.value.atReset", value)
+        }
+        /// `quota.forecast.value.expectedNow` — {value} expected now
+        public static func forecastValueExpectedNow(value: String) -> String {
+            L10n.string("quota.forecast.value.expectedNow", value)
         }
         /// `quota.forecast.value.left` — {percent}% left
         public static func forecastValueLeft(percent: Int) -> String {
@@ -1254,6 +1578,82 @@ extension L10n {
         public static var groupWeeklyCredits: String {
             L10n.string("quota.group.weeklyCredits")
         }
+        /// `quota.history.allCurvesHidden` — Every curve is hidden — pick one from the menu above.
+        public static var historyAllCurvesHidden: String {
+            L10n.string("quota.history.allCurvesHidden")
+        }
+        /// `quota.history.buildingUp` — Quota history builds up as refreshes come in.
+        public static var historyBuildingUp: String {
+            L10n.string("quota.history.buildingUp")
+        }
+        /// `quota.history.curveCount` — {count, plural, one {1 curve} other {# curves}}
+        public static func historyCurveCount(count: Int) -> String {
+            L10n.string("quota.history.curveCount", count)
+        }
+        /// `quota.history.curvePickerA11y` — Choose which quota curves to show
+        public static var historyCurvePickerA11y: String {
+            L10n.string("quota.history.curvePickerA11y")
+        }
+        /// `quota.history.curvesAll` — All {total}
+        public static func historyCurvesAll(total: Int) -> String {
+            L10n.string("quota.history.curvesAll", total)
+        }
+        /// `quota.history.curvesSome` — {shown} of {total}
+        public static func historyCurvesSome(shown: Int, total: Int) -> String {
+            L10n.string("quota.history.curvesSome", shown, total)
+        }
+        /// `quota.history.forecastLegend` — forecast
+        public static var historyForecastLegend: String {
+            L10n.string("quota.history.forecastLegend")
+        }
+        /// `quota.history.moreBuckets` — {names} +{count}
+        public static func historyMoreBuckets(names: String, count: Int) -> String {
+            L10n.string("quota.history.moreBuckets", names, count)
+        }
+        /// `quota.history.moreReadings` — +{count} more
+        public static func historyMoreReadings(count: Int) -> String {
+            L10n.string("quota.history.moreReadings", count)
+        }
+        /// `quota.history.navigatorAllProviders` — All-providers quota history range navigator
+        public static var historyNavigatorAllProviders: String {
+            L10n.string("quota.history.navigatorAllProviders")
+        }
+        /// `quota.history.navigatorProvider` — Quota history range navigator
+        public static var historyNavigatorProvider: String {
+            L10n.string("quota.history.navigatorProvider")
+        }
+        /// `quota.history.providerCount` — {count, plural, one {1 provider} other {# providers}}
+        public static func historyProviderCount(count: Int) -> String {
+            L10n.string("quota.history.providerCount", count)
+        }
+        /// `quota.history.scopeNote` — {scope} · showing {visible} of {total} recorded
+        public static func historyScopeNote(scope: String, visible: String, total: String) -> String {
+            L10n.string("quota.history.scopeNote", scope, visible, total)
+        }
+        /// `quota.history.showAllCurves` — Show all curves
+        public static var historyShowAllCurves: String {
+            L10n.string("quota.history.showAllCurves")
+        }
+        /// `quota.history.showBusiest` — Show only the busiest
+        public static var historyShowBusiest: String {
+            L10n.string("quota.history.showBusiest")
+        }
+        /// `quota.history.title` — Quota history
+        public static var historyTitle: String {
+            L10n.string("quota.history.title")
+        }
+        /// `quota.history.tooltipAtReset` — At reset
+        public static var historyTooltipAtReset: String {
+            L10n.string("quota.history.tooltipAtReset")
+        }
+        /// `quota.history.tooltipPace` — Pace
+        public static var historyTooltipPace: String {
+            L10n.string("quota.history.tooltipPace")
+        }
+        /// `quota.history.tooltipQuotaLeft` — Quota left
+        public static var historyTooltipQuotaLeft: String {
+            L10n.string("quota.history.tooltipQuotaLeft")
+        }
         /// `quota.login.claude` — Run claude login, then refresh.
         public static var loginClaude: String {
             L10n.string("quota.login.claude")
@@ -1274,6 +1674,34 @@ extension L10n {
         public static func loginMisc(provider: String) -> String {
             L10n.string("quota.login.misc", provider)
         }
+        /// `quota.mini.forecastLearning` — learning · {percent}% left
+        public static func miniForecastLearning(percent: Int) -> String {
+            L10n.string("quota.mini.forecastLearning", percent)
+        }
+        /// `quota.mini.forecastLearningCompact` — ~{percent}% left
+        public static func miniForecastLearningCompact(percent: Int) -> String {
+            L10n.string("quota.mini.forecastLearningCompact", percent)
+        }
+        /// `quota.mini.forecastLeft` — {percent}% left
+        public static func miniForecastLeft(percent: Int) -> String {
+            L10n.string("quota.mini.forecastLeft", percent)
+        }
+        /// `quota.mini.forecastLeftCompact` — left {percent}%
+        public static func miniForecastLeftCompact(percent: Int) -> String {
+            L10n.string("quota.mini.forecastLeftCompact", percent)
+        }
+        /// `quota.mini.forecastMayRunOut` — may run out {countdown}
+        public static func miniForecastMayRunOut(countdown: String) -> String {
+            L10n.string("quota.mini.forecastMayRunOut", countdown)
+        }
+        /// `quota.mini.forecastSurplus` — surplus · {percent}% left
+        public static func miniForecastSurplus(percent: Int) -> String {
+            L10n.string("quota.mini.forecastSurplus", percent)
+        }
+        /// `quota.mini.forecastSurplusCompact` — surplus {percent}%
+        public static func miniForecastSurplusCompact(percent: Int) -> String {
+            L10n.string("quota.mini.forecastSurplusCompact", percent)
+        }
         /// `quota.mode.remaining` — remaining
         public static var modeRemaining: String {
             L10n.string("quota.mode.remaining")
@@ -1282,13 +1710,37 @@ extension L10n {
         public static var modeUsed: String {
             L10n.string("quota.mode.used")
         }
+        /// `quota.pace.deficit` — {percent}% in deficit
+        public static func paceDeficit(percent: Int) -> String {
+            L10n.string("quota.pace.deficit", percent)
+        }
+        /// `quota.pace.deficitShort` — {percent}% deficit
+        public static func paceDeficitShort(percent: Int) -> String {
+            L10n.string("quota.pace.deficitShort", percent)
+        }
         /// `quota.pace.lastsUntilReset` — Lasts until reset
         public static var paceLastsUntilReset: String {
             L10n.string("quota.pace.lastsUntilReset")
         }
+        /// `quota.pace.onTrack` — On pace
+        public static var paceOnTrack: String {
+            L10n.string("quota.pace.onTrack")
+        }
+        /// `quota.pace.reserve` — {percent}% in reserve
+        public static func paceReserve(percent: Int) -> String {
+            L10n.string("quota.pace.reserve", percent)
+        }
+        /// `quota.pace.reserveShort` — {percent}% reserve
+        public static func paceReserveShort(percent: Int) -> String {
+            L10n.string("quota.pace.reserveShort", percent)
+        }
         /// `quota.pace.runsOutIn` — Runs out in {countdown}
         public static func paceRunsOutIn(countdown: String) -> String {
             L10n.string("quota.pace.runsOutIn", countdown)
+        }
+        /// `quota.pace.runsOutShort` — out {countdown}
+        public static func paceRunsOutShort(countdown: String) -> String {
+            L10n.string("quota.pace.runsOutShort", countdown)
         }
         /// `quota.perModelLimits` — {count, plural, one {1 per-model limit} other {# per-model limits}} · open {provider} for details
         public static func perModelLimits(count: Int, provider: String) -> String {
@@ -1354,6 +1806,10 @@ extension L10n {
         public static var resetHistoryAxisTimeHelp: String {
             L10n.string("quota.resetHistory.axis.timeHelp")
         }
+        /// `quota.resetHistory.axisCurrent` — Current
+        public static var resetHistoryAxisCurrent: String {
+            L10n.string("quota.resetHistory.axisCurrent")
+        }
         /// `quota.resetHistory.axisCyclesBack` — −{count}
         public static func resetHistoryAxisCyclesBack(count: Int) -> String {
             L10n.string("quota.resetHistory.axisCyclesBack", count)
@@ -1361,6 +1817,34 @@ extension L10n {
         /// `quota.resetHistory.axisNow` — now
         public static var resetHistoryAxisNow: String {
             L10n.string("quota.resetHistory.axisNow")
+        }
+        /// `quota.resetHistory.barIsOneCycle` — Each bar is one quota cycle
+        public static var resetHistoryBarIsOneCycle: String {
+            L10n.string("quota.resetHistory.barIsOneCycle")
+        }
+        /// `quota.resetHistory.compareEmpty` — Nothing to compare yet — weekly and longer quotas appear here once a provider reports one.
+        public static var resetHistoryCompareEmpty: String {
+            L10n.string("quota.resetHistory.compareEmpty")
+        }
+        /// `quota.resetHistory.compareTitle` — Reset History Compare
+        public static var resetHistoryCompareTitle: String {
+            L10n.string("quota.resetHistory.compareTitle")
+        }
+        /// `quota.resetHistory.compareWindow` — Compare the {window}
+        public static func resetHistoryCompareWindow(window: String) -> String {
+            L10n.string("quota.resetHistory.compareWindow", window)
+        }
+        /// `quota.resetHistory.currentCycleCaption` — Current cycle · {used}% used so far · {left}% left
+        public static func resetHistoryCurrentCycleCaption(used: Int, left: Int) -> String {
+            L10n.string("quota.resetHistory.currentCycleCaption", used, left)
+        }
+        /// `quota.resetHistory.cycleCaption` — {time} reset · {used}% used · {left}% left
+        public static func resetHistoryCycleCaption(time: String, used: Int, left: Int) -> String {
+            L10n.string("quota.resetHistory.cycleCaption", time, used, left)
+        }
+        /// `quota.resetHistory.earlyRefillCount` — {count, plural, one {1 cycle refilled before the window was up} other {# cycles refilled before the window was up}}
+        public static func resetHistoryEarlyRefillCount(count: Int) -> String {
+            L10n.string("quota.resetHistory.earlyRefillCount", count)
         }
         /// `quota.resetHistory.lane.emptyState` — No completed cycles yet — a cycle is recorded when the quota refills
         public static var resetHistoryLaneEmptyState: String {
@@ -1382,6 +1866,26 @@ extension L10n {
         public static func resetHistoryLaneWasteSummary(percent: String, count: Int) -> String {
             L10n.string("quota.resetHistory.lane.wasteSummary", percent, count)
         }
+        /// `quota.resetHistory.lastSeenBefore` — last seen {duration} before reset
+        public static func resetHistoryLastSeenBefore(duration: String) -> String {
+            L10n.string("quota.resetHistory.lastSeenBefore", duration)
+        }
+        /// `quota.resetHistory.legend.barHeight` — bar height = remaining at reset
+        public static var resetHistoryLegendBarHeight: String {
+            L10n.string("quota.resetHistory.legend.barHeight")
+        }
+        /// `quota.resetHistory.legend.byDate` — placed by date
+        public static var resetHistoryLegendByDate: String {
+            L10n.string("quota.resetHistory.legend.byDate")
+        }
+        /// `quota.resetHistory.legend.perCycle` — one column per cycle
+        public static var resetHistoryLegendPerCycle: String {
+            L10n.string("quota.resetHistory.legend.perCycle")
+        }
+        /// `quota.resetHistory.legend.refilledEarly` — refilled early
+        public static var resetHistoryLegendRefilledEarly: String {
+            L10n.string("quota.resetHistory.legend.refilledEarly")
+        }
         /// `quota.resetHistory.reset.earlyClockRestarted` — refilled early, next window restarted
         public static var resetHistoryResetEarlyClockRestarted: String {
             L10n.string("quota.resetHistory.reset.earlyClockRestarted")
@@ -1393,6 +1897,14 @@ extension L10n {
         /// `quota.resetHistory.reset.earlyUnclear` — refilled early, onto a different schedule
         public static var resetHistoryResetEarlyUnclear: String {
             L10n.string("quota.resetHistory.reset.earlyUnclear")
+        }
+        /// `quota.resetHistory.retiredAccount` — Signed-out account
+        public static var resetHistoryRetiredAccount: String {
+            L10n.string("quota.resetHistory.retiredAccount")
+        }
+        /// `quota.resetHistory.retiredAccountNumbered` — Signed-out account {number}
+        public static func resetHistoryRetiredAccountNumbered(number: Int) -> String {
+            L10n.string("quota.resetHistory.retiredAccountNumbered", number)
         }
         /// `quota.resetHistory.spoken.allCycles` — every recorded cycle
         public static var resetHistorySpokenAllCycles: String {
@@ -1429,6 +1941,22 @@ extension L10n {
         /// `quota.resetHistory.title` — Reset History
         public static var resetHistoryTitle: String {
             L10n.string("quota.resetHistory.title")
+        }
+        /// `quota.resetHistory.tooltip.completed` — {left}% left at reset · {used}% used
+        public static func resetHistoryTooltipCompleted(left: Int, used: Int) -> String {
+            L10n.string("quota.resetHistory.tooltip.completed", left, used)
+        }
+        /// `quota.resetHistory.tooltip.current` — Current cycle · {left}% left now · {used}% used so far
+        public static func resetHistoryTooltipCurrent(left: Int, used: Int) -> String {
+            L10n.string("quota.resetHistory.tooltip.current", left, used)
+        }
+        /// `quota.resetHistory.tooltip.range` — {start} → {end} reset
+        public static func resetHistoryTooltipRange(start: String, end: String) -> String {
+            L10n.string("quota.resetHistory.tooltip.range", start, end)
+        }
+        /// `quota.resetHistory.tooltip.rangeDue` — {start} → {end} reset due
+        public static func resetHistoryTooltipRangeDue(start: String, end: String) -> String {
+            L10n.string("quota.resetHistory.tooltip.rangeDue", start, end)
         }
         /// `quota.resetHistory.totals.headline` — {used}% used · {wasted}% wasted · {count, plural, one {1 cycle} other {# cycles}}
         public static func resetHistoryTotalsHeadline(used: String, wasted: String, count: Int) -> String {
@@ -1521,6 +2049,18 @@ extension L10n {
         /// `quota.update.failed` — Update failed: {reason}
         public static func updateFailed(reason: String) -> String {
             L10n.string("quota.update.failed", reason)
+        }
+        /// `quota.window.dayOfDays` — Day {day} of {total} · {value}
+        public static func windowDayOfDays(day: Int, total: Int, value: String) -> String {
+            L10n.string("quota.window.dayOfDays", day, total, value)
+        }
+        /// `quota.window.elapsedOfWindow` — {elapsed} of {window} · {value}
+        public static func windowElapsedOfWindow(elapsed: String, window: String, value: String) -> String {
+            L10n.string("quota.window.elapsedOfWindow", elapsed, window, value)
+        }
+        /// `quota.window.resetsSoon` — Resets soon · {value}
+        public static func windowResetsSoon(value: String) -> String {
+            L10n.string("quota.window.resetsSoon", value)
         }
     }
 
@@ -3039,6 +3579,34 @@ extension L10n {
     }
 
     public enum Usage {
+        /// `usage.activity.a11y` — Token usage by weekday and hour, 7 days by 24 hours
+        public static var activityA11y: String {
+            L10n.string("usage.activity.a11y")
+        }
+        /// `usage.activity.cellTooltip` — {day} {hour} · {tokens}
+        public static func activityCellTooltip(day: String, hour: String, tokens: String) -> String {
+            L10n.string("usage.activity.cellTooltip", day, hour, tokens)
+        }
+        /// `usage.activity.heavy` — Heavy
+        public static var activityHeavy: String {
+            L10n.string("usage.activity.heavy")
+        }
+        /// `usage.activity.peak` — Peak {hour} · {day}
+        public static func activityPeak(hour: String, day: String) -> String {
+            L10n.string("usage.activity.peak", hour, day)
+        }
+        /// `usage.activity.peakCell` — Peak {hour} · {day} {cellHour}
+        public static func activityPeakCell(hour: String, day: String, cellHour: String) -> String {
+            L10n.string("usage.activity.peakCell", hour, day, cellHour)
+        }
+        /// `usage.activity.quiet` — Quiet
+        public static var activityQuiet: String {
+            L10n.string("usage.activity.quiet")
+        }
+        /// `usage.activity.tokensShort` — {tokens} tok
+        public static func activityTokensShort(tokens: String) -> String {
+            L10n.string("usage.activity.tokensShort", tokens)
+        }
         /// `usage.breakdown.models` — Models
         public static var breakdownModels: String {
             L10n.string("usage.breakdown.models")
@@ -3058,6 +3626,26 @@ extension L10n {
         /// `usage.breakdown.requests` — Requests
         public static var breakdownRequests: String {
             L10n.string("usage.breakdown.requests")
+        }
+        /// `usage.chartNavigator.label` — Chart range navigator
+        public static var chartNavigatorLabel: String {
+            L10n.string("usage.chartNavigator.label")
+        }
+        /// `usage.chartNavigator.range` — {start} to {end}
+        public static func chartNavigatorRange(start: String, end: String) -> String {
+            L10n.string("usage.chartNavigator.range", start, end)
+        }
+        /// `usage.chartNavigator.showFullRange` — Show Full Range
+        public static var chartNavigatorShowFullRange: String {
+            L10n.string("usage.chartNavigator.showFullRange")
+        }
+        /// `usage.chartNavigator.zoomIn` — Zoom In
+        public static var chartNavigatorZoomIn: String {
+            L10n.string("usage.chartNavigator.zoomIn")
+        }
+        /// `usage.chartNavigator.zoomOut` — Zoom Out
+        public static var chartNavigatorZoomOut: String {
+            L10n.string("usage.chartNavigator.zoomOut")
         }
         /// `usage.filters.allHarnesses` — All harnesses
         public static var filtersAllHarnesses: String {
@@ -3243,9 +3831,45 @@ extension L10n {
         public static var ledgerUnavailableTitle: String {
             L10n.string("usage.ledgerUnavailable.title")
         }
+        /// `usage.mix.dimension.harnesses` — Harnesses
+        public static var mixDimensionHarnesses: String {
+            L10n.string("usage.mix.dimension.harnesses")
+        }
+        /// `usage.mix.dimension.models` — Models
+        public static var mixDimensionModels: String {
+            L10n.string("usage.mix.dimension.models")
+        }
+        /// `usage.mix.dimension.projects` — Projects
+        public static var mixDimensionProjects: String {
+            L10n.string("usage.mix.dimension.projects")
+        }
+        /// `usage.mix.dimension.tokenFlow` — Token Flow
+        public static var mixDimensionTokenFlow: String {
+            L10n.string("usage.mix.dimension.tokenFlow")
+        }
         /// `usage.mix.donutUnit` — tokens
         public static var mixDonutUnit: String {
             L10n.string("usage.mix.donutUnit")
+        }
+        /// `usage.mix.empty` — No local usage in this range.
+        public static var mixEmpty: String {
+            L10n.string("usage.mix.empty")
+        }
+        /// `usage.mix.flow.cache` — Cache
+        public static var mixFlowCache: String {
+            L10n.string("usage.mix.flow.cache")
+        }
+        /// `usage.mix.flow.cacheDetail` — read + creation
+        public static var mixFlowCacheDetail: String {
+            L10n.string("usage.mix.flow.cacheDetail")
+        }
+        /// `usage.mix.flow.freshInput` — Fresh input
+        public static var mixFlowFreshInput: String {
+            L10n.string("usage.mix.flow.freshInput")
+        }
+        /// `usage.mix.flow.output` — Output
+        public static var mixFlowOutput: String {
+            L10n.string("usage.mix.flow.output")
         }
         /// `usage.mix.harness.subtitle` — where requests ran
         public static var mixHarnessSubtitle: String {
@@ -3254,6 +3878,14 @@ extension L10n {
         /// `usage.mix.harness.title` — Harness Mix
         public static var mixHarnessTitle: String {
             L10n.string("usage.mix.harness.title")
+        }
+        /// `usage.mix.lastThirtyDays` — Last 30 days
+        public static var mixLastThirtyDays: String {
+            L10n.string("usage.mix.lastThirtyDays")
+        }
+        /// `usage.mix.ledgerUnreadable` — Usage ledger could not be read.
+        public static var mixLedgerUnreadable: String {
+            L10n.string("usage.mix.ledgerUnreadable")
         }
         /// `usage.mix.model.empty` — No model traffic in this range
         public static var mixModelEmpty: String {
@@ -3266,6 +3898,10 @@ extension L10n {
         /// `usage.mix.model.title` — Model Mix
         public static var mixModelTitle: String {
             L10n.string("usage.mix.model.title")
+        }
+        /// `usage.mix.moreSlices` — {count} more
+        public static func mixMoreSlices(count: Int) -> String {
+            L10n.string("usage.mix.moreSlices", count)
         }
         /// `usage.mix.other` — Other
         public static var mixOther: String {
@@ -3287,6 +3923,10 @@ extension L10n {
         public static var mixProjectTitle: String {
             L10n.string("usage.mix.project.title")
         }
+        /// `usage.mix.projectsPending` — Project attribution appears after the next Codex or Claude cost refresh.
+        public static var mixProjectsPending: String {
+            L10n.string("usage.mix.projectsPending")
+        }
         /// `usage.mix.provider.empty` — No provider traffic in this range
         public static var mixProviderEmpty: String {
             L10n.string("usage.mix.provider.empty")
@@ -3299,6 +3939,10 @@ extension L10n {
         public static var mixProviderTitle: String {
             L10n.string("usage.mix.provider.title")
         }
+        /// `usage.mix.title` — Usage Mix
+        public static var mixTitle: String {
+            L10n.string("usage.mix.title")
+        }
         /// `usage.mix.tokenFlow.empty` — No token traffic in this range
         public static var mixTokenFlowEmpty: String {
             L10n.string("usage.mix.tokenFlow.empty")
@@ -3310,6 +3954,10 @@ extension L10n {
         /// `usage.mix.tokenFlow.title` — Token Flow
         public static var mixTokenFlowTitle: String {
             L10n.string("usage.mix.tokenFlow.title")
+        }
+        /// `usage.mix.tokensCaption` — tokens
+        public static var mixTokensCaption: String {
+            L10n.string("usage.mix.tokensCaption")
         }
         /// `usage.noHarnessSelected.detail` — The All harnesses chip is a switch: click it again to put every harness back in the query.
         public static var noHarnessSelectedDetail: String {
@@ -3595,9 +4243,37 @@ extension L10n {
         public static var whenYouUseGoogleAI: String {
             L10n.string("usage.whenYouUse.googleAI")
         }
+        /// `usage.whenYouUse.provider` — When you use {provider}
+        public static func whenYouUseProvider(provider: String) -> String {
+            L10n.string("usage.whenYouUse.provider", provider)
+        }
         /// `usage.whenYouUse.spaceXAI` — When you use SpaceXAI
         public static var whenYouUseSpaceXAI: String {
             L10n.string("usage.whenYouUse.spaceXAI")
+        }
+        /// `usage.yearHeatmap.a11y` — {provider} daily spend over the past year, {count, plural, one {1 week} other {# weeks}}
+        public static func yearHeatmapA11y(provider: String, count: Int) -> String {
+            L10n.string("usage.yearHeatmap.a11y", provider, count)
+        }
+        /// `usage.yearHeatmap.less` — Less
+        public static var yearHeatmapLess: String {
+            L10n.string("usage.yearHeatmap.less")
+        }
+        /// `usage.yearHeatmap.more` — More
+        public static var yearHeatmapMore: String {
+            L10n.string("usage.yearHeatmap.more")
+        }
+        /// `usage.yearHeatmap.title` — {provider} — Past Year
+        public static func yearHeatmapTitle(provider: String) -> String {
+            L10n.string("usage.yearHeatmap.title", provider)
+        }
+        /// `usage.yearHeatmap.tooltip` — {date} · {amount}
+        public static func yearHeatmapTooltip(date: String, amount: String) -> String {
+            L10n.string("usage.yearHeatmap.tooltip", date, amount)
+        }
+        /// `usage.yearHeatmap.total` — {amount} total
+        public static func yearHeatmapTotal(amount: String) -> String {
+            L10n.string("usage.yearHeatmap.total", amount)
         }
     }
 
@@ -5026,6 +5702,7 @@ extension L10n {
         "common.duration.minutes",
         "common.duration.now",
         "common.name",
+        "common.noData",
         "common.off",
         "common.on",
         "common.open",
@@ -5045,6 +5722,9 @@ extension L10n {
         "common.updated.never",
         "common.updated.secondsAgo",
         "cost.allProviders",
+        "cost.chart.metricCostHelp",
+        "cost.chart.metricTokens",
+        "cost.chart.metricTokensHelp",
         "cost.empty.antigravity",
         "cost.empty.claude",
         "cost.empty.codex",
@@ -5056,7 +5736,31 @@ extension L10n {
         "cost.gemini.emptyTitle",
         "cost.googleAI.empty",
         "cost.googleAI.title",
+        "cost.granularity.auto",
+        "cost.granularity.day",
+        "cost.granularity.hour",
+        "cost.granularity.month",
+        "cost.granularity.week",
         "cost.history.allProviders",
+        "cost.history.building",
+        "cost.history.buildingDetail",
+        "cost.history.clearModelSelection",
+        "cost.history.emptyCost",
+        "cost.history.emptyTokens",
+        "cost.history.extentNote",
+        "cost.history.granularityDisabled",
+        "cost.history.groupBy",
+        "cost.history.hourlyFallback",
+        "cost.history.metricAverage",
+        "cost.history.metricPeak",
+        "cost.history.metricTotal",
+        "cost.history.modelDetailUnavailable",
+        "cost.history.modelsAt",
+        "cost.history.moreModels",
+        "cost.history.navigator",
+        "cost.history.title",
+        "cost.history.weekOf",
+        "cost.history.weekShortOf",
         "cost.metric.peakDay",
         "cost.metric.peakTokenDay",
         "cost.metric.sevenDay",
@@ -5214,8 +5918,13 @@ extension L10n {
         "platform.macos.menuBar.showInMenuBar",
         "platform.macos.menuBar.showTitleText",
         "popover.header.machinesSubtitle",
+        "popover.header.mini",
         "popover.header.miscSubtitle",
+        "popover.header.openWorkbench",
         "popover.header.overviewSubtitle",
+        "popover.header.refreshing",
+        "popover.header.settings",
+        "popover.header.updatedLine",
         "popover.machines.checking",
         "popover.machines.includeInTotals",
         "popover.machines.includeInTotalsHelp",
@@ -5233,8 +5942,10 @@ extension L10n {
         "popover.tab.misc",
         "popover.tab.miscShort",
         "popover.tab.overview",
+        "quota.awaitingFirstObservation",
         "quota.bucket.noResetInfo",
         "quota.bucket.resetsIn",
+        "quota.cycleRecordedOnRefill",
         "quota.empty.needsLogin.detail",
         "quota.empty.needsLogin.headline",
         "quota.empty.network.detail",
@@ -5248,6 +5959,10 @@ extension L10n {
         "quota.forecast.confidence.high",
         "quota.forecast.confidence.learning",
         "quota.forecast.confidence.medium",
+        "quota.forecast.explain.footer",
+        "quota.forecast.explain.hide",
+        "quota.forecast.explain.show",
+        "quota.forecast.explain.title",
         "quota.forecast.guidance.atRisk",
         "quota.forecast.guidance.available",
         "quota.forecast.guidance.surplus",
@@ -5256,6 +5971,46 @@ extension L10n {
         "quota.forecast.guidance.usedWithinTarget",
         "quota.forecast.guidance.watch",
         "quota.forecast.guidance.withinTarget",
+        "quota.forecast.legend.item",
+        "quota.forecast.metric.aboveTarget",
+        "quota.forecast.metric.activityFallback",
+        "quota.forecast.metric.activityTiming",
+        "quota.forecast.metric.activityWeighted",
+        "quota.forecast.metric.behaviorDetail",
+        "quota.forecast.metric.behaviorFallback",
+        "quota.forecast.metric.comparableCycles",
+        "quota.forecast.metric.coverage",
+        "quota.forecast.metric.coverageDetail",
+        "quota.forecast.metric.coverageValue",
+        "quota.forecast.metric.cyclesPending",
+        "quota.forecast.metric.elapsed",
+        "quota.forecast.metric.evidence",
+        "quota.forecast.metric.evidenceDetail",
+        "quota.forecast.metric.evidenceValue",
+        "quota.forecast.metric.expectedLeft",
+        "quota.forecast.metric.expectedUsed",
+        "quota.forecast.metric.forecastAtReset",
+        "quota.forecast.metric.forecastRange",
+        "quota.forecast.metric.insideTarget",
+        "quota.forecast.metric.noComparison",
+        "quota.forecast.metric.plan",
+        "quota.forecast.metric.planDetail",
+        "quota.forecast.metric.rangeLeft",
+        "quota.forecast.metric.rangeUsed",
+        "quota.forecast.metric.recentBurn",
+        "quota.forecast.metric.recentIntervals",
+        "quota.forecast.metric.recentMissing",
+        "quota.forecast.metric.recentTrend",
+        "quota.forecast.metric.safetyTarget",
+        "quota.forecast.metric.timePace",
+        "quota.forecast.metric.timePaceDetail",
+        "quota.forecast.metric.timePaceMissing",
+        "quota.forecast.metric.trendDetail",
+        "quota.forecast.metric.trendDetailMissing",
+        "quota.forecast.metric.trendMissing",
+        "quota.forecast.metric.trendMultiplier",
+        "quota.forecast.metric.unavailable",
+        "quota.forecast.metric.uncertaintyInterval",
         "quota.forecast.reset.atRisk",
         "quota.forecast.reset.enough",
         "quota.forecast.reset.learning",
@@ -5271,6 +6026,8 @@ extension L10n {
         "quota.forecast.useUp.estimated",
         "quota.forecast.useUp.lastsUntilReset",
         "quota.forecast.useUp.uncertain",
+        "quota.forecast.value.atReset",
+        "quota.forecast.value.expectedNow",
         "quota.forecast.value.left",
         "quota.forecast.value.used",
         "quota.forecast.verdict.atRisk",
@@ -5299,15 +6056,47 @@ extension L10n {
         "quota.group.otherModels",
         "quota.group.weekly",
         "quota.group.weeklyCredits",
+        "quota.history.allCurvesHidden",
+        "quota.history.buildingUp",
+        "quota.history.curveCount",
+        "quota.history.curvePickerA11y",
+        "quota.history.curvesAll",
+        "quota.history.curvesSome",
+        "quota.history.forecastLegend",
+        "quota.history.moreBuckets",
+        "quota.history.moreReadings",
+        "quota.history.navigatorAllProviders",
+        "quota.history.navigatorProvider",
+        "quota.history.providerCount",
+        "quota.history.scopeNote",
+        "quota.history.showAllCurves",
+        "quota.history.showBusiest",
+        "quota.history.title",
+        "quota.history.tooltipAtReset",
+        "quota.history.tooltipPace",
+        "quota.history.tooltipQuotaLeft",
         "quota.login.claude",
         "quota.login.codex",
         "quota.login.cursor",
         "quota.login.grok",
         "quota.login.misc",
+        "quota.mini.forecastLearning",
+        "quota.mini.forecastLearningCompact",
+        "quota.mini.forecastLeft",
+        "quota.mini.forecastLeftCompact",
+        "quota.mini.forecastMayRunOut",
+        "quota.mini.forecastSurplus",
+        "quota.mini.forecastSurplusCompact",
         "quota.mode.remaining",
         "quota.mode.used",
+        "quota.pace.deficit",
+        "quota.pace.deficitShort",
         "quota.pace.lastsUntilReset",
+        "quota.pace.onTrack",
+        "quota.pace.reserve",
+        "quota.pace.reserveShort",
         "quota.pace.runsOutIn",
+        "quota.pace.runsOutShort",
         "quota.perModelLimits",
         "quota.reset.in",
         "quota.reset.passed",
@@ -5324,16 +6113,31 @@ extension L10n {
         "quota.resetHistory.axis.cycleHelp",
         "quota.resetHistory.axis.time",
         "quota.resetHistory.axis.timeHelp",
+        "quota.resetHistory.axisCurrent",
         "quota.resetHistory.axisCyclesBack",
         "quota.resetHistory.axisNow",
+        "quota.resetHistory.barIsOneCycle",
+        "quota.resetHistory.compareEmpty",
+        "quota.resetHistory.compareTitle",
+        "quota.resetHistory.compareWindow",
+        "quota.resetHistory.currentCycleCaption",
+        "quota.resetHistory.cycleCaption",
+        "quota.resetHistory.earlyRefillCount",
         "quota.resetHistory.lane.emptyState",
         "quota.resetHistory.lane.noCycles",
         "quota.resetHistory.lane.spokenNoCycles",
         "quota.resetHistory.lane.spokenWaste",
         "quota.resetHistory.lane.wasteSummary",
+        "quota.resetHistory.lastSeenBefore",
+        "quota.resetHistory.legend.barHeight",
+        "quota.resetHistory.legend.byDate",
+        "quota.resetHistory.legend.perCycle",
+        "quota.resetHistory.legend.refilledEarly",
         "quota.resetHistory.reset.earlyClockRestarted",
         "quota.resetHistory.reset.earlyClockUnchanged",
         "quota.resetHistory.reset.earlyUnclear",
+        "quota.resetHistory.retiredAccount",
+        "quota.resetHistory.retiredAccountNumbered",
         "quota.resetHistory.spoken.allCycles",
         "quota.resetHistory.spoken.allTime",
         "quota.resetHistory.spoken.eightCycles",
@@ -5343,6 +6147,10 @@ extension L10n {
         "quota.resetHistory.spoken.twelveCycles",
         "quota.resetHistory.spoken.twelveWeeks",
         "quota.resetHistory.title",
+        "quota.resetHistory.tooltip.completed",
+        "quota.resetHistory.tooltip.current",
+        "quota.resetHistory.tooltip.range",
+        "quota.resetHistory.tooltip.rangeDue",
         "quota.resetHistory.totals.headline",
         "quota.resetHistory.totals.none",
         "quota.resetHistory.truncation",
@@ -5366,6 +6174,9 @@ extension L10n {
         "quota.upcoming.resetsAt",
         "quota.upcoming.title",
         "quota.update.failed",
+        "quota.window.dayOfDays",
+        "quota.window.elapsedOfWindow",
+        "quota.window.resetsSoon",
         "settings.antigravityCookieEnabled",
         "settings.antigravityLocalOnly",
         "settings.antigravitySource",
@@ -5743,11 +6554,23 @@ extension L10n {
         "status.overview.partialOutage",
         "status.overview.refreshing",
         "status.overview.title",
+        "usage.activity.a11y",
+        "usage.activity.cellTooltip",
+        "usage.activity.heavy",
+        "usage.activity.peak",
+        "usage.activity.peakCell",
+        "usage.activity.quiet",
+        "usage.activity.tokensShort",
         "usage.breakdown.models",
         "usage.breakdown.periods",
         "usage.breakdown.projects",
         "usage.breakdown.providers",
         "usage.breakdown.requests",
+        "usage.chartNavigator.label",
+        "usage.chartNavigator.range",
+        "usage.chartNavigator.showFullRange",
+        "usage.chartNavigator.zoomIn",
+        "usage.chartNavigator.zoomOut",
         "usage.filters.allHarnesses",
         "usage.filters.allHarnessesHelpEvery",
         "usage.filters.allHarnessesHelpNone",
@@ -5794,23 +6617,38 @@ extension L10n {
         "usage.hero.unpricedHelp",
         "usage.ledgerUnavailable.detail",
         "usage.ledgerUnavailable.title",
+        "usage.mix.dimension.harnesses",
+        "usage.mix.dimension.models",
+        "usage.mix.dimension.projects",
+        "usage.mix.dimension.tokenFlow",
         "usage.mix.donutUnit",
+        "usage.mix.empty",
+        "usage.mix.flow.cache",
+        "usage.mix.flow.cacheDetail",
+        "usage.mix.flow.freshInput",
+        "usage.mix.flow.output",
         "usage.mix.harness.subtitle",
         "usage.mix.harness.title",
+        "usage.mix.lastThirtyDays",
+        "usage.mix.ledgerUnreadable",
         "usage.mix.model.empty",
         "usage.mix.model.subtitle",
         "usage.mix.model.title",
+        "usage.mix.moreSlices",
         "usage.mix.other",
         "usage.mix.otherCount",
         "usage.mix.project.empty",
         "usage.mix.project.subtitle",
         "usage.mix.project.title",
+        "usage.mix.projectsPending",
         "usage.mix.provider.empty",
         "usage.mix.provider.subtitle",
         "usage.mix.provider.title",
+        "usage.mix.title",
         "usage.mix.tokenFlow.empty",
         "usage.mix.tokenFlow.subtitle",
         "usage.mix.tokenFlow.title",
+        "usage.mix.tokensCaption",
         "usage.noHarnessSelected.detail",
         "usage.noHarnessSelected.title",
         "usage.requestCount",
@@ -5882,7 +6720,14 @@ extension L10n {
         "usage.trend.tokensChartLabel",
         "usage.whenYouUse.everything",
         "usage.whenYouUse.googleAI",
+        "usage.whenYouUse.provider",
         "usage.whenYouUse.spaceXAI",
+        "usage.yearHeatmap.a11y",
+        "usage.yearHeatmap.less",
+        "usage.yearHeatmap.more",
+        "usage.yearHeatmap.title",
+        "usage.yearHeatmap.tooltip",
+        "usage.yearHeatmap.total",
         "workbench.appearance.useDark",
         "workbench.appearance.useLight",
         "workbench.header.refreshPage",
@@ -6237,8 +7082,13 @@ extension L10n {
         "common.updated.daysAgo",
         "common.updated.hoursAgo",
         "common.updated.minutesAgo",
+        "quota.forecast.metric.comparableCycles",
+        "quota.forecast.metric.recentIntervals",
+        "quota.history.curveCount",
+        "quota.history.providerCount",
         "quota.perModelLimits",
         "quota.resetCredits.available",
+        "quota.resetHistory.earlyRefillCount",
         "quota.resetHistory.lane.wasteSummary",
         "quota.resetHistory.totals.headline",
         "quota.resetHistory.verdict.leaky",
@@ -6256,6 +7106,7 @@ extension L10n {
         "usage.table.projectCount",
         "usage.table.statRow",
         "usage.trend.accessibilitySummary",
+        "usage.yearHeatmap.a11y",
         "workbench.sessions.count.sessions",
         "workbench.sessions.delete.confirm",
         "workbench.sessions.row.autoReviewsMerged",

--- a/Sources/VibeBarCore/Localization/L10n+Generated.swift
+++ b/Sources/VibeBarCore/Localization/L10n+Generated.swift
@@ -3843,17 +3843,9 @@ extension L10n {
         public static var mixDimensionProjects: String {
             L10n.string("usage.mix.dimension.projects")
         }
-        /// `usage.mix.dimension.tokenFlow` — Token Flow
-        public static var mixDimensionTokenFlow: String {
-            L10n.string("usage.mix.dimension.tokenFlow")
-        }
         /// `usage.mix.donutUnit` — tokens
         public static var mixDonutUnit: String {
             L10n.string("usage.mix.donutUnit")
-        }
-        /// `usage.mix.empty` — No local usage in this range.
-        public static var mixEmpty: String {
-            L10n.string("usage.mix.empty")
         }
         /// `usage.mix.flow.cache` — Cache
         public static var mixFlowCache: String {
@@ -3899,10 +3891,6 @@ extension L10n {
         public static var mixModelTitle: String {
             L10n.string("usage.mix.model.title")
         }
-        /// `usage.mix.moreSlices` — {count} more
-        public static func mixMoreSlices(count: Int) -> String {
-            L10n.string("usage.mix.moreSlices", count)
-        }
         /// `usage.mix.other` — Other
         public static var mixOther: String {
             L10n.string("usage.mix.other")
@@ -3922,10 +3910,6 @@ extension L10n {
         /// `usage.mix.project.title` — Project Mix
         public static var mixProjectTitle: String {
             L10n.string("usage.mix.project.title")
-        }
-        /// `usage.mix.projectsPending` — Project attribution appears after the next Codex or Claude cost refresh.
-        public static var mixProjectsPending: String {
-            L10n.string("usage.mix.projectsPending")
         }
         /// `usage.mix.provider.empty` — No provider traffic in this range
         public static var mixProviderEmpty: String {
@@ -3954,10 +3938,6 @@ extension L10n {
         /// `usage.mix.tokenFlow.title` — Token Flow
         public static var mixTokenFlowTitle: String {
             L10n.string("usage.mix.tokenFlow.title")
-        }
-        /// `usage.mix.tokensCaption` — tokens
-        public static var mixTokensCaption: String {
-            L10n.string("usage.mix.tokensCaption")
         }
         /// `usage.noHarnessSelected.detail` — The All harnesses chip is a switch: click it again to put every harness back in the query.
         public static var noHarnessSelectedDetail: String {
@@ -6620,9 +6600,7 @@ extension L10n {
         "usage.mix.dimension.harnesses",
         "usage.mix.dimension.models",
         "usage.mix.dimension.projects",
-        "usage.mix.dimension.tokenFlow",
         "usage.mix.donutUnit",
-        "usage.mix.empty",
         "usage.mix.flow.cache",
         "usage.mix.flow.cacheDetail",
         "usage.mix.flow.freshInput",
@@ -6634,13 +6612,11 @@ extension L10n {
         "usage.mix.model.empty",
         "usage.mix.model.subtitle",
         "usage.mix.model.title",
-        "usage.mix.moreSlices",
         "usage.mix.other",
         "usage.mix.otherCount",
         "usage.mix.project.empty",
         "usage.mix.project.subtitle",
         "usage.mix.project.title",
-        "usage.mix.projectsPending",
         "usage.mix.provider.empty",
         "usage.mix.provider.subtitle",
         "usage.mix.provider.title",
@@ -6648,7 +6624,6 @@ extension L10n {
         "usage.mix.tokenFlow.empty",
         "usage.mix.tokenFlow.subtitle",
         "usage.mix.tokenFlow.title",
-        "usage.mix.tokensCaption",
         "usage.noHarnessSelected.detail",
         "usage.noHarnessSelected.title",
         "usage.requestCount",

--- a/Sources/VibeBarCore/Localization/L10n+Generated.swift
+++ b/Sources/VibeBarCore/Localization/L10n+Generated.swift
@@ -1055,6 +1055,18 @@ extension L10n {
         public static var machinesChecking: String {
             L10n.string("popover.machines.checking")
         }
+        /// `popover.machines.freshness.delayed` — Delayed
+        public static var machinesFreshnessDelayed: String {
+            L10n.string("popover.machines.freshness.delayed")
+        }
+        /// `popover.machines.freshness.live` — Live
+        public static var machinesFreshnessLive: String {
+            L10n.string("popover.machines.freshness.live")
+        }
+        /// `popover.machines.freshness.stale` — Stale
+        public static var machinesFreshnessStale: String {
+            L10n.string("popover.machines.freshness.stale")
+        }
         /// `popover.machines.includeInTotals` — Include in totals
         public static var machinesIncludeInTotals: String {
             L10n.string("popover.machines.includeInTotals")
@@ -5974,6 +5986,9 @@ extension L10n {
         "popover.header.settings",
         "popover.header.updatedLine",
         "popover.machines.checking",
+        "popover.machines.freshness.delayed",
+        "popover.machines.freshness.live",
+        "popover.machines.freshness.stale",
         "popover.machines.includeInTotals",
         "popover.machines.includeInTotalsHelp",
         "popover.machines.labelWithStatus",

--- a/Sources/VibeBarCore/Localization/LanguageStamp.swift
+++ b/Sources/VibeBarCore/Localization/LanguageStamp.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// The app's language, as a value a cache key or an `Equatable` guard can
+/// hold.
+///
+/// **Why this exists.** A cache keyed on data is wrong the moment its value
+/// depends on the language too. `AppLocale` learned this for formatters —
+/// twenty `static let` formatters were frozen at launch language until it
+/// memoized on `L10n.resolvedLanguageCode`, which turns a language change
+/// into an ordinary cache miss rather than something a person has to
+/// remember to invalidate. Every cache that holds a *localized string* has
+/// the same defect and needs the same cure.
+///
+/// The three shapes it turns up in, and what to do about each:
+///
+/// - **A `static let` holding a localized value** is frozen for the life of
+///   the process. Where the value is cheap — a handful of pill labels — the
+///   answer is to derive it at render and cache nothing, which deletes the
+///   question instead of answering it. `Scripts/lint_localization.py` fails
+///   on this shape in a migrated file so it cannot come back.
+/// - **A cache that genuinely earns its keep** — a 365-day walk, a
+///   re-segmented chart — keeps its cache and puts this in the stamp, next
+///   to the calendar and time-zone identity that are there for exactly the
+///   same reason.
+/// - **An `Equatable` guard** (`.equatable()`, a data signature) has to let
+///   the language participate in the comparison, or the guard goes on doing
+///   its job and goes on being wrong.
+///
+/// Prefer caching the *number* and deriving the sentence where the two can be
+/// separated: a total is data, and "{amount} total" is a rendering of it.
+public struct LanguageStamp: Equatable, Sendable {
+    /// The `.lproj` code in force when this was taken.
+    public let code: String
+
+    private init(code: String) { self.code = code }
+
+    /// The language in force right now.
+    public static var current: LanguageStamp {
+        LanguageStamp(code: L10n.resolvedLanguageCode)
+    }
+}

--- a/Sources/VibeBarCore/Localization/QuotaGroupLabelLocalizer.swift
+++ b/Sources/VibeBarCore/Localization/QuotaGroupLabelLocalizer.swift
@@ -41,6 +41,35 @@ public enum QuotaGroupLabelLocalizer {
         return table[normalized]?() ?? contractLabel
     }
 
+    /// The separator a composed contract label is built with, on every
+    /// surface that builds one: "ChatGPT · All Models", "Claude · Weekly".
+    private static let separator = " · "
+
+    /// The label to show for a contract label that may be *composed*.
+    ///
+    /// `display` is a whole-string lookup, so it returns "All Models · Weekly"
+    /// untouched — both halves are in the table, and neither gets translated
+    /// because the joined string is not. This resolves part by part instead,
+    /// which is the only rule that gets both of these right at once:
+    ///
+    /// - "All Models · Weekly" translates both halves.
+    /// - "GPT-5.3 Codex Spark · 5 Hours" keeps the product name and
+    ///   translates only the window.
+    ///
+    /// A label with no separator is one part, so this agrees with `display`
+    /// on every simple label and can be used wherever a label is drawn.
+    ///
+    /// Splitting on the separator rather than on whitespace is what keeps
+    /// "All Models" whole; a word-by-word rule would look up "All" and
+    /// "Models" separately and translate neither.
+    public static func displayComposed(_ contractLabel: String) -> String {
+        guard contractLabel.contains(separator) else { return display(contractLabel) }
+        return contractLabel
+            .components(separatedBy: separator)
+            .map(display)
+            .joined(separator: separator)
+    }
+
     /// Whether a label is one this translates, for the tests that assert a
     /// model name is *not* in the table.
     public static func isTranslated(_ contractLabel: String) -> Bool {

--- a/Sources/VibeBarCore/Models/CostChartGranularity.swift
+++ b/Sources/VibeBarCore/Models/CostChartGranularity.swift
@@ -15,10 +15,10 @@ public enum CostChartGranularity: String, CaseIterable, Sendable, Identifiable {
 
     public var displayName: String {
         switch self {
-        case .hour: "Hour"
-        case .day: "Day"
-        case .week: "Week"
-        case .month: "Month"
+        case .hour: L10n.Cost.granularityHour
+        case .day: L10n.Cost.granularityDay
+        case .week: L10n.Cost.granularityWeek
+        case .month: L10n.Cost.granularityMonth
         }
     }
 

--- a/Sources/VibeBarCore/Models/UsageHeatmap+Activity.swift
+++ b/Sources/VibeBarCore/Models/UsageHeatmap+Activity.swift
@@ -29,14 +29,23 @@ public extension UsageHeatmap {
         return best.value > 0 ? (best.weekday, best.hour) : nil
     }
 
-    /// 12-hour formatter for a 0..23 hour index — "12am", "3am", "12pm", "3pm".
-    /// Used in peak labels, axis ticks, and cell tooltips so the merged
-    /// activity card never mixes 12h and 24h styles.
+    /// Fixed reference zone for the hour-only formatter below.
+    private static let utc = TimeZone(secondsFromGMT: 0) ?? .current
+
+    /// A 0..23 hour index as the app's language writes a clock hour —
+    /// "3 PM" in English, "15时" in Chinese. Used in peak labels, axis ticks
+    /// and cell tooltips, so the merged activity card never mixes styles.
     static func formatHourLabel(_ hour: Int) -> String {
-        switch hour {
-        case 0:  return "12am"
-        case 12: return "12pm"
-        default: return hour < 12 ? "\(hour)am" : "\(hour - 12)pm"
-        }
+        // A wall-clock hour with no date behind it, spelled the way the
+        // app's language spells one: "3 PM" in English, "15时" in Chinese.
+        // The reference day is fixed and UTC so only the hour survives.
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = Self.utc
+        let components = DateComponents(
+            year: 2_000, month: 1, day: 1, hour: max(0, min(23, hour))
+        )
+        guard let date = calendar.date(from: components) else { return "" }
+        return AppLocale.dateFormatter(template: "j", timeZone: Self.utc)
+            .string(from: date)
     }
 }

--- a/Sources/VibeBarCore/Resources/en.lproj/Localizable.strings
+++ b/Sources/VibeBarCore/Resources/en.lproj/Localizable.strings
@@ -815,6 +815,21 @@
 /* Placeholder inside an empty reset-history strip, before any quota reading has landed */
 "quota.awaitingFirstObservation" = "Waiting for the first quota observation";
 
+/* Empty state of the CodexBar bridge card when every bridged provider is one Vibe Bar already reads natively */
+"quota.bridge.empty" = "No enabled CodexBar-only provider returned a quota window. Overlapping providers remain on Vibe Bar's native cards.";
+
+/* Tooltip on the CodexBar bridge card's refresh button */
+"quota.bridge.refresh" = "Refresh CodexBar providers";
+
+/* Subtitle of the CodexBar bridge card before its version is known */
+"quota.bridge.subtitle" = "Additional providers · read-only";
+
+/* Subtitle of the CodexBar bridge card once the installed version is known */
+"quota.bridge.subtitleVersion" = "CodexBar %1$@ · read-only";
+
+/* Title of the card listing quota read from a CodexBar install; CodexBar is a product name */
+"quota.bridge.title" = "CodexBar Bridge";
+
 /* Caption under a quota bar when the provider reported no reset time */
 "quota.bucket.noResetInfo" = "No reset info";
 
@@ -1234,6 +1249,39 @@
 
 /* Narrow form of the mini window surplus forecast line */
 "quota.mini.forecastSurplusCompact" = "surplus %1$lld%%";
+
+/* Tooltip on the mini focus layout's button that pages to the next provider */
+"quota.mini.nextProvider" = "Next provider";
+
+/* Mini window placeholder when none of the selected fields has a live reading yet */
+"quota.mini.noLiveData" = "No selected fields have live data";
+
+/* Mini focus layout's page counter when there are too many providers for dots */
+"quota.mini.pageIndicator" = "%1$lld/%2$lld";
+
+/* Empty state of the mini window's refill rail; only the user's selected fields are considered */
+"quota.mini.railEmpty" = "Nothing selected refills in the next seven days.";
+
+/* Heading of the mini window's refill rail, naming how far ahead it looks */
+"quota.mini.railTitle" = "QUOTA RESETS · NEXT %1$lld DAYS";
+
+/* Mini window caption for when a bucket refills; countdown is a compact span */
+"quota.mini.resets" = "resets %1$@";
+
+/* Tooltip on a mini window row; subProvider and row are names, percent the current reading */
+"quota.mini.rowHelp" = "%1$@ — %2$@: %3$lld%%";
+
+/* Body of a misc provider card that has no credential yet */
+"quota.misc.notConfigured" = "Not configured.";
+
+/* Tooltip on the refresh button of a misc provider that has several configured copies */
+"quota.misc.refreshCopies" = "Refresh %1$@ copies";
+
+/* Tooltip on the refresh button of a misc provider's card */
+"quota.misc.refreshProvider" = "Refresh %1$@";
+
+/* Button on an unconfigured misc provider card that opens its settings */
+"quota.misc.setUpInSettings" = "Set up in Settings";
 
 /* Caption saying the bar shows what is left */
 "quota.mode.remaining" = "remaining";

--- a/Sources/VibeBarCore/Resources/en.lproj/Localizable.strings
+++ b/Sources/VibeBarCore/Resources/en.lproj/Localizable.strings
@@ -2801,14 +2801,8 @@
 /* Usage Mix dimension: which working directory the tokens came from */
 "usage.mix.dimension.projects" = "Projects";
 
-/* Usage Mix dimension: fresh input against cache and output */
-"usage.mix.dimension.tokenFlow" = "Token Flow";
-
 /* Unit under the total in the middle of a donut card. */
 "usage.mix.donutUnit" = "tokens";
-
-/* Usage Mix empty state when the range holds no local usage */
-"usage.mix.empty" = "No local usage in this range.";
 
 /* Token Flow slice: cached tokens */
 "usage.mix.flow.cache" = "Cache";
@@ -2843,9 +2837,6 @@
 /* Donut card on the Usage Stats distribution wall: tokens by model. */
 "usage.mix.model.title" = "Model Mix";
 
-/* Detail on the Usage Mix slice that stands in for everything below the cut */
-"usage.mix.moreSlices" = "%1$lld more";
-
 /* Donut slice that collapses everything below the top five. */
 "usage.mix.other" = "Other";
 
@@ -2857,9 +2848,6 @@
 
 /* Donut card on the Usage Stats distribution wall: tokens by project directory. */
 "usage.mix.project.title" = "Project Mix";
-
-/* Usage Mix empty state on the Projects dimension before a cost refresh has attributed anything */
-"usage.mix.projectsPending" = "Project attribution appears after the next Codex or Claude cost refresh.";
 
 /* Empty state inside the Provider Mix donut card. */
 "usage.mix.provider.empty" = "No provider traffic in this range";
@@ -2881,9 +2869,6 @@
 
 /* Donut card on the Usage Stats distribution wall: tokens by kind. */
 "usage.mix.tokenFlow.title" = "Token Flow";
-
-/* Caption under the total in the middle of the Usage Mix donut */
-"usage.mix.tokensCaption" = "tokens";
 
 /* Empty state body explaining the All chip */
 "usage.noHarnessSelected.detail" = "The All harnesses chip is a switch: click it again to put every harness back in the query.";

--- a/Sources/VibeBarCore/Resources/en.lproj/Localizable.strings
+++ b/Sources/VibeBarCore/Resources/en.lproj/Localizable.strings
@@ -764,6 +764,15 @@
 /* Empty-state title while a sync is in flight */
 "popover.machines.checking" = "Checking the Relay…";
 
+/* Badge on a remote machine whose last report is later than expected */
+"popover.machines.freshness.delayed" = "Delayed";
+
+/* Badge on a remote machine reporting on schedule */
+"popover.machines.freshness.live" = "Live";
+
+/* Badge on a remote machine that has not reported for a long time */
+"popover.machines.freshness.stale" = "Stale";
+
 /* Toggle on a remote machine card */
 "popover.machines.includeInTotals" = "Include in totals";
 

--- a/Sources/VibeBarCore/Resources/en.lproj/Localizable.strings
+++ b/Sources/VibeBarCore/Resources/en.lproj/Localizable.strings
@@ -101,6 +101,9 @@
 /* Field label for a user-chosen name */
 "common.name" = "Name";
 
+/* A chart tooltip row for a moment nothing was recorded — the app was not watching, rather than the value being zero */
+"common.noData" = "No data recorded";
+
 /* A toggle's state, read as a value in a summary row */
 "common.off" = "Off";
 
@@ -149,6 +152,15 @@
 /* Scope name for the combined cost card */
 "cost.allProviders" = "All providers";
 
+/* Tooltip on the cost chart's dollar option */
+"cost.chart.metricCostHelp" = "Plot spend in dollars";
+
+/* Segmented-control label that plots token volume instead of spend; the dollar option is the '$' sign and needs no key */
+"cost.chart.metricTokens" = "Tok";
+
+/* Tooltip on the cost chart's token option */
+"cost.chart.metricTokensHelp" = "Plot token volume";
+
 /* Empty cost history */
 "cost.empty.antigravity" = "No Antigravity conversation token metadata found yet.";
 
@@ -182,8 +194,80 @@
 /* Card title; the company name is never translated */
 "cost.googleAI.title" = "Google AI Cost";
 
+/* Cost chart bucket width that follows the visible span instead of being pinned */
+"cost.granularity.auto" = "Auto";
+
+/* Cost chart bucket width: one bar per day */
+"cost.granularity.day" = "Day";
+
+/* Cost chart bucket width: one bar per hour */
+"cost.granularity.hour" = "Hour";
+
+/* Cost chart bucket width: one bar per calendar month */
+"cost.granularity.month" = "Month";
+
+/* Cost chart bucket width: one bar per week */
+"cost.granularity.week" = "Week";
+
 /* Card title on the Overview */
 "cost.history.allProviders" = "All Providers Cost History";
+
+/* Empty state of the cost history chart before the first samples exist */
+"cost.history.building" = "Building history…";
+
+/* Second line of the cost history chart's empty state */
+"cost.history.buildingDetail" = "Cost samples appear after the next local scan.";
+
+/* Tooltip on the button that closes the model breakdown panel */
+"cost.history.clearModelSelection" = "Clear model selection";
+
+/* Overlay on the cost chart when the visible range holds no spend */
+"cost.history.emptyCost" = "No cost recorded in this range.";
+
+/* Overlay on the cost chart when the visible range holds no tokens */
+"cost.history.emptyTokens" = "No tokens recorded in this range.";
+
+/* Caption naming the visible span of the cost chart and the dates at its ends */
+"cost.history.extentNote" = "%1$@ · %2$@ – %3$@";
+
+/* Tooltip on a bucket-width button the current zoom level cannot draw */
+"cost.history.granularityDisabled" = "%1$@ needs a different zoom level";
+
+/* Tooltip on a bucket-width button in the cost chart */
+"cost.history.groupBy" = "Group cost history by %1$@";
+
+/* Note under the cost chart when hourly buckets were asked for but only daily ones exist that far back */
+"cost.history.hourlyFallback" = "hourly n/a · showing daily";
+
+/* Summary figure under the cost chart: the per-bucket average; granularity is the bucket width */
+"cost.history.metricAverage" = "Avg/%1$@";
+
+/* Summary figure under the cost chart: the largest single bucket */
+"cost.history.metricPeak" = "Peak";
+
+/* Summary figure under the cost chart: the visible range's total */
+"cost.history.metricTotal" = "Total";
+
+/* Shown in the model breakdown panel for a bucket old enough that per-model rows were not kept */
+"cost.history.modelDetailUnavailable" = "Model detail is unavailable for this historical period.";
+
+/* Heading of the model breakdown panel; when is the bucket the user clicked */
+"cost.history.modelsAt" = "Models · %1$@";
+
+/* Last row of a cost-chart tooltip, standing in for the models it could not fit */
+"cost.history.moreModels" = "+%1$lld more · click to inspect";
+
+/* Accessibility label for the range navigator under the cost history chart */
+"cost.history.navigator" = "Cost history range navigator";
+
+/* Title of the navigable cost history chart */
+"cost.history.title" = "Cost History";
+
+/* Cost chart tooltip heading for a weekly bucket; date is the week's first day */
+"cost.history.weekOf" = "Week of %1$@";
+
+/* Compact form of the weekly bucket label, used under the peak figure */
+"cost.history.weekShortOf" = "wk %1$@";
 
 /* All-caps metric label: the most expensive day on record */
 "cost.metric.peakDay" = "PEAK DAY";
@@ -656,11 +740,26 @@
 /* Subtitle under the Machines page header */
 "popover.header.machinesSubtitle" = "End-to-end encrypted remote usage";
 
+/* Tooltip on the popover header button that opens the floating mini window */
+"popover.header.mini" = "Mini";
+
 /* Subtitle under the Misc Providers page header */
 "popover.header.miscSubtitle" = "Usage-only · sign in or paste a key";
 
+/* Tooltip on the popover header button that opens the Workbench window */
+"popover.header.openWorkbench" = "Open Workbench";
+
 /* Subtitle under the Overview page header */
 "popover.header.overviewSubtitle" = "All providers · quota & cost";
+
+/* Popover header caption while a refresh is in flight */
+"popover.header.refreshing" = "Refreshing…";
+
+/* Tooltip on the popover header's gear button */
+"popover.header.settings" = "Settings";
+
+/* Popover header caption: the page's own subtitle followed by how long ago the data was updated */
+"popover.header.updatedLine" = "%1$@ · %2$@";
 
 /* Empty-state title while a sync is in flight */
 "popover.machines.checking" = "Checking the Relay…";
@@ -713,11 +812,17 @@
 /* Popover tab. The other tabs are company names (OpenAI, Anthropic, Google AI, SpaceXAI) and are never translated. */
 "popover.tab.overview" = "Overview";
 
+/* Placeholder inside an empty reset-history strip, before any quota reading has landed */
+"quota.awaitingFirstObservation" = "Waiting for the first quota observation";
+
 /* Caption under a quota bar when the provider reported no reset time */
 "quota.bucket.noResetInfo" = "No reset info";
 
 /* Caption under a quota bar; when is a countdown, sometimes with an absolute time */
 "quota.bucket.resetsIn" = "Resets in %1$@";
+
+/* Caption under an empty reset-history strip explaining when a cycle is recorded */
+"quota.cycleRecordedOnRefill" = "A cycle is recorded when the quota refills";
 
 /* Empty state body; command is a CLI name such as codex or claude and is never translated */
 "quota.empty.needsLogin.detail" = "Run `%1$@ login` in your terminal, then refresh.";
@@ -758,6 +863,18 @@
 /* Forecast confidence level */
 "quota.forecast.confidence.medium" = "Medium confidence";
 
+/* Footnote under the forecast metric grid explaining what token history is and is not used for */
+"quota.forecast.explain.footer" = "Quota observations drive consumption. Token history only weights when you tend to work; it is never converted into quota usage.";
+
+/* Accessibility label on the disclosure button while the grid is open */
+"quota.forecast.explain.hide" = "Hide forecast calculation";
+
+/* Accessibility label on the disclosure button while the grid is closed */
+"quota.forecast.explain.show" = "Show forecast calculation";
+
+/* Disclosure button that opens the forecast's metric grid */
+"quota.forecast.explain.title" = "How this forecast was calculated";
+
 /* What to do about an at-risk forecast */
 "quota.forecast.guidance.atRisk" = "Slow down or shift work to another quota";
 
@@ -781,6 +898,120 @@
 
 /* Remaining-mode guidance when nothing needs saying */
 "quota.forecast.guidance.withinTarget" = "Within the %1$lld%% safety target";
+
+/* One reference marker in the quota bar legend: its name followed by the figure it marks */
+"quota.forecast.legend.item" = "%1$@ %2$@";
+
+/* Detail under the safety target metric when the forecast leaves capacity above it */
+"quota.forecast.metric.aboveTarget" = "%1$lld%% capacity above target";
+
+/* Detail under the activity timing metric before any habits exist */
+"quota.forecast.metric.activityFallback" = "wall-clock fallback until habits exist";
+
+/* Forecast metric: how far through the window the user's own working rhythm says we are */
+"quota.forecast.metric.activityTiming" = "Activity timing";
+
+/* Detail under the activity timing metric when weekday and hour habits are known */
+"quota.forecast.metric.activityWeighted" = "weekday and hour weighted";
+
+/* Detail under the behavior fallback metric */
+"quota.forecast.metric.behaviorDetail" = "used when stronger evidence is sparse";
+
+/* Forecast metric: the projection used when stronger inputs are missing */
+"quota.forecast.metric.behaviorFallback" = "Behavior fallback";
+
+/* Forecast metric: how completely each input covers the window */
+"quota.forecast.metric.coverage" = "Coverage";
+
+/* Detail under the coverage metric: freshness of the data and how well habits are known */
+"quota.forecast.metric.coverageDetail" = "fresh %1$lld%% · habits %2$lld%%";
+
+/* Value of the coverage metric: observation and reset-history coverage */
+"quota.forecast.metric.coverageValue" = "obs %1$lld%% · history %2$lld%%";
+
+/* Detail under the reset-history metric before any cycle has completed */
+"quota.forecast.metric.cyclesPending" = "Completed cycles will appear here";
+
+/* Value of the activity timing metric: share of the window already behind us */
+"quota.forecast.metric.elapsed" = "%1$lld%% elapsed";
+
+/* Forecast metric: how much data the projection stands on */
+"quota.forecast.metric.evidence" = "Evidence";
+
+/* Detail under the evidence metric; confidence is the forecast's own confidence label */
+"quota.forecast.metric.evidenceDetail" = "%1$@ · score %2$lld%%";
+
+/* Value of the evidence metric: observations in this cycle and completed cycles behind it */
+"quota.forecast.metric.evidenceValue" = "%1$lld obs · %2$lld cycles";
+
+/* Detail under the forecast metric while the card shows used percentages */
+"quota.forecast.metric.expectedLeft" = "%1$lld%% expected left";
+
+/* Detail under the forecast metric while the card shows remaining percentages */
+"quota.forecast.metric.expectedUsed" = "%1$lld%% expected used";
+
+/* Forecast metric and bar legend entry: the projected figure at the next reset */
+"quota.forecast.metric.forecastAtReset" = "Forecast at reset";
+
+/* Forecast metric: the spread the projection considers plausible */
+"quota.forecast.metric.forecastRange" = "Forecast range";
+
+/* Detail under the safety target metric when the forecast sits inside it */
+"quota.forecast.metric.insideTarget" = "inside the target range";
+
+/* Value of the reset-history metric before any cycle can be compared */
+"quota.forecast.metric.noComparison" = "No comparison yet";
+
+/* Forecast metric: where the personal plan says usage should be right now */
+"quota.forecast.metric.plan" = "Personal plan now";
+
+/* Detail under the personal plan metric: what the plan is built from */
+"quota.forecast.metric.planDetail" = "activity timing + %1$lld%% safety target";
+
+/* Value of the forecast range metric in Remaining mode */
+"quota.forecast.metric.rangeLeft" = "%1$lld–%2$lld%% left";
+
+/* Value of the forecast range metric in Used mode */
+"quota.forecast.metric.rangeUsed" = "%1$lld–%2$lld%% used";
+
+/* Forecast metric: the projection from the most recent intervals alone */
+"quota.forecast.metric.recentBurn" = "Recent burn";
+
+/* Detail under the recent burn metric when there is not enough recent data */
+"quota.forecast.metric.recentMissing" = "Needs at least two useful observations";
+
+/* Forecast metric: whether recent activity is above or below the earlier baseline */
+"quota.forecast.metric.recentTrend" = "Recent trend";
+
+/* Forecast metric: the share of the quota the user wants to still hold at reset */
+"quota.forecast.metric.safetyTarget" = "Safety target";
+
+/* Forecast metric: the projection that only knows how much of the window has elapsed */
+"quota.forecast.metric.timePace" = "Time-only pace";
+
+/* Detail under the time-only pace metric; stage is the pace summary such as '5% in deficit' */
+"quota.forecast.metric.timePaceDetail" = "%1$@ by wall clock";
+
+/* Detail under the time-only pace metric when the bucket reports no window */
+"quota.forecast.metric.timePaceMissing" = "Needs reset time and window length";
+
+/* Detail under the recent trend metric: the two spans being compared */
+"quota.forecast.metric.trendDetail" = "last 7 days versus prior 21 days";
+
+/* Detail under the recent trend metric when the earlier span has no activity */
+"quota.forecast.metric.trendDetailMissing" = "needs prior daily activity";
+
+/* Value of the recent trend metric before a baseline exists */
+"quota.forecast.metric.trendMissing" = "No baseline yet";
+
+/* Value of the recent trend metric; multiplier is a decimal already formatted at the call site */
+"quota.forecast.metric.trendMultiplier" = "%1$@× activity";
+
+/* Value of a forecast metric whose inputs the bucket does not report */
+"quota.forecast.metric.unavailable" = "Unavailable";
+
+/* Detail under the forecast range metric */
+"quota.forecast.metric.uncertaintyInterval" = "uncertainty interval";
 
 /* One-line forecast summary */
 "quota.forecast.reset.atRisk" = "Likely to run out before reset";
@@ -826,6 +1057,12 @@
 
 /* Use-up line when no ETA can be derived */
 "quota.forecast.useUp.uncertain" = "Use-up time uncertain · may run short before reset";
+
+/* A quota figure qualified as the projection for the next reset; value is one of the used/left figures */
+"quota.forecast.value.atReset" = "%1$@ at reset";
+
+/* A quota figure qualified as where usage should stand at this moment */
+"quota.forecast.value.expectedNow" = "%1$@ expected now";
 
 /* The forecast figure in Remaining mode, used inside the status line */
 "quota.forecast.value.left" = "%1$lld%% left";
@@ -911,6 +1148,57 @@
 /* Quota group: a weekly credit balance rather than a percentage */
 "quota.group.weeklyCredits" = "Weekly Credits";
 
+/* Empty state of the all-providers quota history chart when every curve has been switched off */
+"quota.history.allCurvesHidden" = "Every curve is hidden — pick one from the menu above.";
+
+/* Empty state of the quota history chart before enough refreshes have landed */
+"quota.history.buildingUp" = "Quota history builds up as refreshes come in.";
+
+/* Accessibility label for the quota history curve picker */
+"quota.history.curvePickerA11y" = "Choose which quota curves to show";
+
+/* Curve picker summary when nothing is hidden */
+"quota.history.curvesAll" = "All %1$lld";
+
+/* Curve picker summary when some curves are hidden */
+"quota.history.curvesSome" = "%1$lld of %2$lld";
+
+/* Legend entry marking the dotted projection line on the quota history chart */
+"quota.history.forecastLegend" = "forecast";
+
+/* Scope note when a group holds more quotas than the note can name; names are the ones it did name */
+"quota.history.moreBuckets" = "%1$@ +%2$lld";
+
+/* Last row of a crowded chart tooltip, standing in for the readings it could not fit */
+"quota.history.moreReadings" = "+%1$lld more";
+
+/* Accessibility label for the range navigator under the all-providers quota chart */
+"quota.history.navigatorAllProviders" = "All-providers quota history range navigator";
+
+/* Accessibility label for the range navigator under a single provider's quota chart */
+"quota.history.navigatorProvider" = "Quota history range navigator";
+
+/* Footer under a quota history chart; scope names what the chart covers, visible and total are compact spans such as 7d */
+"quota.history.scopeNote" = "%1$@ · showing %2$@ of %3$@ recorded";
+
+/* Menu item that puts every quota curve back on the chart */
+"quota.history.showAllCurves" = "Show all curves";
+
+/* Menu item that leaves only the most-used quota curves on the chart */
+"quota.history.showBusiest" = "Show only the busiest";
+
+/* Title of the quota history chart card */
+"quota.history.title" = "Quota history";
+
+/* Tooltip row on the quota history chart: the projection for the next reset */
+"quota.history.tooltipAtReset" = "At reset";
+
+/* Tooltip row on the quota history chart: where the wall clock said usage should be */
+"quota.history.tooltipPace" = "Pace";
+
+/* Tooltip row on the quota history chart: the recorded remaining quota */
+"quota.history.tooltipQuotaLeft" = "Quota left";
+
 /* What to do when no credential is stored */
 "quota.login.claude" = "Run claude login, then refresh.";
 
@@ -926,17 +1214,56 @@
 /* Fallback for a misc provider; provider is a SubProvider name */
 "quota.login.misc" = "Configure %1$@ in Settings → Misc Providers.";
 
+/* Mini window forecast line while the forecast is still learning the usage pattern */
+"quota.mini.forecastLearning" = "learning · %1$lld%% left";
+
+/* Narrow form of the mini window learning forecast line */
+"quota.mini.forecastLearningCompact" = "~%1$lld%% left";
+
+/* Mini window forecast line for a quota that is comfortably ahead */
+"quota.mini.forecastLeft" = "%1$lld%% left";
+
+/* Narrow form of the mini window forecast line for a quota that is comfortably ahead */
+"quota.mini.forecastLeftCompact" = "left %1$lld%%";
+
+/* Mini window forecast line for a quota that may, rather than will, be exhausted before reset */
+"quota.mini.forecastMayRunOut" = "may run out %1$@";
+
+/* Mini window forecast line for a quota expected to finish its window well under target */
+"quota.mini.forecastSurplus" = "surplus · %1$lld%% left";
+
+/* Narrow form of the mini window surplus forecast line */
+"quota.mini.forecastSurplusCompact" = "surplus %1$lld%%";
+
 /* Caption saying the bar shows what is left */
 "quota.mode.remaining" = "remaining";
 
 /* Caption saying the bar shows what has been spent */
 "quota.mode.used" = "used";
 
+/* Pace summary when usage is running ahead of the linear expectation */
+"quota.pace.deficit" = "%1$lld%% in deficit";
+
+/* Compact form of the pace summary for the mini window when usage runs ahead of the linear expectation */
+"quota.pace.deficitShort" = "%1$lld%% deficit";
+
 /* Legacy elapsed-time pace ETA on a Misc provider card */
 "quota.pace.lastsUntilReset" = "Lasts until reset";
 
+/* Pace summary when usage matches the linear expectation */
+"quota.pace.onTrack" = "On pace";
+
+/* Pace summary when usage is running behind the linear expectation */
+"quota.pace.reserve" = "%1$lld%% in reserve";
+
+/* Compact form of the pace summary for the mini window when usage runs behind the linear expectation */
+"quota.pace.reserveShort" = "%1$lld%% reserve";
+
 /* Legacy elapsed-time pace ETA on a Misc provider card */
 "quota.pace.runsOutIn" = "Runs out in %1$@";
+
+/* Compact projection in the mini window: when the quota is estimated to be exhausted */
+"quota.pace.runsOutShort" = "out %1$@";
 
 /* Live countdown to a bucket's refill; duration is a compact span, sometimes followed by an absolute time */
 "quota.reset.in" = "resets in %1$@";
@@ -980,11 +1307,32 @@
 /* Tooltip on the Time axis option */
 "quota.resetHistory.axis.timeHelp" = "Each cycle where it actually happened, on a shared calendar";
 
+/* Axis label for the cycle that has not reset yet */
+"quota.resetHistory.axisCurrent" = "Current";
+
 /* Caption on a completed column: how many cycles back it is. The leading character is a minus sign, not a hyphen. */
 "quota.resetHistory.axisCyclesBack" = "−%1$lld";
 
 /* Caption on the live column of the reset-history grid */
 "quota.resetHistory.axisNow" = "now";
+
+/* Caption beside the reset-history strip's title */
+"quota.resetHistory.barIsOneCycle" = "Each bar is one quota cycle";
+
+/* Empty state of the reset history comparison before any weekly or longer quota is known */
+"quota.resetHistory.compareEmpty" = "Nothing to compare yet — weekly and longer quotas appear here once a provider reports one.";
+
+/* Title of the card that puts every weekly-and-longer quota's reset history side by side */
+"quota.resetHistory.compareTitle" = "Reset History Compare";
+
+/* Tooltip on a window button in the reset history comparison; window is the spoken span such as 'last 8 weeks' */
+"quota.resetHistory.compareWindow" = "Compare the %1$@";
+
+/* Caption for the cycle still running in the reset-history strip */
+"quota.resetHistory.currentCycleCaption" = "Current cycle · %1$lld%% used so far · %2$lld%% left";
+
+/* Caption for one completed cycle in the reset-history strip; time is the reset moment */
+"quota.resetHistory.cycleCaption" = "%1$@ reset · %2$lld%% used · %3$lld%% left";
 
 /* Empty-state copy for a lane */
 "quota.resetHistory.lane.emptyState" = "No completed cycles yet — a cycle is recorded when the quota refills";
@@ -998,6 +1346,21 @@
 /* One lane inside the screen-reader summary */
 "quota.resetHistory.lane.spokenWaste" = "%1$@: %2$@%% wasted on average over %3$lld cycles";
 
+/* Note appended to a cycle caption when the last reading predates the reset by a while */
+"quota.resetHistory.lastSeenBefore" = "last seen %1$@ before reset";
+
+/* Legend entry explaining what a bar's height means in the reset history comparison */
+"quota.resetHistory.legend.barHeight" = "bar height = remaining at reset";
+
+/* Legend entry for the time axis: bars sit where they happened on a calendar */
+"quota.resetHistory.legend.byDate" = "placed by date";
+
+/* Legend entry for the cycle axis: columns are cycles, not dates */
+"quota.resetHistory.legend.perCycle" = "one column per cycle";
+
+/* Legend entry for the dot marking a cycle that refilled before its window was up */
+"quota.resetHistory.legend.refilledEarly" = "refilled early";
+
 /* What the provider did to the clock on an early refill. This shape means a whole window lies ahead, so the extra capacity is usable. */
 "quota.resetHistory.reset.earlyClockRestarted" = "refilled early, next window restarted";
 
@@ -1006,6 +1369,12 @@
 
 /* An early refill that matches neither shape */
 "quota.resetHistory.reset.earlyUnclear" = "refilled early, onto a different schedule";
+
+/* Lane label for history kept from an account that is no longer signed in */
+"quota.resetHistory.retiredAccount" = "Signed-out account";
+
+/* Lane label for one of several signed-out accounts on the same provider */
+"quota.resetHistory.retiredAccountNumbered" = "Signed-out account %1$lld";
 
 /* Spoken window name */
 "quota.resetHistory.spoken.allCycles" = "every recorded cycle";
@@ -1033,6 +1402,18 @@
 
 /* Card title on a provider detail page */
 "quota.resetHistory.title" = "Reset History";
+
+/* Tooltip figures for a finished cycle in the reset history comparison */
+"quota.resetHistory.tooltip.completed" = "%1$lld%% left at reset · %2$lld%% used";
+
+/* Tooltip figures for the cycle still running */
+"quota.resetHistory.tooltip.current" = "Current cycle · %1$lld%% left now · %2$lld%% used so far";
+
+/* Tooltip line naming the span a finished cycle covered */
+"quota.resetHistory.tooltip.range" = "%1$@ → %2$@ reset";
+
+/* Tooltip line naming the span of the cycle still running and when it is due to reset */
+"quota.resetHistory.tooltip.rangeDue" = "%1$@ → %2$@ reset due";
 
 /* Header arithmetic when nothing has closed */
 "quota.resetHistory.totals.none" = "No completed cycles in this window";
@@ -1093,6 +1474,15 @@
 
 /* Inline error row; reason is a provider message and is not translated */
 "quota.update.failed" = "Update failed: %1$@";
+
+/* Window progress line for a window measured in whole days */
+"quota.window.dayOfDays" = "Day %1$lld of %2$lld · %3$@";
+
+/* Window progress line for a sub-day window; window is its length, elapsed how much of it is gone */
+"quota.window.elapsedOfWindow" = "%1$@ of %2$@ · %3$@";
+
+/* Window progress line once the reset time has passed but no refresh has landed; value is the used/left figure */
+"quota.window.resetsSoon" = "Resets soon · %1$@";
 
 /* Hint under the Antigravity source picker */
 "settings.antigravityCookieEnabled" = "Antigravity cookie import is enabled — sign in at antigravity.google first.";
@@ -2222,6 +2612,27 @@
 /* Card title on the Overview's service-status tile row */
 "status.overview.title" = "Status";
 
+/* Accessibility label for the 7 by 24 activity grid */
+"usage.activity.a11y" = "Token usage by weekday and hour, 7 days by 24 hours";
+
+/* Tooltip on one cell of the activity grid */
+"usage.activity.cellTooltip" = "%1$@ %2$@ · %3$@";
+
+/* High end of the activity grid's intensity legend */
+"usage.activity.heavy" = "Heavy";
+
+/* Caption naming the busiest hour of the activity card when the peak hour and peak cell agree */
+"usage.activity.peak" = "Peak %1$@ · %2$@";
+
+/* Caption naming the busiest hour overall and the busiest single cell when they differ */
+"usage.activity.peakCell" = "Peak %1$@ · %2$@ %3$@";
+
+/* Low end of the activity grid's intensity legend */
+"usage.activity.quiet" = "Quiet";
+
+/* A token count in the activity grid's tooltip; the number is already abbreviated at the call site */
+"usage.activity.tokensShort" = "%1$@ tok";
+
 /* Tab over the Usage Stats breakdown table: one row per model. */
 "usage.breakdown.models" = "Models";
 
@@ -2236,6 +2647,21 @@
 
 /* Tab over the Usage Stats breakdown table: one row per request. The all-caps hero metric of the same word is usage.hero.requests. */
 "usage.breakdown.requests" = "Requests";
+
+/* Accessibility label for the brush strip under a pannable chart */
+"usage.chartNavigator.label" = "Chart range navigator";
+
+/* Accessibility value of the chart range navigator; both ends are already formatted dates */
+"usage.chartNavigator.range" = "%1$@ to %2$@";
+
+/* Accessibility action that returns a chart to its whole domain */
+"usage.chartNavigator.showFullRange" = "Show Full Range";
+
+/* Accessibility action on the chart range navigator */
+"usage.chartNavigator.zoomIn" = "Zoom In";
+
+/* Accessibility action on the chart range navigator */
+"usage.chartNavigator.zoomOut" = "Zoom Out";
 
 /* Chip that puts every harness into the Usage Stats query; 'harness' is the usage-axis unit and stays as spelled. */
 "usage.filters.allHarnesses" = "All harnesses";
@@ -2366,14 +2792,47 @@
 /* Empty state when the local per-request ledger could not be opened */
 "usage.ledgerUnavailable.title" = "Usage ledger unavailable";
 
+/* Usage Mix dimension: which local CLI or app produced the tokens; the harness names themselves are not translated */
+"usage.mix.dimension.harnesses" = "Harnesses";
+
+/* Usage Mix dimension: which model the tokens were spent on */
+"usage.mix.dimension.models" = "Models";
+
+/* Usage Mix dimension: which working directory the tokens came from */
+"usage.mix.dimension.projects" = "Projects";
+
+/* Usage Mix dimension: fresh input against cache and output */
+"usage.mix.dimension.tokenFlow" = "Token Flow";
+
 /* Unit under the total in the middle of a donut card. */
 "usage.mix.donutUnit" = "tokens";
+
+/* Usage Mix empty state when the range holds no local usage */
+"usage.mix.empty" = "No local usage in this range.";
+
+/* Token Flow slice: cached tokens */
+"usage.mix.flow.cache" = "Cache";
+
+/* Detail under the cache slice, naming the two cache token kinds it sums */
+"usage.mix.flow.cacheDetail" = "read + creation";
+
+/* Token Flow slice: input tokens that were not served from cache */
+"usage.mix.flow.freshInput" = "Fresh input";
+
+/* Token Flow slice: tokens the model produced */
+"usage.mix.flow.output" = "Output";
 
 /* Caption under the Harness Mix donut title. */
 "usage.mix.harness.subtitle" = "where requests ran";
 
 /* Donut card on the Usage Stats distribution wall: tokens by harness. Title-case variant of the all-caps section label usage.harnessMix.title. */
 "usage.mix.harness.title" = "Harness Mix";
+
+/* Scope caption beside the Usage Mix title */
+"usage.mix.lastThirtyDays" = "Last 30 days";
+
+/* Usage Mix empty state when the per-request ledger could not be opened */
+"usage.mix.ledgerUnreadable" = "Usage ledger could not be read.";
 
 /* Empty state inside the Model Mix donut card. */
 "usage.mix.model.empty" = "No model traffic in this range";
@@ -2383,6 +2842,9 @@
 
 /* Donut card on the Usage Stats distribution wall: tokens by model. */
 "usage.mix.model.title" = "Model Mix";
+
+/* Detail on the Usage Mix slice that stands in for everything below the cut */
+"usage.mix.moreSlices" = "%1$lld more";
 
 /* Donut slice that collapses everything below the top five. */
 "usage.mix.other" = "Other";
@@ -2396,6 +2858,9 @@
 /* Donut card on the Usage Stats distribution wall: tokens by project directory. */
 "usage.mix.project.title" = "Project Mix";
 
+/* Usage Mix empty state on the Projects dimension before a cost refresh has attributed anything */
+"usage.mix.projectsPending" = "Project attribution appears after the next Codex or Claude cost refresh.";
+
 /* Empty state inside the Provider Mix donut card. */
 "usage.mix.provider.empty" = "No provider traffic in this range";
 
@@ -2405,6 +2870,9 @@
 /* Donut card on the Usage Stats distribution wall: tokens by L1 company. */
 "usage.mix.provider.title" = "Provider Mix";
 
+/* Title of the Overview card that splits recent tokens by project, harness, model or token kind */
+"usage.mix.title" = "Usage Mix";
+
 /* Empty state inside the Token Flow donut card. */
 "usage.mix.tokenFlow.empty" = "No token traffic in this range";
 
@@ -2413,6 +2881,9 @@
 
 /* Donut card on the Usage Stats distribution wall: tokens by kind. */
 "usage.mix.tokenFlow.title" = "Token Flow";
+
+/* Caption under the total in the middle of the Usage Mix donut */
+"usage.mix.tokensCaption" = "tokens";
 
 /* Empty state body explaining the All chip */
 "usage.noHarnessSelected.detail" = "The All harnesses chip is a switch: click it again to put every harness back in the query.";
@@ -2603,8 +3074,26 @@
 /* Heatmap title on the Google AI page */
 "usage.whenYouUse.googleAI" = "When you use Google AI";
 
+/* Title of the weekday-by-hour activity card for one provider */
+"usage.whenYouUse.provider" = "When you use %1$@";
+
 /* Heatmap title on the SpaceXAI page */
 "usage.whenYouUse.spaceXAI" = "When you use SpaceXAI";
+
+/* Low end of the past-year grid's intensity legend */
+"usage.yearHeatmap.less" = "Less";
+
+/* High end of the past-year grid's intensity legend */
+"usage.yearHeatmap.more" = "More";
+
+/* Title of the past-year contribution grid; provider is a name and is not translated */
+"usage.yearHeatmap.title" = "%1$@ — Past Year";
+
+/* Tooltip on one day of the past-year grid */
+"usage.yearHeatmap.tooltip" = "%1$@ · %2$@";
+
+/* Caption beside the past-year grid's title; amount is already formatted currency */
+"usage.yearHeatmap.total" = "%1$@ total";
 
 /* Tooltip on the Workbench header button that switches the window to dark */
 "workbench.appearance.useDark" = "Use dark appearance";

--- a/Sources/VibeBarCore/Resources/en.lproj/Localizable.stringsdict
+++ b/Sources/VibeBarCore/Resources/en.lproj/Localizable.stringsdict
@@ -115,6 +115,22 @@
 			<string>%1$lld providers</string>
 		</dict>
 	</dict>
+	<key>quota.misc.independentCopies</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>1 independent copy</string>
+			<key>other</key>
+			<string>%1$lld independent copies</string>
+		</dict>
+	</dict>
 	<key>quota.perModelLimits</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/Sources/VibeBarCore/Resources/en.lproj/Localizable.stringsdict
+++ b/Sources/VibeBarCore/Resources/en.lproj/Localizable.stringsdict
@@ -51,6 +51,70 @@
 			<string>%1$lld minutes</string>
 		</dict>
 	</dict>
+	<key>quota.forecast.metric.comparableCycles</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>1 comparable reset cycle</string>
+			<key>other</key>
+			<string>%1$lld comparable reset cycles</string>
+		</dict>
+	</dict>
+	<key>quota.forecast.metric.recentIntervals</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>1 recent interval</string>
+			<key>other</key>
+			<string>%1$lld recent intervals</string>
+		</dict>
+	</dict>
+	<key>quota.history.curveCount</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>1 curve</string>
+			<key>other</key>
+			<string>%1$lld curves</string>
+		</dict>
+	</dict>
+	<key>quota.history.providerCount</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>1 provider</string>
+			<key>other</key>
+			<string>%1$lld providers</string>
+		</dict>
+	</dict>
 	<key>quota.perModelLimits</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -81,6 +145,22 @@
 			<string>1 manual reset available</string>
 			<key>other</key>
 			<string>%1$lld manual resets available</string>
+		</dict>
+	</dict>
+	<key>quota.resetHistory.earlyRefillCount</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>1 cycle refilled before the window was up</string>
+			<key>other</key>
+			<string>%1$lld cycles refilled before the window was up</string>
 		</dict>
 	</dict>
 	<key>quota.resetHistory.lane.wasteSummary</key>
@@ -353,6 +433,22 @@
 			<string>1 provider</string>
 			<key>other</key>
 			<string>%1$lld providers</string>
+		</dict>
+	</dict>
+	<key>usage.yearHeatmap.a11y</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$@ daily spend over the past year, %2$#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>1 week</string>
+			<key>other</key>
+			<string>%2$lld weeks</string>
 		</dict>
 	</dict>
 	<key>workbench.sessions.count.sessions</key>

--- a/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.strings
@@ -815,6 +815,21 @@
 /* Placeholder inside an empty reset-history strip, before any quota reading has landed */
 "quota.awaitingFirstObservation" = "等待首次额度观测";
 
+/* Empty state of the CodexBar bridge card when every bridged provider is one Vibe Bar already reads natively */
+"quota.bridge.empty" = "没有仅存在于 CodexBar 的厂商返回额度窗口。重叠的厂商仍显示在 Vibe Bar 自己的卡片上。";
+
+/* Tooltip on the CodexBar bridge card's refresh button */
+"quota.bridge.refresh" = "刷新 CodexBar 厂商";
+
+/* Subtitle of the CodexBar bridge card before its version is known */
+"quota.bridge.subtitle" = "额外厂商 · 只读";
+
+/* Subtitle of the CodexBar bridge card once the installed version is known */
+"quota.bridge.subtitleVersion" = "CodexBar %1$@ · 只读";
+
+/* Title of the card listing quota read from a CodexBar install; CodexBar is a product name */
+"quota.bridge.title" = "CodexBar 桥接";
+
 /* Caption under a quota bar when the provider reported no reset time */
 "quota.bucket.noResetInfo" = "无重置信息";
 
@@ -1234,6 +1249,39 @@
 
 /* Narrow form of the mini window surplus forecast line */
 "quota.mini.forecastSurplusCompact" = "盈余 %1$lld%%";
+
+/* Tooltip on the mini focus layout's button that pages to the next provider */
+"quota.mini.nextProvider" = "下一个厂商";
+
+/* Mini window placeholder when none of the selected fields has a live reading yet */
+"quota.mini.noLiveData" = "所选字段暂无实时数据";
+
+/* Mini focus layout's page counter when there are too many providers for dots */
+"quota.mini.pageIndicator" = "%1$lld/%2$lld";
+
+/* Empty state of the mini window's refill rail; only the user's selected fields are considered */
+"quota.mini.railEmpty" = "所选项目在未来 7 天内没有补额。";
+
+/* Heading of the mini window's refill rail, naming how far ahead it looks */
+"quota.mini.railTitle" = "额度重置 · 未来 %1$lld 天";
+
+/* Mini window caption for when a bucket refills; countdown is a compact span */
+"quota.mini.resets" = "%1$@重置";
+
+/* Tooltip on a mini window row; subProvider and row are names, percent the current reading */
+"quota.mini.rowHelp" = "%1$@ — %2$@：%3$lld%%";
+
+/* Body of a misc provider card that has no credential yet */
+"quota.misc.notConfigured" = "尚未配置。";
+
+/* Tooltip on the refresh button of a misc provider that has several configured copies */
+"quota.misc.refreshCopies" = "刷新 %1$@ 的全部副本";
+
+/* Tooltip on the refresh button of a misc provider's card */
+"quota.misc.refreshProvider" = "刷新 %1$@";
+
+/* Button on an unconfigured misc provider card that opens its settings */
+"quota.misc.setUpInSettings" = "在设置中配置";
 
 /* Caption saying the bar shows what is left */
 "quota.mode.remaining" = "剩余";

--- a/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.strings
@@ -764,6 +764,15 @@
 /* Empty-state title while a sync is in flight */
 "popover.machines.checking" = "正在检查 Relay…";
 
+/* Badge on a remote machine whose last report is later than expected */
+"popover.machines.freshness.delayed" = "延迟";
+
+/* Badge on a remote machine reporting on schedule */
+"popover.machines.freshness.live" = "实时";
+
+/* Badge on a remote machine that has not reported for a long time */
+"popover.machines.freshness.stale" = "已过期";
+
 /* Toggle on a remote machine card */
 "popover.machines.includeInTotals" = "计入总计";
 

--- a/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.strings
@@ -101,6 +101,9 @@
 /* Field label for a user-chosen name */
 "common.name" = "名称";
 
+/* A chart tooltip row for a moment nothing was recorded — the app was not watching, rather than the value being zero */
+"common.noData" = "无记录数据";
+
 /* A toggle's state, read as a value in a summary row */
 "common.off" = "已关闭";
 
@@ -149,6 +152,15 @@
 /* Scope name for the combined cost card */
 "cost.allProviders" = "全部厂商";
 
+/* Tooltip on the cost chart's dollar option */
+"cost.chart.metricCostHelp" = "按美元绘制花费";
+
+/* Segmented-control label that plots token volume instead of spend; the dollar option is the '$' sign and needs no key */
+"cost.chart.metricTokens" = "Tok";
+
+/* Tooltip on the cost chart's token option */
+"cost.chart.metricTokensHelp" = "按 token 数量绘制";
+
 /* Empty cost history */
 "cost.empty.antigravity" = "暂未发现 Antigravity 会话的 token 元数据。";
 
@@ -182,8 +194,80 @@
 /* Card title; the company name is never translated */
 "cost.googleAI.title" = "Google AI 花费";
 
+/* Cost chart bucket width that follows the visible span instead of being pinned */
+"cost.granularity.auto" = "自动";
+
+/* Cost chart bucket width: one bar per day */
+"cost.granularity.day" = "天";
+
+/* Cost chart bucket width: one bar per hour */
+"cost.granularity.hour" = "小时";
+
+/* Cost chart bucket width: one bar per calendar month */
+"cost.granularity.month" = "月";
+
+/* Cost chart bucket width: one bar per week */
+"cost.granularity.week" = "周";
+
 /* Card title on the Overview */
 "cost.history.allProviders" = "全部厂商花费历史";
+
+/* Empty state of the cost history chart before the first samples exist */
+"cost.history.building" = "正在积累历史…";
+
+/* Second line of the cost history chart's empty state */
+"cost.history.buildingDetail" = "下一次本机扫描后会出现花费样本。";
+
+/* Tooltip on the button that closes the model breakdown panel */
+"cost.history.clearModelSelection" = "清除模型选择";
+
+/* Overlay on the cost chart when the visible range holds no spend */
+"cost.history.emptyCost" = "所选范围内没有花费记录。";
+
+/* Overlay on the cost chart when the visible range holds no tokens */
+"cost.history.emptyTokens" = "所选范围内没有 token 记录。";
+
+/* Caption naming the visible span of the cost chart and the dates at its ends */
+"cost.history.extentNote" = "%1$@ · %2$@ – %3$@";
+
+/* Tooltip on a bucket-width button the current zoom level cannot draw */
+"cost.history.granularityDisabled" = "%1$@需要不同的缩放级别";
+
+/* Tooltip on a bucket-width button in the cost chart */
+"cost.history.groupBy" = "按%1$@聚合花费历史";
+
+/* Note under the cost chart when hourly buckets were asked for but only daily ones exist that far back */
+"cost.history.hourlyFallback" = "无按小时数据 · 改按天显示";
+
+/* Summary figure under the cost chart: the per-bucket average; granularity is the bucket width */
+"cost.history.metricAverage" = "平均/%1$@";
+
+/* Summary figure under the cost chart: the largest single bucket */
+"cost.history.metricPeak" = "峰值";
+
+/* Summary figure under the cost chart: the visible range's total */
+"cost.history.metricTotal" = "合计";
+
+/* Shown in the model breakdown panel for a bucket old enough that per-model rows were not kept */
+"cost.history.modelDetailUnavailable" = "该历史区间没有保留按模型的明细。";
+
+/* Heading of the model breakdown panel; when is the bucket the user clicked */
+"cost.history.modelsAt" = "模型 · %1$@";
+
+/* Last row of a cost-chart tooltip, standing in for the models it could not fit */
+"cost.history.moreModels" = "另有 %1$lld 项 · 点击查看";
+
+/* Accessibility label for the range navigator under the cost history chart */
+"cost.history.navigator" = "花费历史范围导航";
+
+/* Title of the navigable cost history chart */
+"cost.history.title" = "花费历史";
+
+/* Cost chart tooltip heading for a weekly bucket; date is the week's first day */
+"cost.history.weekOf" = "%1$@ 当周";
+
+/* Compact form of the weekly bucket label, used under the peak figure */
+"cost.history.weekShortOf" = "%1$@ 当周";
 
 /* All-caps metric label: the most expensive day on record */
 "cost.metric.peakDay" = "单日最高";
@@ -656,11 +740,26 @@
 /* Subtitle under the Machines page header */
 "popover.header.machinesSubtitle" = "端到端加密的远程用量";
 
+/* Tooltip on the popover header button that opens the floating mini window */
+"popover.header.mini" = "迷你窗口";
+
 /* Subtitle under the Misc Providers page header */
 "popover.header.miscSubtitle" = "仅用量 · 登录或粘贴密钥";
 
+/* Tooltip on the popover header button that opens the Workbench window */
+"popover.header.openWorkbench" = "打开 Workbench";
+
 /* Subtitle under the Overview page header */
 "popover.header.overviewSubtitle" = "全部厂商 · 额度与花费";
+
+/* Popover header caption while a refresh is in flight */
+"popover.header.refreshing" = "正在刷新…";
+
+/* Tooltip on the popover header's gear button */
+"popover.header.settings" = "设置";
+
+/* Popover header caption: the page's own subtitle followed by how long ago the data was updated */
+"popover.header.updatedLine" = "%1$@ · %2$@";
 
 /* Empty-state title while a sync is in flight */
 "popover.machines.checking" = "正在检查 Relay…";
@@ -713,11 +812,17 @@
 /* Popover tab. The other tabs are company names (OpenAI, Anthropic, Google AI, SpaceXAI) and are never translated. */
 "popover.tab.overview" = "总览";
 
+/* Placeholder inside an empty reset-history strip, before any quota reading has landed */
+"quota.awaitingFirstObservation" = "等待首次额度观测";
+
 /* Caption under a quota bar when the provider reported no reset time */
 "quota.bucket.noResetInfo" = "无重置信息";
 
 /* Caption under a quota bar; when is a countdown, sometimes with an absolute time */
 "quota.bucket.resetsIn" = "距重置 %1$@";
+
+/* Caption under an empty reset-history strip explaining when a cycle is recorded */
+"quota.cycleRecordedOnRefill" = "额度补满时记录一个周期";
 
 /* Empty state body; command is a CLI name such as codex or claude and is never translated */
 "quota.empty.needsLogin.detail" = "在终端中运行 `%1$@ login`，然后刷新。";
@@ -758,6 +863,18 @@
 /* Forecast confidence level */
 "quota.forecast.confidence.medium" = "中等置信度";
 
+/* Footnote under the forecast metric grid explaining what token history is and is not used for */
+"quota.forecast.explain.footer" = "消耗量来自额度观测值。Token 历史只用于推断惯常工作时段的权重，不会换算成额度用量。";
+
+/* Accessibility label on the disclosure button while the grid is open */
+"quota.forecast.explain.hide" = "隐藏预测计算过程";
+
+/* Accessibility label on the disclosure button while the grid is closed */
+"quota.forecast.explain.show" = "显示预测计算过程";
+
+/* Disclosure button that opens the forecast's metric grid */
+"quota.forecast.explain.title" = "该预测的计算方式";
+
 /* What to do about an at-risk forecast */
 "quota.forecast.guidance.atRisk" = "降低使用速度，或将任务转移至其他额度";
 
@@ -781,6 +898,120 @@
 
 /* Remaining-mode guidance when nothing needs saying */
 "quota.forecast.guidance.withinTarget" = "仍在 %1$lld%% 的安全余量之内";
+
+/* One reference marker in the quota bar legend: its name followed by the figure it marks */
+"quota.forecast.legend.item" = "%1$@ %2$@";
+
+/* Detail under the safety target metric when the forecast leaves capacity above it */
+"quota.forecast.metric.aboveTarget" = "高于目标 %1$lld%% 的额度";
+
+/* Detail under the activity timing metric before any habits exist */
+"quota.forecast.metric.activityFallback" = "形成习惯数据前按自然时间兜底";
+
+/* Forecast metric: how far through the window the user's own working rhythm says we are */
+"quota.forecast.metric.activityTiming" = "活跃时段";
+
+/* Detail under the activity timing metric when weekday and hour habits are known */
+"quota.forecast.metric.activityWeighted" = "按星期与小时加权";
+
+/* Detail under the behavior fallback metric */
+"quota.forecast.metric.behaviorDetail" = "在更强证据不足时使用";
+
+/* Forecast metric: the projection used when stronger inputs are missing */
+"quota.forecast.metric.behaviorFallback" = "行为兜底";
+
+/* Forecast metric: how completely each input covers the window */
+"quota.forecast.metric.coverage" = "覆盖度";
+
+/* Detail under the coverage metric: freshness of the data and how well habits are known */
+"quota.forecast.metric.coverageDetail" = "新鲜度 %1$lld%% · 习惯 %2$lld%%";
+
+/* Value of the coverage metric: observation and reset-history coverage */
+"quota.forecast.metric.coverageValue" = "观测 %1$lld%% · 历史 %2$lld%%";
+
+/* Detail under the reset-history metric before any cycle has completed */
+"quota.forecast.metric.cyclesPending" = "完整周期会显示在这里";
+
+/* Value of the activity timing metric: share of the window already behind us */
+"quota.forecast.metric.elapsed" = "已过 %1$lld%%";
+
+/* Forecast metric: how much data the projection stands on */
+"quota.forecast.metric.evidence" = "依据";
+
+/* Detail under the evidence metric; confidence is the forecast's own confidence label */
+"quota.forecast.metric.evidenceDetail" = "%1$@ · 评分 %2$lld%%";
+
+/* Value of the evidence metric: observations in this cycle and completed cycles behind it */
+"quota.forecast.metric.evidenceValue" = "%1$lld 次观测 · %2$lld 个周期";
+
+/* Detail under the forecast metric while the card shows used percentages */
+"quota.forecast.metric.expectedLeft" = "预计剩余 %1$lld%%";
+
+/* Detail under the forecast metric while the card shows remaining percentages */
+"quota.forecast.metric.expectedUsed" = "预计已用 %1$lld%%";
+
+/* Forecast metric and bar legend entry: the projected figure at the next reset */
+"quota.forecast.metric.forecastAtReset" = "重置时预测";
+
+/* Forecast metric: the spread the projection considers plausible */
+"quota.forecast.metric.forecastRange" = "预测区间";
+
+/* Detail under the safety target metric when the forecast sits inside it */
+"quota.forecast.metric.insideTarget" = "在目标区间内";
+
+/* Value of the reset-history metric before any cycle can be compared */
+"quota.forecast.metric.noComparison" = "尚无可比数据";
+
+/* Forecast metric: where the personal plan says usage should be right now */
+"quota.forecast.metric.plan" = "当前个人计划";
+
+/* Detail under the personal plan metric: what the plan is built from */
+"quota.forecast.metric.planDetail" = "活跃时段 + %1$lld%% 安全余量目标";
+
+/* Value of the forecast range metric in Remaining mode */
+"quota.forecast.metric.rangeLeft" = "剩余 %1$lld–%2$lld%%";
+
+/* Value of the forecast range metric in Used mode */
+"quota.forecast.metric.rangeUsed" = "已用 %1$lld–%2$lld%%";
+
+/* Forecast metric: the projection from the most recent intervals alone */
+"quota.forecast.metric.recentBurn" = "近期消耗";
+
+/* Detail under the recent burn metric when there is not enough recent data */
+"quota.forecast.metric.recentMissing" = "至少需要两次有效观测";
+
+/* Forecast metric: whether recent activity is above or below the earlier baseline */
+"quota.forecast.metric.recentTrend" = "近期趋势";
+
+/* Forecast metric: the share of the quota the user wants to still hold at reset */
+"quota.forecast.metric.safetyTarget" = "安全余量目标";
+
+/* Forecast metric: the projection that only knows how much of the window has elapsed */
+"quota.forecast.metric.timePace" = "纯时间进度";
+
+/* Detail under the time-only pace metric; stage is the pace summary such as '5% in deficit' */
+"quota.forecast.metric.timePaceDetail" = "按自然时间：%1$@";
+
+/* Detail under the time-only pace metric when the bucket reports no window */
+"quota.forecast.metric.timePaceMissing" = "需要重置时间与窗口长度";
+
+/* Detail under the recent trend metric: the two spans being compared */
+"quota.forecast.metric.trendDetail" = "最近 7 天对比之前 21 天";
+
+/* Detail under the recent trend metric when the earlier span has no activity */
+"quota.forecast.metric.trendDetailMissing" = "需要更早的每日活跃数据";
+
+/* Value of the recent trend metric before a baseline exists */
+"quota.forecast.metric.trendMissing" = "尚无基线";
+
+/* Value of the recent trend metric; multiplier is a decimal already formatted at the call site */
+"quota.forecast.metric.trendMultiplier" = "活跃度 %1$@×";
+
+/* Value of a forecast metric whose inputs the bucket does not report */
+"quota.forecast.metric.unavailable" = "不可用";
+
+/* Detail under the forecast range metric */
+"quota.forecast.metric.uncertaintyInterval" = "不确定区间";
 
 /* One-line forecast summary */
 "quota.forecast.reset.atRisk" = "很可能在重置前耗尽";
@@ -826,6 +1057,12 @@
 
 /* Use-up line when no ETA can be derived */
 "quota.forecast.useUp.uncertain" = "耗尽时间不确定 · 可能在重置前不足";
+
+/* A quota figure qualified as the projection for the next reset; value is one of the used/left figures */
+"quota.forecast.value.atReset" = "重置时%1$@";
+
+/* A quota figure qualified as where usage should stand at this moment */
+"quota.forecast.value.expectedNow" = "当前预期%1$@";
 
 /* The forecast figure in Remaining mode, used inside the status line */
 "quota.forecast.value.left" = "剩余 %1$lld%%";
@@ -911,6 +1148,57 @@
 /* Quota group: a weekly credit balance rather than a percentage */
 "quota.group.weeklyCredits" = "每周额度";
 
+/* Empty state of the all-providers quota history chart when every curve has been switched off */
+"quota.history.allCurvesHidden" = "所有曲线均已隐藏 — 请从上方菜单中选择。";
+
+/* Empty state of the quota history chart before enough refreshes have landed */
+"quota.history.buildingUp" = "额度历史会随刷新逐步积累。";
+
+/* Accessibility label for the quota history curve picker */
+"quota.history.curvePickerA11y" = "选择要显示的额度曲线";
+
+/* Curve picker summary when nothing is hidden */
+"quota.history.curvesAll" = "全部 %1$lld";
+
+/* Curve picker summary when some curves are hidden */
+"quota.history.curvesSome" = "%2$lld 中的 %1$lld";
+
+/* Legend entry marking the dotted projection line on the quota history chart */
+"quota.history.forecastLegend" = "预测";
+
+/* Scope note when a group holds more quotas than the note can name; names are the ones it did name */
+"quota.history.moreBuckets" = "%1$@ +%2$lld";
+
+/* Last row of a crowded chart tooltip, standing in for the readings it could not fit */
+"quota.history.moreReadings" = "另有 %1$lld 项";
+
+/* Accessibility label for the range navigator under the all-providers quota chart */
+"quota.history.navigatorAllProviders" = "全部厂商额度历史范围导航";
+
+/* Accessibility label for the range navigator under a single provider's quota chart */
+"quota.history.navigatorProvider" = "额度历史范围导航";
+
+/* Footer under a quota history chart; scope names what the chart covers, visible and total are compact spans such as 7d */
+"quota.history.scopeNote" = "%1$@ · 已记录 %3$@，显示 %2$@";
+
+/* Menu item that puts every quota curve back on the chart */
+"quota.history.showAllCurves" = "显示全部曲线";
+
+/* Menu item that leaves only the most-used quota curves on the chart */
+"quota.history.showBusiest" = "仅显示最活跃的";
+
+/* Title of the quota history chart card */
+"quota.history.title" = "额度历史";
+
+/* Tooltip row on the quota history chart: the projection for the next reset */
+"quota.history.tooltipAtReset" = "重置时";
+
+/* Tooltip row on the quota history chart: where the wall clock said usage should be */
+"quota.history.tooltipPace" = "进度";
+
+/* Tooltip row on the quota history chart: the recorded remaining quota */
+"quota.history.tooltipQuotaLeft" = "剩余额度";
+
 /* What to do when no credential is stored */
 "quota.login.claude" = "运行 claude login，然后刷新。";
 
@@ -926,17 +1214,56 @@
 /* Fallback for a misc provider; provider is a SubProvider name */
 "quota.login.misc" = "在「设置 → 其他厂商」中配置 %1$@。";
 
+/* Mini window forecast line while the forecast is still learning the usage pattern */
+"quota.mini.forecastLearning" = "学习中 · 剩余 %1$lld%%";
+
+/* Narrow form of the mini window learning forecast line */
+"quota.mini.forecastLearningCompact" = "约剩余 %1$lld%%";
+
+/* Mini window forecast line for a quota that is comfortably ahead */
+"quota.mini.forecastLeft" = "剩余 %1$lld%%";
+
+/* Narrow form of the mini window forecast line for a quota that is comfortably ahead */
+"quota.mini.forecastLeftCompact" = "剩余 %1$lld%%";
+
+/* Mini window forecast line for a quota that may, rather than will, be exhausted before reset */
+"quota.mini.forecastMayRunOut" = "可能 %1$@耗尽";
+
+/* Mini window forecast line for a quota expected to finish its window well under target */
+"quota.mini.forecastSurplus" = "盈余 · 剩余 %1$lld%%";
+
+/* Narrow form of the mini window surplus forecast line */
+"quota.mini.forecastSurplusCompact" = "盈余 %1$lld%%";
+
 /* Caption saying the bar shows what is left */
 "quota.mode.remaining" = "剩余";
 
 /* Caption saying the bar shows what has been spent */
 "quota.mode.used" = "已用";
 
+/* Pace summary when usage is running ahead of the linear expectation */
+"quota.pace.deficit" = "超支 %1$lld%%";
+
+/* Compact form of the pace summary for the mini window when usage runs ahead of the linear expectation */
+"quota.pace.deficitShort" = "超支 %1$lld%%";
+
 /* Legacy elapsed-time pace ETA on a Misc provider card */
 "quota.pace.lastsUntilReset" = "可用到重置";
 
+/* Pace summary when usage matches the linear expectation */
+"quota.pace.onTrack" = "进度正常";
+
+/* Pace summary when usage is running behind the linear expectation */
+"quota.pace.reserve" = "结余 %1$lld%%";
+
+/* Compact form of the pace summary for the mini window when usage runs behind the linear expectation */
+"quota.pace.reserveShort" = "结余 %1$lld%%";
+
 /* Legacy elapsed-time pace ETA on a Misc provider card */
 "quota.pace.runsOutIn" = "%1$@后耗尽";
+
+/* Compact projection in the mini window: when the quota is estimated to be exhausted */
+"quota.pace.runsOutShort" = "%1$@耗尽";
 
 /* Live countdown to a bucket's refill; duration is a compact span, sometimes followed by an absolute time */
 "quota.reset.in" = "距重置 %1$@";
@@ -980,11 +1307,32 @@
 /* Tooltip on the Time axis option */
 "quota.resetHistory.axis.timeHelp" = "按实际发生时间排布在同一条日历上";
 
+/* Axis label for the cycle that has not reset yet */
+"quota.resetHistory.axisCurrent" = "当前";
+
 /* Caption on a completed column: how many cycles back it is. The leading character is a minus sign, not a hyphen. */
 "quota.resetHistory.axisCyclesBack" = "−%1$lld";
 
 /* Caption on the live column of the reset-history grid */
 "quota.resetHistory.axisNow" = "现在";
+
+/* Caption beside the reset-history strip's title */
+"quota.resetHistory.barIsOneCycle" = "每根柱条代表一个额度周期";
+
+/* Empty state of the reset history comparison before any weekly or longer quota is known */
+"quota.resetHistory.compareEmpty" = "暂无可对比的数据 — 厂商上报按周或更长周期的额度后会显示在此。";
+
+/* Title of the card that puts every weekly-and-longer quota's reset history side by side */
+"quota.resetHistory.compareTitle" = "重置历史对比";
+
+/* Tooltip on a window button in the reset history comparison; window is the spoken span such as 'last 8 weeks' */
+"quota.resetHistory.compareWindow" = "对比%1$@";
+
+/* Caption for the cycle still running in the reset-history strip */
+"quota.resetHistory.currentCycleCaption" = "当前周期 · 已用 %1$lld%% · 剩余 %2$lld%%";
+
+/* Caption for one completed cycle in the reset-history strip; time is the reset moment */
+"quota.resetHistory.cycleCaption" = "%1$@ 重置 · 已用 %2$lld%% · 剩余 %3$lld%%";
 
 /* Empty-state copy for a lane */
 "quota.resetHistory.lane.emptyState" = "尚无完整周期 — 额度补满时才会记录一个周期";
@@ -998,6 +1346,21 @@
 /* One lane inside the screen-reader summary */
 "quota.resetHistory.lane.spokenWaste" = "%1$@：%3$lld 个周期平均浪费 %2$@%%";
 
+/* Note appended to a cycle caption when the last reading predates the reset by a while */
+"quota.resetHistory.lastSeenBefore" = "重置前 %1$@最后一次观测";
+
+/* Legend entry explaining what a bar's height means in the reset history comparison */
+"quota.resetHistory.legend.barHeight" = "柱高 = 重置时剩余";
+
+/* Legend entry for the time axis: bars sit where they happened on a calendar */
+"quota.resetHistory.legend.byDate" = "按日期排布";
+
+/* Legend entry for the cycle axis: columns are cycles, not dates */
+"quota.resetHistory.legend.perCycle" = "每个周期一列";
+
+/* Legend entry for the dot marking a cycle that refilled before its window was up */
+"quota.resetHistory.legend.refilledEarly" = "提前补额";
+
 /* What the provider did to the clock on an early refill. This shape means a whole window lies ahead, so the extra capacity is usable. */
 "quota.resetHistory.reset.earlyClockRestarted" = "提前补额，下一周期重新计时";
 
@@ -1006,6 +1369,12 @@
 
 /* An early refill that matches neither shape */
 "quota.resetHistory.reset.earlyUnclear" = "提前补额，重置节奏已改变";
+
+/* Lane label for history kept from an account that is no longer signed in */
+"quota.resetHistory.retiredAccount" = "已登出的账号";
+
+/* Lane label for one of several signed-out accounts on the same provider */
+"quota.resetHistory.retiredAccountNumbered" = "已登出的账号 %1$lld";
 
 /* Spoken window name */
 "quota.resetHistory.spoken.allCycles" = "全部已记录周期";
@@ -1033,6 +1402,18 @@
 
 /* Card title on a provider detail page */
 "quota.resetHistory.title" = "重置历史";
+
+/* Tooltip figures for a finished cycle in the reset history comparison */
+"quota.resetHistory.tooltip.completed" = "重置时剩余 %1$lld%% · 已用 %2$lld%%";
+
+/* Tooltip figures for the cycle still running */
+"quota.resetHistory.tooltip.current" = "当前周期 · 当前剩余 %1$lld%% · 已用 %2$lld%%";
+
+/* Tooltip line naming the span a finished cycle covered */
+"quota.resetHistory.tooltip.range" = "%1$@ → %2$@ 重置";
+
+/* Tooltip line naming the span of the cycle still running and when it is due to reset */
+"quota.resetHistory.tooltip.rangeDue" = "%1$@ → %2$@ 预计重置";
 
 /* Header arithmetic when nothing has closed */
 "quota.resetHistory.totals.none" = "该区间内无完整周期";
@@ -1093,6 +1474,15 @@
 
 /* Inline error row; reason is a provider message and is not translated */
 "quota.update.failed" = "更新失败：%1$@";
+
+/* Window progress line for a window measured in whole days */
+"quota.window.dayOfDays" = "第 %1$lld/%2$lld 天 · %3$@";
+
+/* Window progress line for a sub-day window; window is its length, elapsed how much of it is gone */
+"quota.window.elapsedOfWindow" = "%2$@ 已过 %1$@ · %3$@";
+
+/* Window progress line once the reset time has passed but no refresh has landed; value is the used/left figure */
+"quota.window.resetsSoon" = "即将重置 · %1$@";
 
 /* Hint under the Antigravity source picker */
 "settings.antigravityCookieEnabled" = "Antigravity 的 cookie 导入已启用 — 请先在 antigravity.google 登录。";
@@ -2222,6 +2612,27 @@
 /* Card title on the Overview's service-status tile row */
 "status.overview.title" = "状态";
 
+/* Accessibility label for the 7 by 24 activity grid */
+"usage.activity.a11y" = "按星期与小时划分的 token 用量，7 天 × 24 小时";
+
+/* Tooltip on one cell of the activity grid */
+"usage.activity.cellTooltip" = "%1$@ %2$@ · %3$@";
+
+/* High end of the activity grid's intensity legend */
+"usage.activity.heavy" = "繁忙";
+
+/* Caption naming the busiest hour of the activity card when the peak hour and peak cell agree */
+"usage.activity.peak" = "高峰 %1$@ · %2$@";
+
+/* Caption naming the busiest hour overall and the busiest single cell when they differ */
+"usage.activity.peakCell" = "高峰 %1$@ · %2$@ %3$@";
+
+/* Low end of the activity grid's intensity legend */
+"usage.activity.quiet" = "清闲";
+
+/* A token count in the activity grid's tooltip; the number is already abbreviated at the call site */
+"usage.activity.tokensShort" = "%1$@ tok";
+
 /* Tab over the Usage Stats breakdown table: one row per model. */
 "usage.breakdown.models" = "模型";
 
@@ -2236,6 +2647,21 @@
 
 /* Tab over the Usage Stats breakdown table: one row per request. The all-caps hero metric of the same word is usage.hero.requests. */
 "usage.breakdown.requests" = "请求";
+
+/* Accessibility label for the brush strip under a pannable chart */
+"usage.chartNavigator.label" = "图表范围导航";
+
+/* Accessibility value of the chart range navigator; both ends are already formatted dates */
+"usage.chartNavigator.range" = "%1$@ 至 %2$@";
+
+/* Accessibility action that returns a chart to its whole domain */
+"usage.chartNavigator.showFullRange" = "显示完整范围";
+
+/* Accessibility action on the chart range navigator */
+"usage.chartNavigator.zoomIn" = "放大";
+
+/* Accessibility action on the chart range navigator */
+"usage.chartNavigator.zoomOut" = "缩小";
 
 /* Chip that puts every harness into the Usage Stats query; 'harness' is the usage-axis unit and stays as spelled. */
 "usage.filters.allHarnesses" = "全部 harness";
@@ -2366,14 +2792,47 @@
 /* Empty state when the local per-request ledger could not be opened */
 "usage.ledgerUnavailable.title" = "用量账本不可用";
 
+/* Usage Mix dimension: which local CLI or app produced the tokens; the harness names themselves are not translated */
+"usage.mix.dimension.harnesses" = "Harness";
+
+/* Usage Mix dimension: which model the tokens were spent on */
+"usage.mix.dimension.models" = "模型";
+
+/* Usage Mix dimension: which working directory the tokens came from */
+"usage.mix.dimension.projects" = "项目";
+
+/* Usage Mix dimension: fresh input against cache and output */
+"usage.mix.dimension.tokenFlow" = "Token 流向";
+
 /* Unit under the total in the middle of a donut card. */
 "usage.mix.donutUnit" = "token";
+
+/* Usage Mix empty state when the range holds no local usage */
+"usage.mix.empty" = "所选范围内没有本机用量。";
+
+/* Token Flow slice: cached tokens */
+"usage.mix.flow.cache" = "缓存";
+
+/* Detail under the cache slice, naming the two cache token kinds it sums */
+"usage.mix.flow.cacheDetail" = "读取 + 写入";
+
+/* Token Flow slice: input tokens that were not served from cache */
+"usage.mix.flow.freshInput" = "新增输入";
+
+/* Token Flow slice: tokens the model produced */
+"usage.mix.flow.output" = "输出";
 
 /* Caption under the Harness Mix donut title. */
 "usage.mix.harness.subtitle" = "请求的运行位置";
 
 /* Donut card on the Usage Stats distribution wall: tokens by harness. Title-case variant of the all-caps section label usage.harnessMix.title. */
 "usage.mix.harness.title" = "Harness 分布";
+
+/* Scope caption beside the Usage Mix title */
+"usage.mix.lastThirtyDays" = "最近 30 天";
+
+/* Usage Mix empty state when the per-request ledger could not be opened */
+"usage.mix.ledgerUnreadable" = "无法读取用量账本。";
 
 /* Empty state inside the Model Mix donut card. */
 "usage.mix.model.empty" = "所选范围内没有模型流量";
@@ -2383,6 +2842,9 @@
 
 /* Donut card on the Usage Stats distribution wall: tokens by model. */
 "usage.mix.model.title" = "模型分布";
+
+/* Detail on the Usage Mix slice that stands in for everything below the cut */
+"usage.mix.moreSlices" = "另有 %1$lld 项";
 
 /* Donut slice that collapses everything below the top five. */
 "usage.mix.other" = "其他";
@@ -2396,6 +2858,9 @@
 /* Donut card on the Usage Stats distribution wall: tokens by project directory. */
 "usage.mix.project.title" = "项目分布";
 
+/* Usage Mix empty state on the Projects dimension before a cost refresh has attributed anything */
+"usage.mix.projectsPending" = "项目归属会在下一次 Codex 或 Claude 花费刷新后出现。";
+
 /* Empty state inside the Provider Mix donut card. */
 "usage.mix.provider.empty" = "所选范围内没有厂商流量";
 
@@ -2405,6 +2870,9 @@
 /* Donut card on the Usage Stats distribution wall: tokens by L1 company. */
 "usage.mix.provider.title" = "厂商分布";
 
+/* Title of the Overview card that splits recent tokens by project, harness, model or token kind */
+"usage.mix.title" = "用量构成";
+
 /* Empty state inside the Token Flow donut card. */
 "usage.mix.tokenFlow.empty" = "所选范围内没有 token 流量";
 
@@ -2413,6 +2881,9 @@
 
 /* Donut card on the Usage Stats distribution wall: tokens by kind. */
 "usage.mix.tokenFlow.title" = "Token 流向";
+
+/* Caption under the total in the middle of the Usage Mix donut */
+"usage.mix.tokensCaption" = "token";
 
 /* Empty state body explaining the All chip */
 "usage.noHarnessSelected.detail" = "「全部 harness」是一个开关：再次点击即可将全部 harness 重新纳入查询。";
@@ -2603,8 +3074,26 @@
 /* Heatmap title on the Google AI page */
 "usage.whenYouUse.googleAI" = "Google AI 使用时段";
 
+/* Title of the weekday-by-hour activity card for one provider */
+"usage.whenYouUse.provider" = "%1$@ 使用时段";
+
 /* Heatmap title on the SpaceXAI page */
 "usage.whenYouUse.spaceXAI" = "SpaceXAI 使用时段";
+
+/* Low end of the past-year grid's intensity legend */
+"usage.yearHeatmap.less" = "较少";
+
+/* High end of the past-year grid's intensity legend */
+"usage.yearHeatmap.more" = "较多";
+
+/* Title of the past-year contribution grid; provider is a name and is not translated */
+"usage.yearHeatmap.title" = "%1$@ — 过去一年";
+
+/* Tooltip on one day of the past-year grid */
+"usage.yearHeatmap.tooltip" = "%1$@ · %2$@";
+
+/* Caption beside the past-year grid's title; amount is already formatted currency */
+"usage.yearHeatmap.total" = "合计 %1$@";
 
 /* Tooltip on the Workbench header button that switches the window to dark */
 "workbench.appearance.useDark" = "使用深色外观";

--- a/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.strings
@@ -2801,14 +2801,8 @@
 /* Usage Mix dimension: which working directory the tokens came from */
 "usage.mix.dimension.projects" = "项目";
 
-/* Usage Mix dimension: fresh input against cache and output */
-"usage.mix.dimension.tokenFlow" = "Token 流向";
-
 /* Unit under the total in the middle of a donut card. */
 "usage.mix.donutUnit" = "token";
-
-/* Usage Mix empty state when the range holds no local usage */
-"usage.mix.empty" = "所选范围内没有本机用量。";
 
 /* Token Flow slice: cached tokens */
 "usage.mix.flow.cache" = "缓存";
@@ -2843,9 +2837,6 @@
 /* Donut card on the Usage Stats distribution wall: tokens by model. */
 "usage.mix.model.title" = "模型分布";
 
-/* Detail on the Usage Mix slice that stands in for everything below the cut */
-"usage.mix.moreSlices" = "另有 %1$lld 项";
-
 /* Donut slice that collapses everything below the top five. */
 "usage.mix.other" = "其他";
 
@@ -2857,9 +2848,6 @@
 
 /* Donut card on the Usage Stats distribution wall: tokens by project directory. */
 "usage.mix.project.title" = "项目分布";
-
-/* Usage Mix empty state on the Projects dimension before a cost refresh has attributed anything */
-"usage.mix.projectsPending" = "项目归属会在下一次 Codex 或 Claude 花费刷新后出现。";
 
 /* Empty state inside the Provider Mix donut card. */
 "usage.mix.provider.empty" = "所选范围内没有厂商流量";
@@ -2881,9 +2869,6 @@
 
 /* Donut card on the Usage Stats distribution wall: tokens by kind. */
 "usage.mix.tokenFlow.title" = "Token 流向";
-
-/* Caption under the total in the middle of the Usage Mix donut */
-"usage.mix.tokensCaption" = "token";
 
 /* Empty state body explaining the All chip */
 "usage.noHarnessSelected.detail" = "「全部 harness」是一个开关：再次点击即可将全部 harness 重新纳入查询。";

--- a/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.stringsdict
+++ b/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.stringsdict
@@ -45,6 +45,62 @@
 			<string>%1$lld 分钟</string>
 		</dict>
 	</dict>
+	<key>quota.forecast.metric.comparableCycles</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$#@count@可比重置周期</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>other</key>
+			<string>%1$lld 个</string>
+		</dict>
+	</dict>
+	<key>quota.forecast.metric.recentIntervals</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$#@count@近期区间</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>other</key>
+			<string>%1$lld 段</string>
+		</dict>
+	</dict>
+	<key>quota.history.curveCount</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$#@count@曲线</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>other</key>
+			<string>%1$lld 条</string>
+		</dict>
+	</dict>
+	<key>quota.history.providerCount</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$#@count@厂商</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>other</key>
+			<string>%1$lld 家</string>
+		</dict>
+	</dict>
 	<key>quota.perModelLimits</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
@@ -71,6 +127,20 @@
 			<string>lld</string>
 			<key>other</key>
 			<string>%1$lld 张</string>
+		</dict>
+	</dict>
+	<key>quota.resetHistory.earlyRefillCount</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$#@count@在窗口结束前补额</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>other</key>
+			<string>%1$lld 个周期</string>
 		</dict>
 	</dict>
 	<key>quota.resetHistory.lane.wasteSummary</key>
@@ -309,6 +379,20 @@
 			<string>lld</string>
 			<key>other</key>
 			<string>%1$lld 家厂商</string>
+		</dict>
+	</dict>
+	<key>usage.yearHeatmap.a11y</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$@ 过去一年的每日花费，共 %2$#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>other</key>
+			<string>%2$lld 周</string>
 		</dict>
 	</dict>
 	<key>workbench.sessions.count.sessions</key>

--- a/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.stringsdict
+++ b/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.stringsdict
@@ -101,6 +101,20 @@
 			<string>%1$lld 家</string>
 		</dict>
 	</dict>
+	<key>quota.misc.independentCopies</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$#@count@独立配置</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>other</key>
+			<string>%1$lld 份</string>
+		</dict>
+	</dict>
 	<key>quota.perModelLimits</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/Sources/VibeBarCore/Services/SubscriptionWindowProgress.swift
+++ b/Sources/VibeBarCore/Services/SubscriptionWindowProgress.swift
@@ -20,47 +20,52 @@ public enum SubscriptionWindowProgress {
         now: Date = Date()
     ) -> String {
         let displayedPercent = displayMode == .used ? usedPercent : 100 - usedPercent
-        let pct = formatPercent(displayedPercent)
-        let unit = displayMode == .used ? "used" : "left"
+        let value = modeValue(displayedPercent, displayMode: displayMode)
         guard let resetAt, let rawWindowSeconds, rawWindowSeconds > 0 else {
-            return "\(pct) \(unit)"
+            return value
         }
 
         let windowSeconds = TimeInterval(rawWindowSeconds)
         let remaining = resetAt.timeIntervalSince(now)
         if remaining <= 0 {
-            return "Resets soon · \(pct) \(unit)"
+            return L10n.Quota.windowResetsSoon(value: value)
         }
         let elapsed = max(0, min(windowSeconds, windowSeconds - remaining))
 
         if rawWindowSeconds >= 86_400 {
             let totalDays = max(1, Int((windowSeconds / 86_400).rounded()))
             let dayNumber = clamp(Int(elapsed / 86_400) + 1, lower: 1, upper: totalDays)
-            return "Day \(dayNumber) of \(totalDays) · \(pct) \(unit)"
+            return L10n.Quota.windowDayOfDays(day: dayNumber, total: totalDays, value: value)
         }
 
         let totalLabel = rawWindowSeconds == 18_000
-            ? "5 Hours"
+            ? L10n.Quota.groupFiveHours
             : formatShortDuration(windowSeconds)
         let elapsedLabel = formatShortDuration(elapsed)
-        return "\(elapsedLabel) of \(totalLabel) · \(pct) \(unit)"
+        return L10n.Quota.windowElapsedOfWindow(
+            elapsed: elapsedLabel, window: totalLabel, value: value
+        )
     }
 
     private static func clamp(_ value: Int, lower: Int, upper: Int) -> Int {
         min(max(value, lower), upper)
     }
 
-    private static func formatPercent(_ value: Double) -> String {
-        let v = value.isFinite ? max(0, min(100, value)) : 0
-        return "\(Int(v.rounded()))%"
+    /// "42% used" / "42% left" — the same pair the forecast surfaces read.
+    private static func modeValue(_ value: Double, displayMode: DisplayMode) -> String {
+        let percent = Int((value.isFinite ? max(0, min(100, value)) : 0).rounded())
+        switch displayMode {
+        case .used: return L10n.Quota.forecastValueUsed(percent: percent)
+        case .remaining: return L10n.Quota.forecastValueLeft(percent: percent)
+        }
     }
 
     private static func formatShortDuration(_ seconds: TimeInterval) -> String {
         let total = max(0, Int(seconds.rounded()))
         let hours = total / 3_600
         let minutes = (total % 3_600) / 60
-        if hours == 0 { return "\(minutes)m" }
-        if minutes == 0 { return "\(hours)h" }
-        return "\(hours)h \(minutes)m"
+        if hours == 0 { return L10n.Common.durationMinutes(minutes: minutes) }
+        if minutes == 0 { return L10n.Common.durationHours(hours: hours) }
+        return L10n.Common.durationHoursMinutes(hours: hours, minutes: minutes)
     }
 }

--- a/Sources/VibeBarCore/Services/UsagePace.swift
+++ b/Sources/VibeBarCore/Services/UsagePace.swift
@@ -139,11 +139,27 @@ public extension UsagePace {
         let value = Int(abs(deltaPercent).rounded())
         switch stage {
         case .onTrack:
-            return "On pace"
+            return L10n.Quota.paceOnTrack
         case .slightlyAhead, .ahead, .farAhead:
-            return "\(value)% in deficit"
+            return L10n.Quota.paceDeficit(percent: value)
         case .slightlyBehind, .behind, .farBehind:
-            return "\(value)% in reserve"
+            return L10n.Quota.paceReserve(percent: value)
+        }
+    }
+
+    /// The same summary with the preposition dropped, for the mini window's
+    /// compact rows. A shorter *key*, not `replacingOccurrences` on the long
+    /// one: a language that does not spell "in reserve" with a separable word
+    /// would have kept the long form and silently overflowed the row.
+    var stageSummaryCompact: String {
+        let value = Int(abs(deltaPercent).rounded())
+        switch stage {
+        case .onTrack:
+            return L10n.Quota.paceOnTrack
+        case .slightlyAhead, .ahead, .farAhead:
+            return L10n.Quota.paceDeficitShort(percent: value)
+        case .slightlyBehind, .behind, .farBehind:
+            return L10n.Quota.paceReserveShort(percent: value)
         }
     }
 }

--- a/Tests/VibeBarCoreTests/LanguageStampTests.swift
+++ b/Tests/VibeBarCoreTests/LanguageStampTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+@testable import VibeBarCore
+
+/// `LanguageStamp` is the value every language-aware cache key and
+/// `.equatable()` guard in the app holds. Those guards live in the App
+/// target, which has no tests of its own, so this pins the one thing they
+/// all depend on: that the stamp actually differs across a language change
+/// and compares equal within one.
+final class LanguageStampTests: XCTestCase {
+    private func withLanguage<T>(_ language: AppLanguage, _ body: () -> T) -> T {
+        let restore = L10n.languageOverride
+        defer { L10n.languageOverride = restore }
+        L10n.languageOverride = language
+        return body()
+    }
+
+    func testStampDiffersAcrossLanguages() {
+        let english = withLanguage(.english) { LanguageStamp.current }
+        let chinese = withLanguage(.simplifiedChinese) { LanguageStamp.current }
+        XCTAssertNotEqual(
+            english, chinese,
+            "a cache keyed on this would survive a language change and keep serving the old one"
+        )
+    }
+
+    func testStampIsStableWithinALanguage() {
+        let (first, second) = withLanguage(.english) {
+            (LanguageStamp.current, LanguageStamp.current)
+        }
+        XCTAssertEqual(
+            first, second,
+            "an unstable stamp would invalidate every cache holding it on every render"
+        )
+    }
+
+    /// The stamp follows the app's own language setting, not the machine's.
+    /// That is the whole reason it exists rather than reading `Locale`.
+    func testStampFollowsTheAppLanguageNotTheSystem() {
+        XCTAssertEqual(
+            withLanguage(.simplifiedChinese) { LanguageStamp.current.code },
+            "zh-Hans"
+        )
+        XCTAssertEqual(withLanguage(.english) { LanguageStamp.current.code }, "en")
+    }
+}

--- a/Tests/VibeBarCoreTests/LocalizationCatalogTests.swift
+++ b/Tests/VibeBarCoreTests/LocalizationCatalogTests.swift
@@ -212,6 +212,38 @@ final class LocalizationCatalogTests: XCTestCase {
         }
     }
 
+    /// A composed label has to be resolved part by part. Whole-string lookup
+    /// leaves "All Models · Weekly" in English — both halves are in the table
+    /// and the joined string is not — and a word-by-word rule would split
+    /// "All Models" and translate neither half.
+    func testComposedLabelsAreResolvedPartByPart() {
+        let restore = L10n.languageOverride
+        defer { L10n.languageOverride = restore }
+        L10n.languageOverride = .simplifiedChinese
+
+        XCTAssertEqual(
+            QuotaGroupLabelLocalizer.displayComposed("All Models · Weekly"),
+            "全部模型 · 每周"
+        )
+        // The product name survives; only the window word moves.
+        XCTAssertEqual(
+            QuotaGroupLabelLocalizer.displayComposed("GPT-5.3 Codex Spark · 5 Hours"),
+            "GPT-5.3 Codex Spark · 5 小时"
+        )
+        XCTAssertEqual(
+            QuotaGroupLabelLocalizer.displayComposed("Claude · Weekly · Sonnet"),
+            "Claude · 每周 · Sonnet"
+        )
+        // A label with no separator is one part, so the two agree everywhere
+        // a simple label is drawn.
+        for label in ["Weekly", "All Models", "Sonnet", "gpt-5.5", ""] {
+            XCTAssertEqual(
+                QuotaGroupLabelLocalizer.displayComposed(label),
+                QuotaGroupLabelLocalizer.display(label)
+            )
+        }
+    }
+
     /// Every glossary term is a name the app is allowed to print verbatim.
     /// If one of them ever became a catalog *value*, the two would be
     /// saying different things about the same word.

--- a/Tests/VibeBarCoreTests/LocalizationLintTests.swift
+++ b/Tests/VibeBarCoreTests/LocalizationLintTests.swift
@@ -131,6 +131,26 @@ final class LocalizationLintTests: XCTestCase {
                 let right = AppLocale.dateFormatter(template: "MMMd")
             }
 
+            // A stored static holding a catalog value: frozen in whatever
+            // language the process launched in, which no other rule here sees.
+            static let frozenPills: [(String, TimeInterval)] = [
+                (L10n.Common.durationHours(hours: 6), 6 * 3_600),
+                (L10n.Common.durationDays(days: 7), 7 * 86_400)
+            ]
+            static var frozenVar: String = L10n.Common.refresh
+            static let frozenNames = [CostChartGranularity.hour.displayName]
+
+            // …and the shapes that must stay quiet: a computed static derives
+            // per access, and a stored static of non-catalog values is data.
+            static var derivedPills: [String] { [L10n.Common.refresh] }
+            static let widths: [CGFloat] = [32, 64]
+            // A closure defers the lookup to call time, which is how
+            // QuotaGroupLabelLocalizer's table stays correct while looking
+            // exactly like the bug.
+            static let deferred: [String: () -> String] = [
+                "weekly": { L10n.Quota.groupWeekly }
+            ]
+
             private func sectionLabel(_ text: String) -> some View { Text(text) }
         }
         """.write(to: fixture, atomically: true, encoding: .utf8)
@@ -161,6 +181,17 @@ final class LocalizationLintTests: XCTestCase {
         ] {
             XCTAssertTrue(found.contains(expected), "the lint missed \(expected): \(found)")
         }
+
+        // The frozen-static rule: three stored statics hold a catalog value,
+        // and the two beside them that do not must stay quiet. Counted rather
+        // than matched by text so the wording of the finding can change.
+        let frozen = text.split(separator: "\n").filter {
+            $0.contains("frozen at launch language")
+        }
+        XCTAssertEqual(
+            frozen.count, 3,
+            "expected exactly the three stored statics holding a catalog value: \(text)"
+        )
         // The formatting rule reports a reason rather than a literal, so
         // these are matched as substrings of the whole report.
         for expected in [

--- a/Tests/VibeBarCoreTests/UsageHeatmapActivityTests.swift
+++ b/Tests/VibeBarCoreTests/UsageHeatmapActivityTests.swift
@@ -4,22 +4,65 @@ import XCTest
 final class UsageHeatmapActivityTests: XCTestCase {
     // MARK: - formatHourLabel
 
+    /// The label is a clock hour spelled the way the *app's* language spells
+    /// one, not a hardcoded English 12-hour string: an English reader gets
+    /// "3 PM", a Chinese reader "15时". Pinning the language is what makes
+    /// these assertions independent of the machine's own locale.
+    private func withLanguage(_ language: AppLanguage, _ body: () -> Void) {
+        let restore = L10n.languageOverride
+        defer { L10n.languageOverride = restore }
+        L10n.languageOverride = language
+        body()
+    }
+
+    /// English day periods are joined by U+202F NARROW NO-BREAK SPACE, not by
+    /// an ordinary space. Spelled as an escape rather than pasted in, because
+    /// an invisible character in a literal is a test nobody can debug.
+    private func englishHour(_ hour: String, _ period: String) -> String {
+        "\(hour)\u{202F}\(period)"
+    }
+
     func testFormatHourLabelMidnight() {
-        XCTAssertEqual(UsageHeatmap.formatHourLabel(0), "12am")
+        withLanguage(.english) {
+            XCTAssertEqual(UsageHeatmap.formatHourLabel(0), englishHour("12", "AM"))
+        }
+        withLanguage(.simplifiedChinese) {
+            XCTAssertEqual(UsageHeatmap.formatHourLabel(0), "0时")
+        }
     }
 
     func testFormatHourLabelNoon() {
-        XCTAssertEqual(UsageHeatmap.formatHourLabel(12), "12pm")
+        withLanguage(.english) {
+            XCTAssertEqual(UsageHeatmap.formatHourLabel(12), englishHour("12", "PM"))
+        }
+        withLanguage(.simplifiedChinese) {
+            XCTAssertEqual(UsageHeatmap.formatHourLabel(12), "12时")
+        }
     }
 
     func testFormatHourLabelMorning() {
-        XCTAssertEqual(UsageHeatmap.formatHourLabel(3), "3am")
-        XCTAssertEqual(UsageHeatmap.formatHourLabel(11), "11am")
+        withLanguage(.english) {
+            XCTAssertEqual(UsageHeatmap.formatHourLabel(3), englishHour("3", "AM"))
+            XCTAssertEqual(UsageHeatmap.formatHourLabel(11), englishHour("11", "AM"))
+        }
     }
 
     func testFormatHourLabelAfternoon() {
-        XCTAssertEqual(UsageHeatmap.formatHourLabel(15), "3pm")
-        XCTAssertEqual(UsageHeatmap.formatHourLabel(23), "11pm")
+        withLanguage(.english) {
+            XCTAssertEqual(UsageHeatmap.formatHourLabel(15), englishHour("3", "PM"))
+            XCTAssertEqual(UsageHeatmap.formatHourLabel(23), englishHour("11", "PM"))
+        }
+        withLanguage(.simplifiedChinese) {
+            XCTAssertEqual(UsageHeatmap.formatHourLabel(15), "15时")
+        }
+    }
+
+    /// An hour outside 0...23 is clamped rather than rolling into the next day.
+    func testFormatHourLabelClampsOutOfRange() {
+        withLanguage(.english) {
+            XCTAssertEqual(UsageHeatmap.formatHourLabel(-1), englishHour("12", "AM"))
+            XCTAssertEqual(UsageHeatmap.formatHourLabel(99), englishHour("11", "PM"))
+        }
     }
 
     // MARK: - hourTotals


### PR DESCRIPTION
Batch C: the popover shell, the provider pages and their modules, the
cost and usage surfaces, the mini windows, and the Core types that
produce copy for them. 21 files, 215 keys.

Several of these were bugs rather than translation gaps, and they are the
reason this pass is worth reading rather than skimming:

- The hour label hardcoded an English 12-hour clock and both heatmaps
  hardcoded `["Sun", …]`. Those cannot be catalogue keys — a Chinese
  reader reads `15时`, not a translation of `3pm` — so they come from
  `AppLocale` now.
- The remote machines page formatted tokens and currency against the
  process locale rather than the app's.
- The mini window shortened `5% in reserve` by deleting the word ` in`.
  That is a no-op in Chinese, so the row silently overflowed. It is a
  separate key now.
- Two captions were assembled from fragments and are whole keys, because
  Chinese word order does not survive concatenation.

Adding the model files to the lint manifest exposed a false positive in
the lint's own inference (`id(...)` was being read as copy), fixed at the
inference rather than by exempting the file.

The quota label seam is resolved part by part on the separator, so
`All Models · Weekly` translates both halves while `GPT-5.3 Codex Spark ·
5 Hours` keeps its product name. Auditing the *readers* rather than the
renderer found five more raw call sites than were reported.

Deliberately left, each named in the commit that touches its neighbour:
the shared group-label catalogue, `ToolType.subtitle`, the Resets page's
older call sites, the misc landing view, and the layout editor's module
names. `Gemini Chat` and AntiGravity's `High`/`Medium`/`Low` stay English
— contract values the localizer's table does not cover on purpose.

## Verification

    swift build                            → clean
    swift test                             → 2091 tests, 0 failures
    Scripts/build_localizations.py --check → clean
    Scripts/lint_localization.py           → 62 migrated file(s) clean
    ./Scripts/build_app.sh release         → empty entitlements, both .lproj present

🤖 Generated with [Claude Code](https://claude.com/claude-code)