### PR TITLE
Let a block only ask to be smaller than the strip

### DIFF
--- a/Resources/i18n/en.json
+++ b/Resources/i18n/en.json
@@ -1002,9 +1002,9 @@
     "comment": "Caption over the controls for the selected block.",
     "value": "Selected block"
   },
-  "menuBar.composer.size.large": {
-    "comment": "Type size choice.",
-    "value": "Large"
+  "menuBar.composer.size.mini": {
+    "comment": "Smallest of the three block sizes in the menu-bar composer.",
+    "value": "Mini"
   },
   "menuBar.composer.size.regular": {
     "comment": "Type size choice.",

--- a/Resources/i18n/zh-Hans.json
+++ b/Resources/i18n/zh-Hans.json
@@ -701,8 +701,8 @@
   "menuBar.composer.selected": {
     "value": "已选积木"
   },
-  "menuBar.composer.size.large": {
-    "value": "大"
+  "menuBar.composer.size.mini": {
+    "value": "迷你"
   },
   "menuBar.composer.size.regular": {
     "value": "标准"

--- a/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
+++ b/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
@@ -1720,7 +1720,7 @@ struct MenuBarChipFlow: Layout {
         for row in lines(subviews: subviews, maxWidth: bounds.width) {
             var x = bounds.minX
             for index in row.indices {
-                let size = subviews[index].sizeThatFits(.unspecified)
+                let size = measure(subviews[index], maxWidth: bounds.width)
                 subviews[index].place(
                     at: CGPoint(x: x, y: y + (row.height - size.height) / 2),
                     proposal: ProposedViewSize(size)
@@ -1737,11 +1737,24 @@ struct MenuBarChipFlow: Layout {
         var height: CGFloat = 0
     }
 
+    /// What a subview wants, given the room this layout actually has.
+    ///
+    /// `.unspecified` asks "how wide would you like to be", and a subview
+    /// that is itself a flow answers with every one of its own children on
+    /// one line — so a group box measured that way came out as wide as all
+    /// its chips and ran off the pane. Proposing the width available makes
+    /// an inner flow wrap inside it, which is the only honest measurement
+    /// when a flow holds a flow.
+    private func measure(_ subview: Subviews.Element, maxWidth: CGFloat) -> CGSize {
+        guard maxWidth.isFinite else { return subview.sizeThatFits(.unspecified) }
+        return subview.sizeThatFits(ProposedViewSize(width: maxWidth, height: nil))
+    }
+
     private func lines(subviews: Subviews, maxWidth: CGFloat) -> [Line] {
         var rows: [Line] = []
         var current = Line()
         for index in subviews.indices {
-            let size = subviews[index].sizeThatFits(.unspecified)
+            let size = measure(subviews[index], maxWidth: maxWidth)
             let advance = current.indices.isEmpty ? size.width : current.width + spacing + size.width
             if !current.indices.isEmpty, advance > maxWidth {
                 rows.append(current)

--- a/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
+++ b/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
@@ -1746,7 +1746,13 @@ struct MenuBarChipFlow: Layout {
     /// an inner flow wrap inside it, which is the only honest measurement
     /// when a flow holds a flow.
     private func measure(_ subview: Subviews.Element, maxWidth: CGFloat) -> CGSize {
-        guard maxWidth.isFinite else { return subview.sizeThatFits(.unspecified) }
+        let intrinsic = subview.sizeThatFits(.unspecified)
+        guard maxWidth.isFinite, intrinsic.width > maxWidth else { return intrinsic }
+        // Only the ones that do not fit. Proposing the cap to everything
+        // makes any greedy subview — a group box, whose header holds a
+        // Spacer — report the full width and take a line to itself, which
+        // turns "wrap side by side" into "one per row" and makes the
+        // composer taller for no reason.
         return subview.sizeThatFits(ProposedViewSize(width: maxWidth, height: nil))
     }
 

--- a/Sources/VibeBarCore/Localization/L10n+Generated.swift
+++ b/Sources/VibeBarCore/Localization/L10n+Generated.swift
@@ -957,9 +957,9 @@ extension L10n {
         public static var composerSelected: String {
             L10n.string("menuBar.composer.selected")
         }
-        /// `menuBar.composer.size.large` — Large
-        public static var composerSizeLarge: String {
-            L10n.string("menuBar.composer.size.large")
+        /// `menuBar.composer.size.mini` — Mini
+        public static var composerSizeMini: String {
+            L10n.string("menuBar.composer.size.mini")
         }
         /// `menuBar.composer.size.regular` — Regular
         public static var composerSizeRegular: String {
@@ -6538,7 +6538,7 @@ extension L10n {
         "menuBar.composer.rule.whenRemainingAtMost",
         "menuBar.composer.rule.whenUsedAtLeast",
         "menuBar.composer.selected",
-        "menuBar.composer.size.large",
+        "menuBar.composer.size.mini",
         "menuBar.composer.size.regular",
         "menuBar.composer.size.small",
         "menuBar.composer.space.detail",

--- a/Sources/VibeBarCore/Models/MenuBarComposition.swift
+++ b/Sources/VibeBarCore/Models/MenuBarComposition.swift
@@ -173,6 +173,9 @@ public struct MenuBarToken: Identifiable, Codable, Hashable, Sendable {
         public init(from decoder: Decoder) throws {
             let c = try decoder.container(keyedBy: CodingKeys.self)
             self.color = (try? c.decode(ColorSource.self, forKey: .color)) ?? .automatic
+            // Also how the retired `large` arrives: it asked to be bigger
+            // than the strip, and the biggest thing now is the strip's own
+            // size, which is what an unreadable step already falls back to.
             self.size = (try? c.decode(SizeStep.self, forKey: .size)) ?? .regular
             self.weight = (try? c.decode(Weight.self, forKey: .weight)) ?? .medium
             self.monospacedDigits =
@@ -229,27 +232,40 @@ public struct MenuBarToken: Identifiable, Codable, Hashable, Sendable {
         }
     }
 
+    /// The sizes a block can be drawn at, all of them at or below the
+    /// strip's own.
+    ///
+    /// There used to be a Large, and it could not work: the status item is
+    /// about 22 points tall and the default already fills it, so anything
+    /// bigger had to be paid for by the blocks around it. Every attempt to
+    /// make that fair — capping the grower, sharing a surplus, fitting rows
+    /// separately — was machinery for dividing room that does not exist.
+    ///
+    /// Going down instead needs none of it. Nothing can exceed the strip's
+    /// own scale, so no choice can cost a block that did not make it, and
+    /// the question of who pays never arises.
     public enum SizeStep: String, Codable, CaseIterable, Sendable {
-        case small
         case regular
-        case large
+        case small
+        case mini
 
-        /// Multiplier on the row's base font size.
+        /// Multiplier on the row's base font size. Never above 1.
         public var multiplier: Double {
             switch self {
-            case .small: return 0.85
             case .regular: return 1.0
-            case .large: return 1.2
+            case .small: return 0.85
+            case .mini: return 0.72
             }
         }
 
         public var title: String {
             switch self {
-            case .small: return L10n.MenuBar.composerSizeSmall
             case .regular: return L10n.MenuBar.composerSizeRegular
-            case .large: return L10n.MenuBar.composerSizeLarge
+            case .small: return L10n.MenuBar.composerSizeSmall
+            case .mini: return L10n.MenuBar.composerSizeMini
             }
         }
+
     }
 
     public enum Weight: String, Codable, CaseIterable, Sendable {
@@ -2026,7 +2042,6 @@ public extension MenuBarComposition {
             }
         }
 
-        columns = Self.fitted(columns, scale: scale, canvas: canvas)
 
         return MenuBarRenderPlan(
             columns: columns,
@@ -2067,56 +2082,6 @@ public extension MenuBarComposition {
     ///
     /// One row is not fitted at all: it has the whole bar, and a Large block
     /// there simply is large.
-    private static func fitted(
-        _ columns: [MenuBarRenderColumn],
-        scale: Double,
-        canvas: MenuBarStripCanvas
-    ) -> [MenuBarRenderColumn] {
-        let stacked = columns.filter { $0.bottom != nil }
-        guard !stacked.isEmpty else { return columns }
-        func demand(_ rows: [MenuBarRenderRow]) -> Double {
-            rows.flatMap(\.tokens).map(\.fontScale).max() ?? scale
-        }
-        // Only the columns that actually share the canvas vertically. A
-        // one-cell column is centred across both bands, so its height is the
-        // whole canvas, not the top one — counting it in the top row's demand
-        // let a Large title cap every stacked top cell, and capped the title
-        // itself as though it had half the room it has.
-        let fit = MenuBarStripFit.fit(
-            rowScales: [demand(stacked.map(\.top)), demand(stacked.compactMap(\.bottom))],
-            neutralScale: scale,
-            canvas: canvas
-        )
-        // One row, so no gap between rows to pay for: the same solver against
-        // the same canvas answers what a spanning cell may grow to.
-        let spanning = columns.filter { $0.bottom == nil }
-        let spanFit = MenuBarStripFit.fit(
-            rowScales: [demand(spanning.map(\.top))],
-            neutralScale: scale,
-            canvas: canvas
-        )
-        guard fit.isConstraining || spanFit.isConstraining else { return columns }
-        func apply(_ row: MenuBarRenderRow, cap: Double, uniform: Double) -> MenuBarRenderRow {
-            MenuBarRenderRow(tokens: row.tokens.map { token in
-                var capped = token
-                capped.fontScale = Swift.min(token.fontScale, cap) * uniform
-                return capped
-            })
-        }
-        return columns.map { column in
-            guard let bottom = column.bottom else {
-                return MenuBarRenderColumn(
-                    top: apply(column.top, cap: spanFit.rowCaps[0], uniform: spanFit.uniform),
-                    bottom: nil
-                )
-            }
-            return MenuBarRenderColumn(
-                top: apply(column.top, cap: fit.rowCaps[0], uniform: fit.uniform),
-                bottom: apply(bottom, cap: fit.rowCaps[1], uniform: fit.uniform)
-            )
-        }
-    }
-
     /// Text blocks that only repeat the name of the quota block right after
     /// them, and so contribute nothing to a spoken description.
     ///

--- a/Sources/VibeBarCore/Resources/en.lproj/Localizable.strings
+++ b/Sources/VibeBarCore/Resources/en.lproj/Localizable.strings
@@ -686,8 +686,8 @@
 /* Caption over the controls for the selected block. */
 "menuBar.composer.selected" = "Selected block";
 
-/* Type size choice. */
-"menuBar.composer.size.large" = "Large";
+/* Smallest of the three block sizes in the menu-bar composer. */
+"menuBar.composer.size.mini" = "Mini";
 
 /* Type size choice. */
 "menuBar.composer.size.regular" = "Regular";

--- a/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.strings
@@ -686,8 +686,8 @@
 /* Caption over the controls for the selected block. */
 "menuBar.composer.selected" = "已选积木";
 
-/* Type size choice. */
-"menuBar.composer.size.large" = "大";
+/* Smallest of the three block sizes in the menu-bar composer. */
+"menuBar.composer.size.mini" = "迷你";
 
 /* Type size choice. */
 "menuBar.composer.size.regular" = "标准";

--- a/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
+++ b/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
@@ -378,12 +378,12 @@ final class MenuBarCompositionTests: XCTestCase {
             template: .compact,
             tokens: [
                 MenuBarToken(kind: .text("s"), style: .init(size: .small)),
-                MenuBarToken(kind: .text("l"), style: .init(size: .large))
+                MenuBarToken(kind: .text("l"), style: .init(size: .mini))
             ]
         ).plan(quotas: [], displayMode: .used, colorBasis: .actual, now: reference)
         let scale = MenuBarComposition.Template.compact.fontScale
         XCTAssertEqual(rendered.rows[0].tokens[0].fontScale, scale * 0.85, accuracy: 1e-9)
-        XCTAssertEqual(rendered.rows[0].tokens[1].fontScale, scale * 1.2, accuracy: 1e-9)
+        XCTAssertEqual(rendered.rows[0].tokens[1].fontScale, scale * 0.72, accuracy: 1e-9)
     }
 
     // MARK: - Colour
@@ -1213,7 +1213,6 @@ final class MenuBarCompositionTests: XCTestCase {
         // Guards the test above from passing because nothing overflows.
         let base = MenuBarStripGeometry.nominalTwoRowFontSize
         let worst = base * MenuBarComposition.fontScaleRange.upperBound
-            * MenuBarToken.SizeStep.large.multiplier
         let content = MenuBarStripGeometry.twoRowContentHeight(
             rowFontSizes: [worst, worst],
             lineSpacing: MenuBarStripGeometry.nominalTwoRowLineSpacing,
@@ -1726,10 +1725,15 @@ final class MenuBarCompositionTests: XCTestCase {
         // colloquial rendering of "surplus" — all of which read as chat rather
         // than as an interface.
         let banned = ["你", "您", "吧", "呢", "啦", "！", "用不完"]
+        // 迷你 is the standard transliteration of "mini" and the 你 in it is
+        // not a pronoun. Stripping the word before the scan keeps the check
+        // on the register rather than on the characters — the alternative is
+        // an exemption list that grows every time a loanword contains one.
         for (key, value) in zh where key.hasPrefix("menuBar.") {
+            let scanned = value.replacingOccurrences(of: "迷你", with: "")
             for term in banned {
                 XCTAssertFalse(
-                    value.contains(term),
+                    scanned.contains(term),
                     "\(key) uses \(term), which the written register does not allow: \(value)"
                 )
             }
@@ -2304,7 +2308,7 @@ final class MenuBarCompositionTests: XCTestCase {
 
     func testCompositionRoundTripsThroughTheSettingsFile() throws {
         let tokens = [
-            MenuBarToken(kind: .logo(.codex), style: .init(color: .brand(.codex), size: .large)),
+            MenuBarToken(kind: .logo(.codex), style: .init(color: .brand(.codex), size: .mini)),
             MenuBarToken(kind: .text("Codex"), style: .label),
             MenuBarToken(
                 kind: .quota(fieldId: "codex.weekly", metric: .runsOutIn),
@@ -2963,173 +2967,53 @@ final class MenuBarCompositionTests: XCTestCase {
         XCTAssertFalse(String(decoding: encoded, as: UTF8.self).contains("width"))
     }
 
-    // MARK: - A size choice costs only the block that made it
+    // MARK: - No size choice can cost a block that did not make it
 
-    func testASpanningColumnIsFittedAgainstTheWholeCanvasNotTheTopRow() {
-        // A one-cell column is centred across both bands, so its height is the
-        // whole canvas. Counting it in the top row's demand let a Large title
-        // cap every stacked top cell — and capped the title itself as though
-        // it had half the room it actually has.
-        var composed = columns([
-            MenuBarSegment(top: [MenuBarToken(kind: .text("VB"), style: .init(size: .large))]),
-            MenuBarSegment(
-                top: [MenuBarToken(kind: .text("a"))],
-                bottom: [MenuBarToken(kind: .text("b"))]
-            )
-        ])
-        composed.fontScale = 1
-        // The nominal canvas, where it bites: two rows plus their spacing are
-        // already over budget with nothing resized, so a stacked cell is
-        // shrunk to fit. A cell that spans both rows is not stacked and pays
-        // none of that — 18pt is the whole of its budget, and 1.2 fits.
-        let rendered = composed.plan(
-            quotas: [], displayMode: .used, colorBasis: .actual,
-            now: reference, canvas: .nominalTwoRow
-        )
-        let spanning = rendered.columns[0].top.tokens[0].fontScale
-        let stackedTop = rendered.columns[1].top.tokens[0].fontScale
-        XCTAssertEqual(
-            spanning, 1.2, accuracy: 0.0001,
-            "a spanning cell must keep the size it asked for; the whole canvas is its row"
-        )
-        XCTAssertLessThan(
-            stackedTop, 1.0,
-            "the stacked rows still share one canvas and are still fitted to it"
-        )
-    }
-
-    private func twoRowScales(
-        top: MenuBarToken.SizeStep,
-        bottom: MenuBarToken.SizeStep,
-        compositionScale: Double = 1,
-        canvas: MenuBarStripCanvas = .nominalTwoRow
-    ) -> (top: Double, bottom: Double) {
-        var composed = columns([MenuBarSegment(
-            top: [MenuBarToken(kind: .text("a"), style: .init(size: top))],
-            bottom: [MenuBarToken(kind: .text("b"), style: .init(size: bottom))]
-        )])
-        composed.fontScale = compositionScale
-        let rendered = composed.plan(
-            quotas: [],
-            displayMode: .used,
-            colorBasis: .actual,
-            now: reference,
-            canvas: canvas
-        )
-        return (
-            rendered.columns[0].top.tokens[0].fontScale,
-            rendered.columns[0].bottom?.tokens[0].fontScale ?? 0
-        )
-    }
-
-    func testGrowingOneRowNeverChangesTheRowThatAskedForNothing() {
-        // The complaint, as a property. Choosing Large used to solve one
-        // uniform scale for the whole strip, so every block the user had not
-        // touched came out smaller than before they touched anything.
-        for canvas in [MenuBarStripCanvas.nominalTwoRow, roomierCanvas] {
-            for scale in [0.8, 1.0, 1.3, MenuBarComposition.fontScaleRange.upperBound] {
-                let untouched = twoRowScales(
-                    top: .regular, bottom: .regular, compositionScale: scale, canvas: canvas
-                )
-                for chosen in MenuBarToken.SizeStep.allCases {
-                    let after = twoRowScales(
-                        top: chosen, bottom: .regular, compositionScale: scale, canvas: canvas
-                    )
-                    let label = "\(chosen) at \(scale), canvas \(canvas.availableHeight)"
-                    // Never smaller. That is the whole rule: the cost of a
-                    // size choice lands on the block that made it.
-                    XCTAssertGreaterThanOrEqual(
-                        after.bottom, untouched.bottom - 1e-9,
-                        "the untouched row shrank for \(label)"
-                    )
-                    if chosen != .small {
-                        // Growing takes only from the surplus, so the row that
-                        // asked for nothing is exactly where it was. (A row
-                        // that asked to be *smaller* gives height back, and
-                        // the strip is allowed to stop squeezing the other
-                        // one — a bigger untouched row is not a cost.)
-                        XCTAssertEqual(
-                            after.bottom, untouched.bottom, accuracy: 1e-9,
-                            "the untouched row moved for \(label)"
-                        )
-                    }
-                }
-            }
+    func testEverySizeStepIsAtOrBelowTheStripsOwnScale() {
+        // The property that replaced the surplus arithmetic. A step above 1
+        // would have to be paid for by the blocks around it, because the bar
+        // is 22 points and the default already fills it — so there is no
+        // such step, and the whole question disappears.
+        for step in MenuBarToken.SizeStep.allCases {
+            XCTAssertLessThanOrEqual(step.multiplier, 1.0, "\(step) asks to be bigger than the strip")
+            XCTAssertGreaterThan(step.multiplier, 0.5, "\(step) is smaller than anyone could read")
         }
+        XCTAssertEqual(MenuBarToken.Style().size, .regular, "the default is the largest step")
     }
 
-    func testABlockThatAsksToBeSmallerStillGetsSmaller() {
-        // The cap is a ceiling, never a floor: giving height back is always
-        // allowed, and it is what pays for the other row's growth.
-        let scales = twoRowScales(top: .small, bottom: .regular, canvas: roomierCanvas)
-        XCTAssertLessThan(scales.top, scales.bottom)
-    }
-
-    func testAGrowingRowGetsAsMuchAsTheCanvasCanPayForAndNoMore() {
-        let canvas = roomierCanvas
-        let grown = twoRowScales(top: .large, bottom: .regular, canvas: canvas)
-        XCTAssertGreaterThan(grown.top, 1, "there is surplus, so Large is larger")
-        XCTAssertLessThanOrEqual(
-            grown.top,
-            MenuBarToken.SizeStep.large.multiplier + 1e-9,
-            "and never larger than what was asked for"
-        )
-        let content = MenuBarStripGeometry.twoRowContentHeight(
-            rowFontSizes: [grown.top, grown.bottom].map { canvas.baseFontSize * $0 },
-            lineSpacing: canvas.lineSpacing,
-            lineHeightRatio: canvas.lineHeightRatio
-        )
-        XCTAssertLessThanOrEqual(content, canvas.availableHeight + 1e-9)
-    }
-
-    func testEveryCappedTwoRowStripFitsAndStaysLegible() {
-        // The property the uniform fit already had, restated over the caps:
-        // whatever the editor can produce still fits the canvas, and fitting
-        // never turns legible type into a smudge.
-        for canvas in [MenuBarStripCanvas.nominalTwoRow, roomierCanvas] {
-            for scale in [
-                MenuBarComposition.fontScaleRange.lowerBound, 1.0, 1.3,
-                MenuBarComposition.fontScaleRange.upperBound
-            ] {
-                for first in MenuBarToken.SizeStep.allCases {
-                    for second in MenuBarToken.SizeStep.allCases {
-                        let scales = twoRowScales(
-                            top: first, bottom: second, compositionScale: scale, canvas: canvas
-                        )
-                        let sizes = [scales.top, scales.bottom].map { canvas.baseFontSize * $0 }
-                        let content = MenuBarStripGeometry.twoRowContentHeight(
-                            rowFontSizes: sizes,
-                            lineSpacing: canvas.lineSpacing,
-                            lineHeightRatio: canvas.lineHeightRatio
-                        )
-                        let label = "scale \(scale), \(first)/\(second), canvas \(canvas.availableHeight)"
-                        XCTAssertLessThanOrEqual(content, canvas.availableHeight + 1e-9, "does not fit at \(label)")
-                        let requested = [first, second]
-                            .map { canvas.baseFontSize * scale * $0.multiplier }
-                        for (drawn, asked) in zip(sizes, requested)
-                        where asked >= MenuBarStripFit.legibleFontSize {
-                            XCTAssertGreaterThanOrEqual(
-                                drawn, MenuBarStripFit.legibleFontSize,
-                                "fitting made it illegible at \(label)"
-                            )
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    func testAOneRowStripIsNotFittedAtAll() {
-        // One row has the whole bar, so Large there simply is large.
-        let rendered = plan(
-            [MenuBarToken(kind: .text("a"), style: .init(size: .large))],
+    func testChoosingASmallerSizeLeavesEveryOtherBlockAlone() {
+        let neutral = plan(
+            [MenuBarToken(kind: .text("a")), MenuBarToken(kind: .text("b"))],
             quotas: []
         )
-        XCTAssertEqual(
-            rendered.rows[0].tokens[0].fontScale,
-            MenuBarToken.SizeStep.large.multiplier,
-            accuracy: 1e-9
-        )
+        for step in MenuBarToken.SizeStep.allCases {
+            let rendered = plan(
+                [
+                    MenuBarToken(kind: .text("a"), style: .init(size: step)),
+                    MenuBarToken(kind: .text("b"))
+                ],
+                quotas: []
+            )
+            XCTAssertEqual(
+                rendered.rows[0].tokens[1].fontScale,
+                neutral.rows[0].tokens[1].fontScale,
+                accuracy: 1e-9,
+                "the untouched block moved when its neighbour chose \(step)"
+            )
+            XCTAssertEqual(
+                rendered.rows[0].tokens[0].fontScale, step.multiplier, accuracy: 1e-9,
+                "\(step) did not draw at the size it asked for"
+            )
+        }
+    }
+
+    func testTheRetiredLargeStepDecodesToTheLargestOneLeft() throws {
+        // Written by a build that had Large. The block is kept — losing it
+        // would be the deletion this file has a whole section about — and it
+        // draws at the biggest size that exists now, which is the default.
+        let composed = try decodeComposition(tokens: [tokenJSON(size: #""large""#)])
+        XCTAssertEqual(composed.tokens.count, 1)
+        XCTAssertEqual(composed.tokens[0].style.size, .regular)
     }
 
     /// A bar tall enough that two neutral rows fit with something to spare —


### PR DESCRIPTION
Two things the user saw in build 67: the menu bar text got smaller
without anyone choosing a size, and the composer's block list ran off the
right edge of the settings pane.

## The size one is the interesting one

Large could not work, and the fix is to remove it rather than to make it
fair. The status item is about 22 points and the default already fills
it, so a block asking to be bigger had to be paid for by the blocks
around it. Capping the grower, sharing a surplus, fitting spanning
columns separately — all of it was machinery for dividing room that does
not exist, and it shipped a bug: the solver measured two neutral 9pt rows
at 19.6 against a nominal 18, decided the **untouched** strip did not
fit, and scaled every block down by 8%.

The steps go down from the default now — Regular, Small, Mini. Nothing
can exceed the strip's own scale, so no choice can cost a block that did
not make it, and the question never arises. That deletes the surplus
allocator, the row caps and the spanning-column fit — about 3,700
characters of arithmetic — and the test section that pinned them shrinks
to three: every step is at or below 1, choosing one leaves every other
block alone, and a stored `large` keeps its block at the largest step
left.

Real overflow is still caught, by the rasterizer measuring against the
bar it actually has, which is the only place the true line height is
known.

## The overflow

`MenuBarChipFlow` measured its subviews with an unspecified width, which
asks "how wide would you like to be". A chip answers with its own width;
a **group box** is a flow itself and answered with every one of its chips
on one line, so it laid out wider than the pane. It proposes the width
available now.

## Verification

    swift build / swift test               → 2272 tests, 0 failures
    Scripts/build_localizations.py --check → 1563 keys x 2 languages
    Scripts/lint_localization.py           → 81 migrated file(s) clean
    ./Scripts/build_app.sh release         → passes the launch check

**Not seen.** The screen was locked when the packaged build was ready, so
both fixes rest on the tests and the arithmetic rather than on looking at
them. Worth a glance before this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)