### PR TITLE
Bump build number to 67 for the 1.6.2 Dev release

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -26,7 +26,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.6.2</string>
 	<key>CFBundleVersion</key>
-	<string>66</string>
+	<string>67</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
Build 67 on the Dev channel. Since build 66:

- **Menu-bar columns** (#317) — blocks group into segments the strip draws
  as columns: three groups give a 3×2 strip, each column centred in its
  own width. Rows are containers rather than a `New row` block, groups
  move and save as named presets, spaces have a width, and a size choice
  now costs only the block that made it instead of shrinking the whole
  strip. Closes the two-row title gap the seed used to apologise for.
- **Reset times name the weekday** (#316), and a composed `Resets at`
  block chooses how much of the date it prints. `Resets in` is one key in
  one case now, and the forecast line spells its countdown out.
- **Status and quota copy in the reader's language** (#315) — the Status
  card and a quota caption were rendering English under Chinese; the
  lint that reported those files clean now reads what a label member
  returns, not only what it is passed to.
- **Remote machines is experimental** (#311) and holds no popover tab
  without a workspace.
- **SpaceXAI and Grok Bot icons** (#318) — the Grok Bot quota showed
  Cursor's logo because its bucket is reported under Cursor's account,
  and the SpaceXAI company tab showed Grok's.

## Verification

    swift build                            → clean
    swift test                             → 2275 tests, 0 failures
    Scripts/build_localizations.py --check → 1563 keys x 2 languages
    Scripts/lint_localization.py           → 81 migrated file(s) clean
    ./Scripts/build_app.sh release         → packaged 1.6.2 (67), launch check passed
    codesign -d --entitlements -           → empty <dict/>, no app-sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)