### PR TITLE
Stop charging the strip for padding it never reserves

### DIFF
--- a/Sources/VibeBarApp/Views/MenuBarStripView.swift
+++ b/Sources/VibeBarApp/Views/MenuBarStripView.swift
@@ -50,9 +50,18 @@ enum MenuBarStripMetrics {
     /// Points between two adjacent columns of a rasterized strip.
     static let twoRowColumnSpacing: CGFloat = 8
 
-    /// Height the rasterized image actually has for content, after padding.
+    /// Height the rasterized image actually has for content.
+    ///
+    /// The bar's own drawable height, and nothing subtracted for padding:
+    /// `twoRowVerticalPadding` only widens the image when the content is
+    /// *smaller* than the bar, and the rasterizer centres what it draws
+    /// rather than reserving that inset. Charging the fit for it made the
+    /// composed strip measure two neutral 9pt bands — 20pt with the negative
+    /// line spacing — against an 18pt box, so a strip that fits exactly was
+    /// told to shrink and came out ~8% below the built-in layout it was
+    /// seeded from.
     static func twoRowAvailableHeight() -> CGFloat {
-        max(18, NSStatusBar.system.thickness - 2) - twoRowVerticalPadding * 2
+        max(18, NSStatusBar.system.thickness - 2)
     }
 
     /// The canvas a stacked strip is planned against — this Mac's bar, not the

--- a/Sources/VibeBarCore/Models/MenuBarComposition.swift
+++ b/Sources/VibeBarCore/Models/MenuBarComposition.swift
@@ -2943,10 +2943,11 @@ public enum MenuBarStripGeometry {
     public static let maximumTwoRowGlyphSide: Double = 12
 
     /// The two-row canvas as the status bar usually presents it: a 22pt bar
-    /// less the rasterizer's 2pt inset and 1pt of padding each side. The App
-    /// reads the real thickness at draw time; these exist so the fit property
-    /// can be asserted against the shape users actually get.
-    public static let nominalTwoRowAvailableHeight: Double = 18
+    /// less the rasterizer's 2pt inset. The App reads the real thickness at
+    /// draw time; these exist so the fit property can be asserted against the
+    /// shape users actually get. No padding comes off it — see
+    /// `MenuBarStripMetrics.twoRowAvailableHeight`.
+    public static let nominalTwoRowAvailableHeight: Double = 20
     public static let nominalTwoRowFontSize: Double = 9
     public static let nominalTwoRowLineSpacing: Double = -2
     public static let nominalLineHeightRatio: Double = 1.2

--- a/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
+++ b/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
@@ -1245,6 +1245,40 @@ final class MenuBarCompositionTests: XCTestCase {
         }
     }
 
+    /// The regression this canvas height exists for: a composed strip nobody
+    /// resized came out ~8% smaller than the built-in two-row layout it was
+    /// seeded from. Both draw two neutral 9pt bands into the same image, so
+    /// the only thing that could separate them was a fit the composed path
+    /// applies and the field path does not — and it only fired because the
+    /// canvas had the rasterizer's vertical padding taken off it. The
+    /// rasterizer centres what it draws and never reserves that inset, so the
+    /// strip was being charged for space nothing was holding.
+    func testAnUntouchedTwoRowStripIsDrawnAtItsOwnFace() {
+        let canvas = MenuBarStripCanvas.nominalTwoRow
+        let neutral = MenuBarStripGeometry.twoRowContentHeight(
+            rowFontSizes: [canvas.baseFontSize, canvas.baseFontSize],
+            lineSpacing: canvas.lineSpacing,
+            lineHeightRatio: canvas.lineHeightRatio
+        )
+        XCTAssertEqual(
+            MenuBarStripFit.scale(
+                contentHeight: neutral,
+                availableHeight: canvas.availableHeight
+            ),
+            1,
+            accuracy: 1e-9,
+            "two neutral rows measure \(neutral) against \(canvas.availableHeight)"
+        )
+        // And the planner agrees: nobody grew anything, so nobody is capped.
+        let fit = MenuBarStripFit.fit(
+            rowScales: [1, 1],
+            neutralScale: 1,
+            canvas: canvas
+        )
+        XCTAssertEqual(fit.uniform, 1, accuracy: 1e-9)
+        XCTAssertTrue(fit.rowCaps.allSatisfy { $0 == .infinity })
+    }
+
     func testAStripThatFitsIsNotScaledAtAll() {
         XCTAssertEqual(MenuBarStripFit.scale(contentHeight: 16, availableHeight: 18), 1)
         XCTAssertEqual(MenuBarStripFit.scale(contentHeight: 18, availableHeight: 18), 1)


### PR DESCRIPTION
A composed two-row strip rendered ~8% smaller than the built-in two-row layout it was seeded from, at identical content and face. Measured on the live bar: Default bands are 13 device px, Custom 12.

## Root cause

`MenuBarStripMetrics.twoRowAvailableHeight()` subtracted the rasterizer's 1pt vertical padding from each end of the bar. The rasterizer never reserves it — `twoRowImage` centres the block (`blockBottom = max(0, floor((imageHeight - blockHeight) / 2))`) and the image height is clamped to the bar regardless. The padding only widens the image when content is *smaller* than the bar.

On this Mac (`thickness = 22`):

| | value |
|---|---|
| image height ceiling | `max(18, 22 - 2)` = **20** |
| two neutral 9pt bands | `11 + 11 - 2` = **20** |
| old `availableHeight` | 20 − 1×2 = **18** |
| resulting fit | 18 / 20 = **0.9** |

The field two-row path calls `installTwoRowImageContent` with no fit at all, so only the composed path paid this. Content 20 in a 20pt image gives `blockBottom = 0` — an exact fit, cropped by nothing.

## Change

`twoRowAvailableHeight()` returns the bar's drawable height, and `nominalTwoRowAvailableHeight` goes 18 → 20 to match. Both the status item's fit and the planner's per-row caps read it, so both stop firing on a strip that fits.

## Test

`testAnUntouchedTwoRowStripIsDrawnAtItsOwnFace` asserts the property — a strip nobody resized draws at its own face and the planner caps nobody. Reverting the constant fails it at exactly 0.918, the ratio measured on screen.

`swift build`, `swift test` (2273 passed, 3 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)