### PR TITLE
Make remote machines experimental, and stop it holding a tab

### DIFF
--- a/Resources/i18n/en.json
+++ b/Resources/i18n/en.json
@@ -1382,8 +1382,8 @@
   },
   "quota.forecast.metric.coverageValue": {
     "args": {
-      "observations": "int",
-      "history": "int"
+      "history": "int",
+      "observations": "int"
     },
     "comment": "Value of the coverage metric: observation and reset-history coverage",
     "value": "obs {observations}% · history {history}%"
@@ -1412,8 +1412,8 @@
   },
   "quota.forecast.metric.evidenceValue": {
     "args": {
-      "observations": "int",
-      "cycles": "int"
+      "cycles": "int",
+      "observations": "int"
     },
     "comment": "Value of the evidence metric: observations in this cycle and completed cycles behind it",
     "value": "{observations} obs · {cycles} cycles"
@@ -2127,16 +2127,16 @@
   },
   "quota.resetHistory.currentCycleCaption": {
     "args": {
-      "used": "int",
-      "left": "int"
+      "left": "int",
+      "used": "int"
     },
     "comment": "Caption for the cycle still running in the reset-history strip",
     "value": "Current cycle · {used}% used so far · {left}% left"
   },
   "quota.resetHistory.cycleCaption": {
     "args": {
-      "used": "int",
-      "left": "int"
+      "left": "int",
+      "used": "int"
     },
     "comment": "Caption for one completed cycle in the reset-history strip; time is the reset moment",
     "value": "{time} reset · {used}% used · {left}% left"
@@ -3294,6 +3294,14 @@
   "settings.remote.disconnectTitle": {
     "comment": "Confirmation dialog title",
     "value": "Disconnect from this workspace?"
+  },
+  "settings.remote.experimentalBadge": {
+    "comment": "Badge beside the Remote Core section title marking the feature as experimental.",
+    "value": "Experimental"
+  },
+  "settings.remote.experimentalNote": {
+    "comment": "One-line explanation under the Remote Core section title, shown whether or not a workspace is connected.",
+    "value": "Remote machines are experimental: the protocol and this pane can change between releases, and the popover tab stays hidden until a workspace is connected."
   },
   "settings.remote.exportIdentity": {
     "comment": "Button that writes this Mac's public identity to a file",

--- a/Resources/i18n/zh-Hans.json
+++ b/Resources/i18n/zh-Hans.json
@@ -2234,6 +2234,12 @@
   "settings.remote.disconnectTitle": {
     "value": "是否断开与该工作区的连接？"
   },
+  "settings.remote.experimentalBadge": {
+    "value": "实验性"
+  },
+  "settings.remote.experimentalNote": {
+    "value": "远端机器为实验性功能：协议与本面板可能在版本之间变化；未连接工作区时，popover 不显示该标签页。"
+  },
   "settings.remote.exportIdentity": {
     "value": "导出 Core 身份…"
   },

--- a/Resources/i18n/zh-Hans.json
+++ b/Resources/i18n/zh-Hans.json
@@ -2238,7 +2238,7 @@
     "value": "实验性"
   },
   "settings.remote.experimentalNote": {
-    "value": "远端机器为实验性功能：协议与本面板可能在版本之间变化；未连接工作区时，popover 不显示该标签页。"
+    "value": "远端机器为实验性功能：协议与此设置页可能在版本之间变化；未连接工作区时，面板不显示该标签页。"
   },
   "settings.remote.exportIdentity": {
     "value": "导出 Core 身份…"

--- a/Scripts/capture_demo_screenshots.sh
+++ b/Scripts/capture_demo_screenshots.sh
@@ -56,6 +56,17 @@ fi
 
 [[ -x "$APP" ]] || { echo "capture: no app at $APP — run ./Scripts/build_app.sh first" >&2; exit 1; }
 [[ -d "$DEMO_HOME/.vibebar" ]] || { echo "capture: no demo home at $DEMO_HOME — run ./Scripts/demo_home.py first" >&2; exit 1; }
+
+# Machines is hidden until a workspace is connected, so on a Mac with no
+# Remote Core the popover would answer this request with Overview and save
+# it under the Machines name — quietly replacing a published README
+# screenshot with the wrong page. Drop the capture and say so instead:
+# demo_home.py skips the remote build the same way, and a missing screenshot
+# is a visible gap where a wrong one is not.
+if [[ ! -f "$DEMO_HOME/.vibebar/remote_core.json" ]]; then
+  SURFACES=("${SURFACES[@]:#popover-machines=*}")
+  echo "capture: no remote_core.json in the demo home — skipping popover-machines" >&2
+fi
 mkdir -p "$OUT"
 
 capture_one() {

--- a/Scripts/capture_demo_screenshots.sh
+++ b/Scripts/capture_demo_screenshots.sh
@@ -65,7 +65,8 @@ fi
 # is a visible gap where a wrong one is not.
 if [[ ! -f "$DEMO_HOME/.vibebar/remote_core.json" ]]; then
   SURFACES=("${SURFACES[@]:#popover-machines=*}")
-  echo "capture: no remote_core.json in the demo home — skipping popover-machines" >&2
+  echo "capture: no remote_core.json in the demo home — skipping popover-machines;" >&2
+  echo "capture: docs/screenshots/popover-machines*.png keeps whatever it already had" >&2
 fi
 
 # Asking for only that surface is a supported invocation, and skipping it can

--- a/Scripts/capture_demo_screenshots.sh
+++ b/Scripts/capture_demo_screenshots.sh
@@ -67,6 +67,15 @@ if [[ ! -f "$DEMO_HOME/.vibebar/remote_core.json" ]]; then
   SURFACES=("${SURFACES[@]:#popover-machines=*}")
   echo "capture: no remote_core.json in the demo home — skipping popover-machines" >&2
 fi
+
+# Asking for only that surface is a supported invocation, and skipping it can
+# empty the list. Stop here rather than falling through to the optimizer,
+# whose "$OUT"/*.png is a fatal unmatched glob in zsh when nothing was
+# captured — an obscure abort in place of the clean skip just announced.
+if (( ${#SURFACES[@]} == 0 )); then
+  echo "capture: nothing to capture" >&2
+  exit 0
+fi
 mkdir -p "$OUT"
 
 capture_one() {

--- a/Sources/VibeBarApp/Views/CardShell.swift
+++ b/Sources/VibeBarApp/Views/CardShell.swift
@@ -51,14 +51,31 @@ struct CardShell<Content: View>: View {
 /// cannot invent a fourth.
 struct SettingsSectionCard<Content: View>: View {
     let title: String
+    /// Optional word beside the title, for a section whose stability differs
+    /// from the rest of Settings. Nil for every ordinary section, which is
+    /// why a badge reads as a claim rather than as decoration.
+    var badge: String?
     let density: Theme.Density
     @ViewBuilder var content: () -> Content
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text(title)
-                .font(.system(size: 12, weight: .semibold))
-                .foregroundStyle(.secondary)
+            HStack(spacing: 6) {
+                Text(title)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                if let badge {
+                    Text(badge)
+                        .font(.system(size: 9.5, weight: .semibold))
+                        .foregroundStyle(.orange)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 1.5)
+                        .background(
+                            Capsule(style: .continuous)
+                                .fill(Color.orange.opacity(0.14))
+                        )
+                }
+            }
             // The surface is painted inside `CardShell`, so the width has to
             // be claimed by the content: a frame on the outside would only
             // stretch a transparent wrapper and let a narrow section (System,

--- a/Sources/VibeBarApp/Views/PageModuleCatalog.swift
+++ b/Sources/VibeBarApp/Views/PageModuleCatalog.swift
@@ -112,7 +112,10 @@ enum PageModuleCatalog {
     /// Driven by the same `OverviewPage` enumeration the tab strip uses, so a
     /// provider hidden from the popover disappears from the editor too.
     static func editablePages(settings: AppSettings) -> [(page: PageLayoutPageID, title: String)] {
-        OverviewPage.visiblePages(settings: settings).compactMap { page in
+        // `remoteConfigured` cannot change this list: Remote machines has no
+        // `layoutPageID`, so the `compactMap` drops it either way. Passing
+        // false keeps the editor from depending on a service it never reads.
+        OverviewPage.visiblePages(settings: settings, remoteConfigured: false).compactMap { page in
             guard let id = page.layoutPageID else { return nil }
             return (id, page.label)
         }

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -72,7 +72,15 @@ struct PopoverRoot: View {
         .onAppear {
             if !hasAppliedInitialPage {
                 hasAppliedInitialPage = true
-                overviewPage = initialPage
+                // A caller can name a page the strip is not showing — demo
+                // mode restores one by raw value, and a workspace can be
+                // disconnected between opening the popover twice. Landing on
+                // a tab that is not in the strip leaves nothing selected.
+                let pages = OverviewPage.visiblePages(
+                    settings: settingsStore.settings,
+                    remoteConfigured: remoteProbeService.isConfigured
+                )
+                overviewPage = pages.contains(initialPage) ? initialPage : .overview
             }
             refreshStaleCacheForCurrentPage()
         }
@@ -258,10 +266,20 @@ enum OverviewPage: String, CaseIterable, Identifiable {
     var id: String { rawValue }
 
     /// Tabs currently visible in the popover, in strip order.
-    static func visiblePages(settings: AppSettings) -> [OverviewPage] {
+    ///
+    /// Remote machines is experimental and appears only once a workspace is
+    /// connected. There is no separate opt-in switch because connecting one
+    /// *is* the opt-in — and an empty tab that every user carries is a worse
+    /// answer than no tab, since the strip's width is shared by every
+    /// provider the user actually has.
+    static func visiblePages(
+        settings: AppSettings,
+        remoteConfigured: Bool
+    ) -> [OverviewPage] {
         [.overview]
             + settings.visibleCoreProviderList.compactMap(OverviewPage.page(for:))
-            + [.machines, .misc]
+            + (remoteConfigured ? [.machines] : [])
+            + [.misc]
     }
 
     /// The layout-engine page this tab renders, or `nil` for tabs that are not
@@ -319,9 +337,13 @@ private struct OverviewPageSwitch: View {
     let density: Theme.Density
 
     @EnvironmentObject var settingsStore: SettingsStore
+    @EnvironmentObject var remoteProbeService: RemoteProbeService
 
     private var visiblePages: [OverviewPage] {
-        OverviewPage.visiblePages(settings: settingsStore.settings)
+        OverviewPage.visiblePages(
+            settings: settingsStore.settings,
+            remoteConfigured: remoteProbeService.isConfigured
+        )
     }
 
     var body: some View {
@@ -365,9 +387,18 @@ private struct OverviewPageSwitch: View {
                 )
         )
         .onChange(of: settingsStore.settings.visibleCoreProviders) { _, _ in
-            if !visiblePages.contains(selection) {
-                selection = .overview
-            }
+            fallBackIfSelectionVanished()
+        }
+        // Disconnecting a workspace removes a tab while the user is standing
+        // on it, so the same fallback has to watch configuration too.
+        .onChange(of: remoteProbeService.isConfigured) { _, _ in
+            fallBackIfSelectionVanished()
+        }
+    }
+
+    private func fallBackIfSelectionVanished() {
+        if !visiblePages.contains(selection) {
+            selection = .overview
         }
     }
 }

--- a/Sources/VibeBarApp/Views/RemoteSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/RemoteSettingsSection.swift
@@ -80,7 +80,16 @@ struct RemoteSettingsSection: View {
     // MARK: - Status
 
     private var statusSection: some View {
-        section(L10n.Settings.remoteCore) {
+        // The badge is on the first section rather than every one: it marks
+        // the feature, not each control inside it.
+        SettingsSectionCard(
+            title: L10n.Settings.remoteCore,
+            badge: L10n.Settings.remoteExperimentalBadge,
+            density: density
+        ) {
+            Text(L10n.Settings.remoteExperimentalNote)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
             if service.isConfigured {
                 infoRow(L10n.Settings.remoteWorkspace, service.workspaceID?.uuidString.lowercased() ?? "—")
                 infoRow(L10n.Settings.remoteRelay, service.relayURL?.absoluteString ?? "—")

--- a/Sources/VibeBarCore/Localization/L10n+Generated.swift
+++ b/Sources/VibeBarCore/Localization/L10n+Generated.swift
@@ -3013,6 +3013,14 @@ extension L10n {
         public static var remoteDisconnectTitle: String {
             L10n.string("settings.remote.disconnectTitle")
         }
+        /// `settings.remote.experimentalBadge` — Experimental
+        public static var remoteExperimentalBadge: String {
+            L10n.string("settings.remote.experimentalBadge")
+        }
+        /// `settings.remote.experimentalNote` — Remote machines are experimental: the protocol and this pane can change between releases, and the popover tab stays hidden until a workspace is connected.
+        public static var remoteExperimentalNote: String {
+            L10n.string("settings.remote.experimentalNote")
+        }
         /// `settings.remote.exportIdentity` — Export Core Identity…
         public static var remoteExportIdentity: String {
             L10n.string("settings.remote.exportIdentity")
@@ -6474,6 +6482,8 @@ extension L10n {
         "settings.remote.disconnectDetail",
         "settings.remote.disconnectIntro",
         "settings.remote.disconnectTitle",
+        "settings.remote.experimentalBadge",
+        "settings.remote.experimentalNote",
         "settings.remote.exportIdentity",
         "settings.remote.importProvisioning",
         "settings.remote.join",

--- a/Sources/VibeBarCore/Resources/en.lproj/Localizable.strings
+++ b/Sources/VibeBarCore/Resources/en.lproj/Localizable.strings
@@ -2192,6 +2192,12 @@
 /* Confirmation dialog title */
 "settings.remote.disconnectTitle" = "Disconnect from this workspace?";
 
+/* Badge beside the Remote Core section title marking the feature as experimental. */
+"settings.remote.experimentalBadge" = "Experimental";
+
+/* One-line explanation under the Remote Core section title, shown whether or not a workspace is connected. */
+"settings.remote.experimentalNote" = "Remote machines are experimental: the protocol and this pane can change between releases, and the popover tab stays hidden until a workspace is connected.";
+
 /* Button that writes this Mac's public identity to a file */
 "settings.remote.exportIdentity" = "Export Core Identity…";
 

--- a/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.strings
@@ -2192,6 +2192,12 @@
 /* Confirmation dialog title */
 "settings.remote.disconnectTitle" = "是否断开与该工作区的连接？";
 
+/* Badge beside the Remote Core section title marking the feature as experimental. */
+"settings.remote.experimentalBadge" = "实验性";
+
+/* One-line explanation under the Remote Core section title, shown whether or not a workspace is connected. */
+"settings.remote.experimentalNote" = "远端机器为实验性功能：协议与本面板可能在版本之间变化；未连接工作区时，popover 不显示该标签页。";
+
 /* Button that writes this Mac's public identity to a file */
 "settings.remote.exportIdentity" = "导出 Core 身份…";
 

--- a/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.strings
@@ -2196,7 +2196,7 @@
 "settings.remote.experimentalBadge" = "实验性";
 
 /* One-line explanation under the Remote Core section title, shown whether or not a workspace is connected. */
-"settings.remote.experimentalNote" = "远端机器为实验性功能：协议与本面板可能在版本之间变化；未连接工作区时，popover 不显示该标签页。";
+"settings.remote.experimentalNote" = "远端机器为实验性功能：协议与此设置页可能在版本之间变化；未连接工作区时，面板不显示该标签页。";
 
 /* Button that writes this Mac's public identity to a file */
 "settings.remote.exportIdentity" = "导出 Core 身份…";


### PR DESCRIPTION
Remote machines shipped as a permanent tab in a strip whose width every
provider shares. A user with no workspace paid for it on every popover
open and got an explanatory empty state in return. It now appears only
once a workspace is connected.

There is no separate opt-in switch, because connecting a workspace *is*
the opt-in. A second gate would only be a door in front of a door.

Removing a tab means the selection can be standing on it — a workspace
disconnected while the popover is open, or a caller naming a page the
strip is not showing, which demo mode does by raw value. Both fall back
to Overview rather than leaving nothing selected.

The pane says what experimental means rather than only labelling it: the
protocol and the pane can change between releases, and the tab stays
hidden until a workspace is connected. The badge sits on the first
section because it marks the feature, not each control inside it, and
`SettingsSectionCard` gained an optional badge that is nil everywhere
else — which is what keeps it reading as a claim rather than decoration.

## Verification

Both paths exercised in a running app, against two demo homes — one with
a Core config and one without:

- Configured: the `Machines` tab is present, as before.
- Not configured: the tab is absent, and the freed width lets the header
  subtitle finish instead of truncating to `All providers · quot…`.
- The Settings pane renders the badge and the note beside the localized
  section title.

    swift build                            → clean
    swift test                             → 2097 tests, 0 failures
    Scripts/build_localizations.py --check → 1422 keys x 2 languages
    Scripts/lint_localization.py           → 78 migrated file(s) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)