### PR TITLE
Bump build number to 65 for the 1.6.2 Dev release

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -4,17 +4,6 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
-	<!-- Every language the bundle ships an .lproj for. This is what puts
-	     Vibe Bar in System Settings > General > Language & Region >
-	     Applications, so a per-app language can be chosen there as well as
-	     in Vibe Bar's own Settings; both land in Locale.preferredLanguages,
-	     which is what L10n resolves .system against. Kept in step with
-	     L10n.supported and Resources/i18n/ by LocalizationCatalogTests. -->
-	<key>CFBundleLocalizations</key>
-	<array>
-		<string>en</string>
-		<string>zh-Hans</string>
-	</array>
 	<key>CFBundleDisplayName</key>
 	<string>Vibe Bar</string>
 	<key>CFBundleExecutable</key>
@@ -25,6 +14,11 @@
 	<string>com.astroqore.VibeBar</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>en</string>
+		<string>zh-Hans</string>
+	</array>
 	<key>CFBundleName</key>
 	<string>Vibe Bar</string>
 	<key>CFBundlePackageType</key>
@@ -32,7 +26,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.6.2</string>
 	<key>CFBundleVersion</key>
-	<string>64</string>
+	<string>65</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
Build 65 on the Dev channel. Since build 64:

- **Menu bar composer** (#305) — the strip is built out of typed blocks:
  provider logos, arbitrary text, any quota, each in any colour or one
  that follows a quota's actual or forecast verdict. Pick a template,
  drag blocks to arrange, and switch back to the field-based strip at any
  time without losing what you built.
- **Localization** (#306, #308, #309, #310) — Simplified Chinese across
  the popover, Workbench, Settings and the menu bar, with dates and
  numbers following the selected language rather than the system's.
- **MCP session manager** (#307) — an agent can search this Mac's agent
  sessions by keyword and get back a session id, its working directory
  and its transcript path.
- **Remote machines is experimental** (#311) and no longer holds a
  popover tab when no workspace is connected.

## Verification

    swift build                            → clean
    swift test                             → 2234 tests, 0 failures
    Scripts/build_localizations.py --check → 1521 keys x 2 languages
    Scripts/lint_localization.py           → 80 migrated file(s) clean
    ./Scripts/build_app.sh release         → packaged 1.6.2 (65)
    codesign -d --entitlements -           → empty <dict/>, no app-sandbox

The composer and the remote tab were also exercised in a running app
rather than only under test: the two-row composed strip renders with real
provider glyphs and forecast colouring, and the Machines tab is present
with a workspace connected and absent without one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)