### PR TITLE
Make the resource-bundle fallback actually a fallback

### DIFF
--- a/Scripts/build_app.sh
+++ b/Scripts/build_app.sh
@@ -155,5 +155,46 @@ fi
 
 codesign --verify --deep --strict "$APP_DIR"
 
+# Does the packaged app find its own resources?
+#
+# SwiftPM's generated `Bundle.module` accessor knows two places: a bundle
+# beside `Bundle.main.bundleURL`, and the absolute build directory of the
+# machine that compiled it. A packaged app has neither — the bundle goes under
+# Contents/Resources, because a file outside Contents makes codesign reject the
+# app — so any code that reaches `Bundle.module` traps. On the machine that
+# built it the second path still exists, which is exactly why this shipped
+# once: every local launch resolved through the build directory and only an
+# installed copy failed.
+#
+# So hide that directory and require the app to start without it, with a
+# surface rendered so the localized paths are actually exercised. A launch that
+# proves nothing is worse than no launch at all.
+smoke_home="$(mktemp -d)"
+mkdir -p "$smoke_home/.vibebar"
+: > "$smoke_home/VIBEBAR_DEMO_HOME.txt"
+mv "$CORE_RESOURCE_BUNDLE" "$CORE_RESOURCE_BUNDLE.packaging-smoke"
+restore_core_bundle() {
+    [[ -d "$CORE_RESOURCE_BUNDLE.packaging-smoke" ]] &&
+        mv "$CORE_RESOURCE_BUNDLE.packaging-smoke" "$CORE_RESOURCE_BUNDLE"
+    rm -rf "$smoke_home"
+}
+trap restore_core_bundle EXIT
+
+VIBEBAR_DEMO_HOME="$smoke_home" \
+VIBEBAR_DEMO_SURFACE=popover \
+    "$APP_DIR/Contents/MacOS/VibeBar" > "$smoke_home/launch.log" 2>&1 &
+smoke_pid=$!
+sleep 10
+if kill -0 "$smoke_pid" 2>/dev/null; then
+    kill "$smoke_pid" 2>/dev/null || true
+    wait "$smoke_pid" 2>/dev/null || true
+else
+    echo "Packaged app did not survive a launch without the build directory:" >&2
+    sed -n '1,10p' "$smoke_home/launch.log" >&2
+    exit 1
+fi
+restore_core_bundle
+trap - EXIT
+
 echo "==> done: $APP_DIR"
 echo "Run with: open \"$APP_DIR\""

--- a/Sources/VibeBarCore/Localization/L10n.swift
+++ b/Sources/VibeBarCore/Localization/L10n.swift
@@ -174,6 +174,43 @@ public enum L10n {
 
     private static let missSentinel = "\u{0}vibebar.l10n.miss"
 
+    /// Where a `.lproj` may live, in the order they are tried.
+    ///
+    /// `Bundle.module` is a trap, not a lookup. SwiftPM generates an accessor
+    /// that knows two locations — the absolute build directory of the machine
+    /// that compiled it, and a bundle sitting beside `Bundle.main.bundleURL` —
+    /// and calls `fatalError` when neither exists. A packaged app is exactly
+    /// that case: the CI build directory is gone, and the resource bundle is
+    /// under `Contents/Resources` because a file outside `Contents` makes
+    /// codesign reject the app.
+    ///
+    /// Listing it beside `Bundle.main` therefore did not make it a fallback —
+    /// building the array evaluated it, so the trap fired before the bundle
+    /// that had the answer was ever consulted. On a developer's Mac the build
+    /// directory the accessor names is still there, which is why this only
+    /// failed once installed. `PricingResolver` already navigates the same
+    /// hazard; this is the same rule, said once more where the second caller
+    /// needed it.
+    private static func hostBundles() -> [Bundle] {
+        var hosts: [Bundle] = [.main]
+        if let resources = Bundle.main.resourceURL,
+           let embedded = Bundle(
+               url: resources.appendingPathComponent(
+                   "VibeBar_VibeBarCore.bundle",
+                   isDirectory: true
+               )
+           )
+        {
+            hosts.append(embedded)
+        }
+        if Bundle.main.bundleURL.pathExtension != "app" {
+            // Not installed: `swift test` and `swift run` are the hosts whose
+            // build directory the accessor actually names.
+            hosts.append(.module)
+        }
+        return hosts
+    }
+
     /// The `.lproj` sub-bundle for `code`, memoized.
     ///
     /// Two hosts, one lookup: a packaged `Vibe Bar.app` carries the
@@ -185,7 +222,7 @@ public enum L10n {
     private static func bundle(for code: String) -> Bundle? {
         bundles.withLock { cache in
             if let cached = cache[code] { return cached.bundle }
-            let resolved = [Bundle.main, Bundle.module]
+            let resolved = hostBundles()
                 .compactMap { host -> String? in
                     if let exact = host.path(forResource: code, ofType: "lproj") {
                         return exact


### PR DESCRIPTION
Build 65 crashed on launch once installed, and the draft release has been
pulled.

`L10n` resolved its `.lproj` from `[Bundle.main, Bundle.module]`. The
order is right and the evaluation is not: constructing that array
evaluates `Bundle.module`, whose generated accessor calls `fatalError`
when neither of its two locations exists — a bundle beside
`Bundle.main.bundleURL`, or the absolute build directory of the machine
that compiled it. A packaged app has neither: packaging puts the bundle
under `Contents/Resources`, because a file outside `Contents` makes
codesign reject the app. So the trap fired before the bundle holding the
answer was consulted. `PricingResolver` already documents and avoids this
hazard; the same rule now exists where the second caller needed it.

## Why it shipped, and what stops the next one

On the machine that builds the app, the build directory the accessor
names is still there. Every local launch resolved through it, so the bug
was invisible until an installed copy ran with a `/Users/runner/...` path
that does not exist.

Packaging now hides that directory and requires the app to start without
it. The check is only as good as what it exercises: an earlier version
launched with no surface, survived the bug, and would have let this
release through a second time. It renders a surface now, so the localized
paths actually run.

Verified both directions:

- with the fix, `build_app.sh` exits 0
- with the fix reverted, it exits 1 and prints the fatal error
- the resource bundle is restored either way

## Verification

    swift build                            → clean
    swift test                             → 2234 tests, 0 failures
    Scripts/build_localizations.py --check → 1521 keys x 2 languages
    Scripts/lint_localization.py           → 80 migrated file(s) clean
    ./Scripts/build_app.sh release         → passes the new launch check
    codesign -d --entitlements -           → empty <dict/>

🤖 Generated with [Claude Code](https://claude.com/claude-code)