### PR TITLE
Bump build number to 66 for the 1.6.2 Dev release

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -26,7 +26,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.6.2</string>
 	<key>CFBundleVersion</key>
-	<string>65</string>
+	<string>66</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
Build 66 on the Dev channel, replacing 65 — which crashed on launch once
installed and was pulled before its appcast entry ever published. Same
contents, plus the fix for that crash (#313).

Since build 64:

- **Menu bar composer** (#305) — the strip is built out of typed blocks:
  provider logos, arbitrary text, any quota, each in any colour or one
  that follows a quota's actual or forecast verdict. Pick a template,
  drag blocks to arrange, and switch back to the field-based strip at any
  time without losing what you built.
- **Localization** (#306, #308, #309, #310) — Simplified Chinese across
  the popover, Workbench, Settings and the menu bar, with dates and
  numbers following the selected language rather than the system's.
- **MCP session manager** (#307) — an agent can search this Mac's agent
  sessions by keyword and get back a session id, its working directory
  and its transcript path.
- **Remote machines is experimental** (#311) and no longer holds a
  popover tab when no workspace is connected.
- **Packaged-app resource resolution** (#313) — the crash above, and a
  packaging check that reproduces it on the machine that builds the app.

## Verification

    swift build                            → clean
    swift test                             → 2234 tests, 0 failures
    Scripts/build_localizations.py --check → 1521 keys x 2 languages
    Scripts/lint_localization.py           → 80 migrated file(s) clean
    ./Scripts/build_app.sh release         → packaged 1.6.2 (66), launch check passed
    codesign -d --entitlements -           → empty <dict/>, no app-sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)