### PR TITLE
Bump build number to 68 for the 1.6.2 Dev release

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -26,7 +26,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.6.2</string>
 	<key>CFBundleVersion</key>
-	<string>67</string>
+	<string>68</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
Build 68 on the Dev channel, replacing 67 within the hour it shipped.

67 drew every menu-bar block 8% smaller than 66 did, without anyone
choosing a size: the composer's fit solver measured two neutral 9pt rows
at 19.6 against a nominal 18, concluded the untouched strip did not fit,
and scaled everything down.

The cause was a size step that could not work. The status item is about
22 points and the default already fills it, so a block asking to be
*bigger* had to be paid for by its neighbours, and every attempt to make
that fair was machinery for dividing room that does not exist. The steps
go down from the default now — Regular, Small, Mini — which deletes the
surplus allocator, the row caps and the spanning-column fit along with
the bug. A stored `large` keeps its block at the largest step left.

Also: the composer's block list ran off the pane, because a group box is
itself a flow and answered an unspecified width proposal with every chip
on one line.

## Verification

    swift build                            → clean
    swift test                             → 2272 tests, 0 failures
    Scripts/build_localizations.py --check → 1563 keys x 2 languages
    Scripts/lint_localization.py           → 81 migrated file(s) clean
    ./Scripts/build_app.sh release         → packaged 1.6.2 (68), launch check passed
    codesign -d --entitlements -           → empty <dict/>, no app-sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)