### PR TITLE
Give SpaceXAI, Google AI and Grok Bot their own marks

### DIFF
--- a/Resources/ProviderIcons/ProviderIcon-googleai.svg
+++ b/Resources/ProviderIcons/ProviderIcon-googleai.svg
@@ -1,0 +1,7 @@
+<!-- Google's four-segment G, from lobehub/lobe-icons (MIT) `icons/google.svg`, retrieved 2026-09-04; the viewBox is cropped to the mark's own bounds and the four brand colours are dropped because this renderer tints the shape. -->
+<svg width="100" height="100" viewBox="1 1 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path fill="#FFFFFF" fill-rule="evenodd" d="M23 12.245c0-.905-.075-1.565-.236-2.25h-10.54v4.083h6.186c-.124 1.014-.797 2.542-2.294 3.569l-.021.136 3.332 2.53.23.022C21.779 18.417 23 15.593 23 12.245z"/>
+  <path fill="#FFFFFF" fill-rule="evenodd" d="M12.225 23c3.03 0 5.574-.978 7.433-2.665l-3.542-2.688c-.948.648-2.22 1.1-3.891 1.1a6.745 6.745 0 01-6.386-4.572l-.132.011-3.465 2.628-.045.124C4.043 20.531 7.835 23 12.225 23z"/>
+  <path fill="#FFFFFF" fill-rule="evenodd" d="M5.84 14.175A6.65 6.65 0 015.463 12c0-.758.138-1.491.361-2.175l-.006-.147-3.508-2.67-.115.054A10.831 10.831 0 001 12c0 1.772.436 3.447 1.197 4.938l3.642-2.763z"/>
+  <path fill="#FFFFFF" fill-rule="evenodd" d="M12.225 5.253c2.108 0 3.529.892 4.34 1.638l3.167-3.031C17.787 2.088 15.255 1 12.225 1 7.834 1 4.043 3.469 2.197 7.062l3.63 2.763a6.77 6.77 0 016.398-4.572z"/>
+</svg>

--- a/Resources/ThirdPartyLicenses/LobeIcons.txt
+++ b/Resources/ThirdPartyLicenses/LobeIcons.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 LobeHub
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Scripts/build_app.sh
+++ b/Scripts/build_app.sh
@@ -106,7 +106,7 @@ for lang in en zh-Hans; do
         exit 1
     fi
 done
-for license_name in CodexBar SweetCookieKit Sparkle; do
+for license_name in CodexBar SweetCookieKit Sparkle LobeIcons; do
     if [[ ! -f "$APP_DIR/Contents/Resources/ThirdPartyLicenses/$license_name.txt" ]]; then
         echo "Packaged third-party license resources are incomplete." >&2
         exit 1

--- a/Sources/VibeBarApp/ProviderBrandIcon.swift
+++ b/Sources/VibeBarApp/ProviderBrandIcon.swift
@@ -24,7 +24,7 @@ enum ProviderBrandIcon {
     private static let cacheLimit = 512
 
     private struct SourceKey: Hashable {
-        let tool: ToolType
+        let name: String
         let width: CGFloat
         let height: CGFloat
     }
@@ -32,12 +32,23 @@ enum ProviderBrandIcon {
     private struct RenderKey: Hashable {
         /// `nil` is the Vibe Bar glyph drawn for a `MenuBarItemKind`, which
         /// ignores the kind itself.
-        let tool: ToolType?
+        let name: String?
         let width: CGFloat
         let height: CGFloat
         let tint: NSColor?
         let appearance: String?
         let includeStatusDot: Bool
+    }
+
+    /// Everything the pipeline needs to draw one mark: which art, and how far
+    /// past the canvas to draw it. `ToolType` and `BrandMark` both resolve to
+    /// one of these, so a brand no tool can name still shares the cache, the
+    /// tint compositing and the overshoot rule.
+    struct MarkSource {
+        let resourceName: String
+        let drawScale: CGFloat
+        /// Two brands ship as string literals rather than files on disk.
+        var inlineSVG: String?
     }
 
     static func image(
@@ -47,7 +58,7 @@ enum ProviderBrandIcon {
         appearance: NSAppearance? = nil
     ) -> NSImage? {
         let key = RenderKey(
-            tool: nil,
+            name: nil,
             width: size.width,
             height: size.height,
             tint: tint,
@@ -68,8 +79,26 @@ enum ProviderBrandIcon {
         tint: NSColor? = nil,
         appearance: NSAppearance? = nil
     ) -> NSImage? {
+        image(for: tool.markSource, size: size, tint: tint, appearance: appearance)
+    }
+
+    static func image(
+        for mark: BrandMark,
+        size: NSSize = NSSize(width: 16, height: 16),
+        tint: NSColor? = nil,
+        appearance: NSAppearance? = nil
+    ) -> NSImage? {
+        image(for: mark.markSource, size: size, tint: tint, appearance: appearance)
+    }
+
+    private static func image(
+        for mark: MarkSource,
+        size: NSSize,
+        tint: NSColor?,
+        appearance: NSAppearance?
+    ) -> NSImage? {
         let key = RenderKey(
-            tool: tool,
+            name: mark.resourceName,
             width: size.width,
             height: size.height,
             tint: tint,
@@ -77,7 +106,7 @@ enum ProviderBrandIcon {
             includeStatusDot: false
         )
         if let cached = renderCache[key] { return cached }
-        guard let source = sourceImage(for: tool, size: size) else { return nil }
+        guard let source = sourceImage(for: mark, size: size) else { return nil }
         guard let tint else {
             // The cached source stays untouched: `isTemplate` is a property of
             // the image object, and the tinted path draws from the same one.
@@ -90,7 +119,7 @@ enum ProviderBrandIcon {
             let image = NSImage(size: size)
             image.lockFocus()
             let rect = NSRect(origin: .zero, size: size)
-            let sourceRect = sourceDrawRect(for: tool, in: rect)
+            let sourceRect = sourceDrawRect(scale: mark.drawScale, in: rect)
             NSColor.clear.setFill()
             rect.fill()
             tint.setFill()
@@ -207,29 +236,23 @@ enum ProviderBrandIcon {
         }
     }
 
-    private static func sourceImage(for tool: ToolType, size: NSSize) -> NSImage? {
-        let key = SourceKey(tool: tool, width: size.width, height: size.height)
+    private static func sourceImage(for mark: MarkSource, size: NSSize) -> NSImage? {
+        let key = SourceKey(name: mark.resourceName, width: size.width, height: size.height)
         if let cached = sourceCache[key] { return cached }
-        guard let image = decodeSourceImage(for: tool, size: size) else { return nil }
+        guard let image = decodeSourceImage(for: mark, size: size) else { return nil }
         if sourceCache.count >= cacheLimit { sourceCache.removeAll(keepingCapacity: true) }
         sourceCache[key] = image
         return image
     }
 
-    private static func decodeSourceImage(for tool: ToolType, size: NSSize) -> NSImage? {
-        if let url = providerIconURL(for: tool),
+    private static func decodeSourceImage(for mark: MarkSource, size: NSSize) -> NSImage? {
+        if let url = providerIconURL(named: mark.resourceName),
            let image = NSImage(contentsOf: url) {
             image.size = size
             return image
         }
 
-        let svg: String? = switch tool {
-        case .codex: openAISVG
-        case .claude: claudeSVG
-        case .alibaba, .alibabaTokenPlan, .gemini, .antigravity, .grok, .copilot, .zai, .minimax, .kimi, .cursor, .mimo, .iflytek, .tencentHunyuan, .tencentTokenPlan, .volcengine, .volcengineAgentPlan, .baiduQianfan, .openCodeGo, .kilo, .kiro, .ollama, .openRouter, .warp:
-            nil
-        }
-        guard let svg, let image = NSImage(data: Data(svg.utf8)) else { return nil }
+        guard let svg = mark.inlineSVG, let image = NSImage(data: Data(svg.utf8)) else { return nil }
         image.size = size
         return image
     }
@@ -237,17 +260,16 @@ enum ProviderBrandIcon {
     /// Resolving a bundle resource hits the filesystem, so the answer is
     /// memoized alongside the decoded marks: `Bundle.main.url(forResource:)`
     /// used to run once per row per render.
-    private static var iconURLCache: [ToolType: URL?] = [:]
+    private static var iconURLCache: [String: URL?] = [:]
 
-    private static func providerIconURL(for tool: ToolType) -> URL? {
-        if let cached = iconURLCache[tool] { return cached }
-        let resolved = resolveProviderIconURL(for: tool)
-        iconURLCache[tool] = resolved
+    private static func providerIconURL(named name: String) -> URL? {
+        if let cached = iconURLCache[name] { return cached }
+        let resolved = resolveProviderIconURL(named: name)
+        iconURLCache[name] = resolved
         return resolved
     }
 
-    private static func resolveProviderIconURL(for tool: ToolType) -> URL? {
-        let name = tool.providerIconResourceName
+    private static func resolveProviderIconURL(named name: String) -> URL? {
         if let url = Bundle.main.url(
             forResource: name,
             withExtension: "svg",
@@ -266,8 +288,7 @@ enum ProviderBrandIcon {
         return nil
     }
 
-    private static func sourceDrawRect(for tool: ToolType, in rect: NSRect) -> NSRect {
-        let scale = tool.providerIconDrawScale
+    private static func sourceDrawRect(scale: CGFloat, in rect: NSRect) -> NSRect {
         let width = rect.width * scale
         let height = rect.height * scale
         return NSRect(
@@ -296,13 +317,13 @@ enum ProviderBrandIcon {
         return body()
     }
 
-    private static let openAISVG = """
+    static let openAISVG = """
     <svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path d="M83.7733 42.8087C84.6678 40.1149 84.9771 37.2613 84.6807 34.4385C84.3843 31.6156 83.489 28.8885 82.0544 26.4394C77.6908 18.8436 68.9203 14.9365 60.3548 16.7725C57.9831 14.1344 54.9591 12.1668 51.5864 11.0673C48.2137 9.96772 44.611 9.77498 41.1402 10.5084C37.6694 11.2418 34.4527 12.8755 31.8132 15.2455C29.1736 17.6155 27.204 20.6383 26.1024 24.0103C23.3212 24.5806 20.6938 25.738 18.3958 27.405C16.0977 29.0721 14.1819 31.2104 12.7765 33.6772C8.36538 41.2609 9.3669 50.8267 15.2527 57.3327C14.3549 60.0251 14.0424 62.8782 14.3361 65.7012C14.6298 68.5241 15.523 71.2518 16.9558 73.7017C21.325 81.3002 30.1011 85.207 38.6712 83.3686C40.5554 85.4904 42.8707 87.1858 45.4623 88.3416C48.0539 89.4975 50.8622 90.0871 53.6999 90.0713C62.4793 90.079 70.2575 84.4114 72.9393 76.0515C75.7201 75.4802 78.347 74.3225 80.6449 72.6555C82.9427 70.9886 84.8587 68.8507 86.2649 66.3846C90.6227 58.8145 89.6172 49.3005 83.7733 42.8087ZM53.6999 84.8356C50.1955 84.8411 46.801 83.6129 44.1116 81.3661L44.5848 81.098L60.5123 71.9043C60.9087 71.6718 61.2379 71.3402 61.4674 70.942C61.6969 70.5439 61.8189 70.0929 61.8215 69.6333V47.1769L68.5553 51.072C68.6225 51.1063 68.6694 51.1707 68.6814 51.2456V69.854C68.6641 78.1208 61.9667 84.8183 53.6999 84.8356ZM21.4977 71.0843C19.7402 68.0497 19.1092 64.4925 19.7156 61.0386L20.1885 61.3225L36.1321 70.5165C36.5266 70.748 36.9757 70.87 37.4331 70.87C37.8905 70.87 38.3396 70.748 38.7341 70.5165L58.21 59.2883V67.0628C58.2081 67.1031 58.1973 67.1424 58.1782 67.1779C58.1591 67.2134 58.1322 67.2441 58.0996 67.2678L41.9671 76.5722C34.798 80.7022 25.6388 78.2463 21.4977 71.0843ZM17.3026 36.3898C19.0723 33.3357 21.8655 31.0062 25.1878 29.8138V48.7376C25.1818 49.1949 25.2986 49.6453 25.5261 50.042C25.7535 50.4387 26.0833 50.7671 26.4809 50.9928L45.8622 62.1739L39.1283 66.069C39.0919 66.0883 39.0513 66.0984 39.0101 66.0984C38.9689 66.0984 38.9283 66.0883 38.8919 66.069L22.7908 56.7809C15.6359 52.6337 13.1822 43.4816 17.3026 36.3112V36.3898ZM72.624 49.2426L53.1792 37.9512L59.8976 34.0718C59.9341 34.0524 59.9747 34.0423 60.016 34.0423C60.0573 34.0423 60.0979 34.0524 60.1344 34.0718L76.2355 43.3761C78.6973 44.7966 80.7043 46.8882 82.0221 49.4065C83.3398 51.9249 83.914 54.7661 83.6775 57.5985C83.4411 60.431 82.4038 63.1377 80.6867 65.4027C78.9696 67.6677 76.6436 69.3975 73.9803 70.3901V51.466C73.9663 51.0096 73.834 50.5647 73.5962 50.1749C73.3584 49.7851 73.0234 49.4638 72.624 49.2426ZM79.3261 39.1657L78.8529 38.8815L62.9411 29.6089C62.5442 29.376 62.0924 29.2532 61.6322 29.2532C61.172 29.2532 60.7202 29.376 60.3233 29.6089L40.8629 40.8374V33.0628C40.8587 33.0233 40.8654 32.9834 40.882 32.9473C40.8987 32.9113 40.9248 32.8803 40.9575 32.8579L57.0586 23.5692C59.5263 22.1476 62.3478 21.458 65.193 21.5811C68.0382 21.7042 70.7896 22.6348 73.1253 24.2642C75.461 25.8936 77.2845 28.1543 78.3825 30.782C79.4806 33.4097 79.8077 36.2957 79.3257 39.1025V39.1657H79.3261ZM37.1888 52.9484L30.455 49.069C30.4213 49.0487 30.3925 49.0212 30.3707 48.9884C30.3488 48.9557 30.3345 48.9186 30.3286 48.8797V30.3188C30.3323 27.4714 31.1466 24.6839 32.6761 22.2822C34.2057 19.8805 36.3874 17.9639 38.9661 16.7564C41.5448 15.549 44.4139 15.1005 47.2381 15.4636C50.0622 15.8267 52.7247 16.9862 54.9141 18.8067L54.4409 19.0748L38.5134 28.2686C38.117 28.5011 37.7879 28.8327 37.5584 29.2308C37.329 29.629 37.207 30.0799 37.2045 30.5395L37.1888 52.9487V52.9484ZM40.8472 45.0632L49.5209 40.0643L58.21 45.0635V55.0615L49.5523 60.0608L40.8632 55.0615L40.8472 45.0632Z" fill="white"/>
     </svg>
     """
 
-    private static let claudeSVG = """
+    static let claudeSVG = """
     <svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path d="M25.7146 63.2153L41.4393 54.3917L41.7025 53.6226L41.4393 53.1976H40.6705L38.0394 53.0359L29.054 52.7929L21.2624 52.4691L13.7134 52.0644L11.8111 51.6594L10.0303 49.3118L10.2123 48.138L11.8111 47.0657L14.0981 47.2681L19.1574 47.6119L26.7467 48.138L32.2516 48.4618L40.4073 49.3118H41.7025L41.8846 48.7857L41.4393 48.4618L41.0955 48.138L33.243 42.8155L24.7432 37.1894L20.2909 33.9513L17.8824 32.3119L16.6684 30.774L16.1422 27.4147L18.328 25.0062L21.2624 25.2088L22.0112 25.4112L24.9861 27.6979L31.3407 32.616L39.6381 38.7273L40.8525 39.7391L41.3381 39.395L41.399 39.1523L40.8525 38.2415L36.3394 30.0858L31.5227 21.7883L29.3775 18.3478L28.811 16.2837C28.6087 15.4334 28.4669 14.7252 28.4669 13.8549L30.9563 10.4753L32.3321 10.0303L35.6515 10.4756L37.0479 11.6897L39.112 16.4052L42.4513 23.8327L47.6321 33.9313L49.15 36.9265L49.9594 39.6991L50.2632 40.5491H50.7894V40.0632L51.2141 34.3766L52.0035 27.3944L52.7726 18.4087L53.0358 15.8793L54.2905 12.8435L56.7795 11.2041L58.7224 12.135L60.3212 14.422L60.0986 15.899L59.1474 22.0718L57.2857 31.7458L56.0713 38.2218H56.7795L57.5892 37.4121L60.8677 33.061L66.3723 26.18L68.801 23.448L71.6342 20.4325L73.4556 18.9957H76.8962L79.4255 22.7601L78.2926 26.6456L74.7509 31.1384L71.8163 34.943L67.607 40.6097L64.9758 45.1431L65.2188 45.5072L65.8464 45.4466L75.358 43.4228L80.4984 42.4917L86.6304 41.4393L89.4033 42.7346L89.7065 44.0502L88.6135 46.7419L82.0566 48.3607L74.3662 49.8989L62.9118 52.6109L62.77 52.7121L62.9321 52.9144L68.0925 53.4L70.2987 53.5214H75.7021L85.7601 54.2702L88.3912 56.0108L89.9697 58.1358L89.7065 59.7545L85.6589 61.8189L80.1949 60.5236L67.4452 57.4881L63.0735 56.3952H62.4665V56.7596L66.1093 60.3213L72.7877 66.3523L81.1461 74.1236L81.5707 76.0462L80.4984 77.5638L79.3649 77.4021L72.0186 71.8772L69.1854 69.3879L62.77 63.9844H62.3453V64.5509L63.8223 66.7164L71.6342 78.4544L72.0389 82.0567L71.4725 83.2308L69.4487 83.939L67.2222 83.534L62.6485 77.1189L57.9333 69.8937L54.1284 63.4177L53.6631 63.6809L51.4167 87.8651L50.3644 89.0995L47.9356 90.0303L45.9121 88.4924L44.8392 86.0031L45.9118 81.0852L47.2071 74.6701L48.2594 69.5699L49.2106 63.2356L49.7773 61.131L49.7367 60.9892L49.2715 61.0498L44.4954 67.607L37.23 77.4224L31.4825 83.5746L30.1063 84.1211L27.7181 82.8864L27.9408 80.6805L29.2763 78.7177L37.2297 68.5988L42.026 62.3248L45.1227 58.7025L45.1024 58.176H44.9204L23.7917 71.8975L20.0274 72.3831L18.4083 70.8655L18.6106 68.3761L19.3798 67.5664L25.7343 63.195L25.7146 63.2153Z" fill="white"/>
     </svg>
@@ -425,6 +446,158 @@ struct ToolBrandBadge: View {
     }
 }
 
+/// A brand the `ToolType` axis cannot name.
+///
+/// That axis is L2 — the thing whose quota is being read. Two kinds of brand
+/// sit off it. An **L1 company** above a pair of tools: SpaceXAI over Grok and
+/// Cursor, Google AI over Gemini and AntiGravity. And an **L2 SubProvider that
+/// shares another tool's account**: Grok Bot's quota arrives inside Cursor's,
+/// so the tool axis says Cursor and only the bucket says otherwise.
+///
+/// Drawing those from a member is how the SpaceXAI tab wore Grok's slash, the
+/// Google AI tab wore Gemini's spark, and Grok Bot wore Cursor's cursor.
+enum BrandMark: String, CaseIterable, Hashable {
+    case spaceXAI
+    case googleAI
+    case grokBot
+
+    /// The L1 company mark for a core provider, where the company has one the
+    /// representative tool does not already wear. OpenAI and Anthropic are
+    /// absent on purpose: `ProviderIcon-codex` and `ProviderIcon-claude` *are*
+    /// those companies' marks, so their tabs were never wrong.
+    static func company(for tool: ToolType) -> BrandMark? {
+        switch tool.coreProviderRepresentative {
+        case .gemini: return .googleAI
+        case .grok:   return .spaceXAI
+        default:      return nil
+        }
+    }
+
+    /// The mark an L2 SubProvider wears when it is not its tool's own, keyed
+    /// by the bucket — the same seam `quotaSubProviderName(bucketID:)` names
+    /// it by, so the icon and the label can never disagree.
+    static func subProvider(tool: ToolType, bucketID: String?) -> BrandMark? {
+        guard tool == .cursor, bucketID == "grok_bot_weekly" else { return nil }
+        return .grokBot
+    }
+
+    var providerIconResourceName: String {
+        switch self {
+        case .spaceXAI: return "ProviderIcon-spacexai"
+        case .googleAI: return "ProviderIcon-googleai"
+        case .grokBot:  return "ProviderIcon-grokbot"
+        }
+    }
+
+    /// Drawn at exactly its canvas, unlike the tool marks.
+    ///
+    /// That 1.25 overshoot exists to push an anti-aliased boundary off the
+    /// edge of line work that stops short of it. All three of these arrived
+    /// already fitted to their own viewBox, and overshooting them crops the
+    /// Grok Bot disc into a squircle, bites the right side off Google's G,
+    /// and cuts the tips off the SpaceXAI wings. Checked by rendering each at
+    /// the 13pt the tab strip draws them at.
+    var providerIconDrawScale: CGFloat { 1 }
+
+    var fallbackSystemImage: String {
+        switch self {
+        case .spaceXAI: return "x.circle"
+        case .googleAI: return "g.circle"
+        case .grokBot:  return "circle.dashed"
+        }
+    }
+
+    var markSource: ProviderBrandIcon.MarkSource {
+        ProviderBrandIcon.MarkSource(
+            resourceName: providerIconResourceName,
+            drawScale: providerIconDrawScale
+        )
+    }
+}
+
+/// A brand mark that is not a tool, drawn exactly as `ToolBrandIconView` draws
+/// one that is.
+struct BrandMarkIconView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    let mark: BrandMark
+    var size: CGFloat = 16
+
+    var body: some View {
+        Group {
+            if let image = ProviderBrandIcon.image(
+                for: mark,
+                size: NSSize(width: size, height: size),
+                tint: NSColor.labelColor,
+                appearance: nsAppearance(for: colorScheme)
+            ) {
+                Image(nsImage: image)
+                    .resizable()
+                    .scaledToFit()
+            } else {
+                Image(systemName: mark.fallbackSystemImage)
+                    .resizable()
+                    .scaledToFit()
+            }
+        }
+        .frame(width: size, height: size)
+        .foregroundStyle(.primary)
+        .accessibilityHidden(true)
+    }
+
+    private func nsAppearance(for colorScheme: ColorScheme) -> NSAppearance? {
+        switch colorScheme {
+        case .dark:  return NSAppearance(named: .darkAqua)
+        case .light: return NSAppearance(named: .aqua)
+        @unknown default: return nil
+        }
+    }
+}
+
+/// Brand icon for a surface that names an L1 company — a tab, a sidebar row, a
+/// settings section heading. Falls back to the representative tool's mark
+/// where the company has no separate one.
+struct CompanyBrandIconView: View {
+    let tool: ToolType
+    var size: CGFloat = 16
+
+    var body: some View {
+        if let mark = BrandMark.company(for: tool) {
+            BrandMarkIconView(mark: mark, size: size)
+        } else {
+            ToolBrandIconView(tool: tool, size: size)
+        }
+    }
+}
+
+/// `ToolBrandBadge` for a surface that names an L1 company.
+struct CompanyBrandBadge: View {
+    let tool: ToolType
+    var iconSize: CGFloat = 17
+    var containerSize: CGFloat = 24
+
+    var body: some View {
+        CompanyBrandIconView(tool: tool, size: min(containerSize, max(iconSize, containerSize * 0.85)))
+            .frame(width: containerSize, height: containerSize, alignment: .center)
+            .accessibilityHidden(true)
+    }
+}
+
+/// Brand icon for a quota section: its tool's mark, unless the bucket names a
+/// SubProvider with one of its own.
+struct QuotaBrandIconView: View {
+    let tool: ToolType
+    let bucketID: String?
+    var size: CGFloat = 16
+
+    var body: some View {
+        if let mark = BrandMark.subProvider(tool: tool, bucketID: bucketID) {
+            BrandMarkIconView(mark: mark, size: size)
+        } else {
+            ToolBrandIconView(tool: tool, size: size)
+        }
+    }
+}
+
 extension ToolType {
     var providerIconResourceName: String {
         switch self {
@@ -453,6 +626,23 @@ extension ToolType {
         case .ollama:      return "ProviderIcon-ollama"
         case .openRouter:  return "ProviderIcon-openrouter"
         case .warp:        return "ProviderIcon-warp"
+        }
+    }
+
+    var markSource: ProviderBrandIcon.MarkSource {
+        ProviderBrandIcon.MarkSource(
+            resourceName: providerIconResourceName,
+            drawScale: providerIconDrawScale,
+            inlineSVG: inlineProviderIconSVG
+        )
+    }
+
+    /// Two brands never got a file: their paths live in `ProviderBrandIcon`.
+    var inlineProviderIconSVG: String? {
+        switch self {
+        case .codex:  return ProviderBrandIcon.openAISVG
+        case .claude: return ProviderBrandIcon.claudeSVG
+        default:      return nil
         }
     }
 

--- a/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
+++ b/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
@@ -580,7 +580,11 @@ struct MenuBarComposerEditor: View {
                         }
                     } label: {
                         HStack(spacing: 4) {
-                            ToolBrandIconView(tool: section.tool, size: 11)
+                            QuotaBrandIconView(
+                                tool: section.tool,
+                                bucketID: section.options.first?.bucketId,
+                                size: 11
+                            )
                             Text(section.title).font(.system(size: 11, weight: .medium))
                         }
                     }

--- a/Sources/VibeBarApp/Views/MenuBarFieldsEditor.swift
+++ b/Sources/VibeBarApp/Views/MenuBarFieldsEditor.swift
@@ -111,7 +111,8 @@ struct MenuBarFieldsEditor: View {
             ForEach(runs(shown)) { run in
                 if let company = run.companyName {
                     HStack(spacing: 6) {
-                        ToolBrandIconView(tool: run.tool, size: 12)
+                        // `companyName` is `vendorName` — an L1 heading.
+                        CompanyBrandIconView(tool: run.tool, size: 12)
                             .opacity(0.85)
                         Text(company)
                             .font(.caption2)
@@ -241,7 +242,11 @@ struct MenuBarFieldsEditor: View {
             ForEach(Array(sections.enumerated()), id: \.offset) { _, pair in
                 VStack(alignment: .leading, spacing: 6) {
                     HStack(spacing: 6) {
-                        ToolBrandIconView(tool: pair.section.tool, size: 13)
+                        QuotaBrandIconView(
+                            tool: pair.section.tool,
+                            bucketID: pair.section.fields.first?.bucketId,
+                            size: 13
+                        )
                             .opacity(0.85)
                         Text(pair.section.title)
                             .font(.caption)

--- a/Sources/VibeBarApp/Views/MiniWindowsSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/MiniWindowsSettingsSection.swift
@@ -426,7 +426,11 @@ struct MiniWindowsSettingsSection: View {
             ForEach(sections) { section in
                 VStack(alignment: .leading, spacing: 8) {
                     HStack(spacing: 6) {
-                        ToolBrandIconView(tool: section.tool, size: 13)
+                        QuotaBrandIconView(
+                            tool: section.tool,
+                            bucketID: section.entries.first?.option.bucketId,
+                            size: 13
+                        )
                             .opacity(0.85)
                         Text(section.title)
                             .font(.caption)
@@ -591,7 +595,8 @@ struct MiniWindowsSettingsSection: View {
                 ForEach(groups) { group in
                     if let company = group.companyName {
                         HStack(spacing: 6) {
-                            ToolBrandIconView(tool: group.tool, size: 12)
+                            // `companyName` is `vendorName` — an L1 heading.
+                            CompanyBrandIconView(tool: group.tool, size: 12)
                                 .opacity(0.85)
                             Text(company)
                                 .font(.caption2)

--- a/Sources/VibeBarApp/Views/Onboarding/OnboardingStepViews.swift
+++ b/Sources/VibeBarApp/Views/Onboarding/OnboardingStepViews.swift
@@ -349,7 +349,7 @@ struct OnboardingBrowserCookiesStep: View {
 
     private func providerRow(_ tool: ToolType, importing: Bool, saved: Bool, status: String?) -> some View {
         HStack(spacing: 10) {
-            ToolBrandBadge(tool: tool, iconSize: 17, containerSize: 24)
+            CompanyBrandBadge(tool: tool, iconSize: 17, containerSize: 24)
             Text(tool.vendorName)
                 .font(.system(size: 13, weight: .medium))
             Spacer(minLength: 12)

--- a/Sources/VibeBarApp/Views/Onboarding/OnboardingStepViews.swift
+++ b/Sources/VibeBarApp/Views/Onboarding/OnboardingStepViews.swift
@@ -101,7 +101,7 @@ private struct OnboardingCoreProviderCard: View {
     var body: some View {
         CardShell(density: density) {
             HStack(spacing: 10) {
-                ToolBrandBadge(tool: tool, iconSize: 20, containerSize: 26)
+                CompanyBrandBadge(tool: tool, iconSize: 20, containerSize: 26)
                 VStack(alignment: .leading, spacing: 1) {
                     Text(tool.vendorName)
                         .font(.system(size: 13, weight: .semibold))

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -1347,7 +1347,7 @@ private struct OverviewStatusSummaryCard: View {
                 // tile (height − chrome) / rows — at compact density that is
                 // 45 pt, and four points of air here were what pushed the
                 // detail line out of it.
-                ToolBrandIconView(tool: tool, size: density.bucketTitleFontSize + 6)
+                CompanyBrandIconView(tool: tool, size: density.bucketTitleFontSize + 6)
                     .opacity(0.9)
                     .frame(
                         width: density.bucketTitleFontSize + 6,

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -221,14 +221,25 @@ struct ProviderSectionTitle: View {
     let subtitleFontSize: CGFloat
     var iconSize: CGFloat = 17
     var badgeSize: CGFloat = 24
+    /// Nearly every caller titles this with `vendorName` — an L1 company — so
+    /// the company mark is the default and a product-level heading opts out.
+    var showsCompanyMark: Bool = true
 
     var body: some View {
         HStack(alignment: .center, spacing: 8) {
-            ToolBrandBadge(
-                tool: tool,
-                iconSize: iconSize,
-                containerSize: badgeSize
-            )
+            if showsCompanyMark {
+                CompanyBrandBadge(
+                    tool: tool,
+                    iconSize: iconSize,
+                    containerSize: badgeSize
+                )
+            } else {
+                ToolBrandBadge(
+                    tool: tool,
+                    iconSize: iconSize,
+                    containerSize: badgeSize
+                )
+            }
             HStack(alignment: .firstTextBaseline, spacing: 7) {
                 Text(title)
                     .font(.system(size: titleFontSize, weight: .semibold))
@@ -1037,7 +1048,9 @@ private struct GeminiCostEmptyCard: View {
                     titleFontSize: density.titleFontSize,
                     subtitleFontSize: density.subtitleFontSize,
                     iconSize: 16,
-                    badgeSize: 24
+                    badgeSize: 24,
+                    // Titled with the product, so it keeps the product's mark.
+                    showsCompanyMark: false
                 )
                 Spacer(minLength: 4)
             }

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -414,10 +414,13 @@ private struct OverviewSwitchIcon: View {
         // Overview with 13pt for the rest, and ProviderBrandIconView
         // for codex/claude with ToolBrandIconView for gemini/grok,
         // made the row read "高低不齐" (uneven baselines / sizes).
-        // One renderer (`ToolBrandIconView` driven off the L2-
-        // representative ToolType) keeps every tab visually pinned to
-        // the same baseline. Overview and Misc still get SF symbols
-        // because they aren't single-provider tabs.
+        // One renderer keeps every tab visually pinned to the same
+        // baseline. Overview and Misc still get SF symbols because
+        // they aren't single-provider tabs.
+        //
+        // The strip labels L1 companies, so it draws L1 marks:
+        // `CompanyBrandIconView` gives Google AI and SpaceXAI their own
+        // rather than borrowing Gemini's spark and Grok's slash.
         Group {
             switch page {
             case .overview:
@@ -434,9 +437,9 @@ private struct OverviewSwitchIcon: View {
             case .claude:
                 ToolBrandIconView(tool: .claude, size: Self.iconSize)
             case .googleAI:
-                ToolBrandIconView(tool: .gemini, size: Self.iconSize)
+                CompanyBrandIconView(tool: .gemini, size: Self.iconSize)
             case .grok:
-                ToolBrandIconView(tool: .grok, size: Self.iconSize)
+                CompanyBrandIconView(tool: .grok, size: Self.iconSize)
             }
         }
         .opacity(isSelected ? 1 : 0.72)
@@ -956,7 +959,7 @@ private struct GrokCombinedCard: View {
 
                 if showsGrokBot {
                     HStack(alignment: .center, spacing: 6) {
-                        ToolBrandIconView(tool: .grok, size: 13)
+                        BrandMarkIconView(mark: .grokBot, size: 13)
                             .opacity(0.85)
                         Text("Grok Bot")
                             .font(.system(size: max(10, density.subtitleFontSize), weight: .semibold))

--- a/Sources/VibeBarApp/Views/QuotaGroupCard.swift
+++ b/Sources/VibeBarApp/Views/QuotaGroupCard.swift
@@ -45,6 +45,10 @@ struct QuotaGroupModule: Identifiable {
     /// Gemini Web, AntiGravity, Grok, Cursor, or Grok Bot).
     let linkedSectionTitle: String?
     let linkedSectionIconTool: ToolType?
+    /// The bucket the linked section starts at, so its header can wear the
+    /// SubProvider's own mark where it has one — Grok Bot rides Cursor's
+    /// account, and only the bucket says so.
+    var linkedSectionBucketID: String?
     /// Set on the first card of the page. It inherits the provider header —
     /// brand icon, product name, plan badge, refresh button — that the single
     /// pre-split card carried at the top.
@@ -150,9 +154,8 @@ enum QuotaGroupModuleBuilder {
                         )
                     },
                     linkedSectionTitle: linkedSectionTitle,
-                    linkedSectionIconTool: head.tool == .cursor && head.bucket.id == "grok_bot_weekly"
-                        ? .grok
-                        : head.tool,
+                    linkedSectionIconTool: head.tool,
+                    linkedSectionBucketID: head.bucket.id,
                     showsProviderHeader: modules.isEmpty
                 )
             )
@@ -270,7 +273,11 @@ struct QuotaGroupCard: View {
                 // divider; the card boundary does that now, so only the name
                 // and brand icon survive.
                 HStack(alignment: .center, spacing: 6) {
-                    ToolBrandIconView(tool: module.linkedSectionIconTool ?? module.tool, size: 13)
+                    QuotaBrandIconView(
+                        tool: module.linkedSectionIconTool ?? module.tool,
+                        bucketID: module.linkedSectionBucketID,
+                        size: 13
+                    )
                         .opacity(0.85)
                     Text(linkedSectionTitle)
                         .font(.system(size: max(10, density.subtitleFontSize), weight: .semibold))

--- a/Sources/VibeBarApp/Views/ServiceStatusCard.swift
+++ b/Sources/VibeBarApp/Views/ServiceStatusCard.swift
@@ -82,7 +82,7 @@ private struct ServiceStatusRow: View {
 
         VStack(alignment: .leading, spacing: density.statusComponentSpacing + 2) {
             HStack(alignment: .center, spacing: 8) {
-                ToolBrandBadge(
+                CompanyBrandBadge(
                     tool: tool,
                     iconSize: density.bucketTitleFontSize + 3,
                     containerSize: density.bucketTitleFontSize + 10

--- a/Sources/VibeBarApp/Views/SettingsSidebarView.swift
+++ b/Sources/VibeBarApp/Views/SettingsSidebarView.swift
@@ -255,7 +255,9 @@ struct SettingsSidebarView: View {
         return sidebarRow(
             destination: .coreProvider(tool),
             title: coreProviderTitle(tool),
-            icon: AnyView(ToolBrandIconView(tool: tool, size: 17).frame(width: 20, height: 20)),
+            // The row is titled with the company (`coreProviderTitle`),
+            // so it is marked with the company too.
+            icon: AnyView(CompanyBrandIconView(tool: tool, size: 17).frame(width: 20, height: 20)),
             enabled: enabled,
             showsStatusDot: true,
             showsDragHandle: true

--- a/Sources/VibeBarApp/Views/SettingsView.swift
+++ b/Sources/VibeBarApp/Views/SettingsView.swift
@@ -729,7 +729,8 @@ struct SettingsView: View {
             environment.routeHealth[route]?.status == .ok
         }
         return HStack(spacing: 10) {
-            ToolBrandIconView(tool: representative, size: 20)
+            // `statusProviderName` is the L1 vendor, so this is a company row.
+            CompanyBrandIconView(tool: representative, size: 20)
                 .frame(width: 24, height: 24)
             VStack(alignment: .leading, spacing: 1) {
                 Text(representative.statusProviderName)
@@ -1287,10 +1288,11 @@ struct MiniWindowFieldProviderSection: Identifiable {
         .init(tool: .antigravity, title: ToolType.antigravity.toolName,    fields: MenuBarFieldCatalog.antigravityFields),
         .init(tool: .grok,        title: ToolType.grok.toolName,           fields: MenuBarFieldCatalog.grokFields),
         .init(tool: .cursor,      title: ToolType.cursor.toolName,         fields: MenuBarFieldCatalog.cursorFields),
-        // Grok Bot shares Cursor's adapter and brand icon but is a separate
-        // L2 SubProvider, so it gets its own header rather than an unexplained
-        // third row under Cursor. Sectioning is keyed by title, not by tool,
-        // because two sections legitimately share `.cursor`.
+        // Grok Bot shares Cursor's adapter but is a separate L2 SubProvider,
+        // so it gets its own header — and, since `BrandMark.subProvider`,
+        // its own mark — rather than an unexplained third row under Cursor.
+        // Sectioning is keyed by title, not by tool, because two sections
+        // legitimately share `.cursor`.
         .init(
             tool: .cursor,
             title: ToolType.cursor.quotaSubProviderName(bucketID: "grok_bot_weekly"),

--- a/Sources/VibeBarApp/Views/Workbench/UsageBreakdownTables.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageBreakdownTables.swift
@@ -495,7 +495,7 @@ struct UsageBreakdownTables: View {
     /// still follows the L1 company, matching the Harness Mix card.
     private func harnessCell(_ harness: Harness, _ column: UsageTableColumn) -> some View {
         HStack(spacing: 7) {
-            ToolBrandBadge(tool: harness.company, iconSize: 13, containerSize: 16)
+            CompanyBrandBadge(tool: harness.company, iconSize: 13, containerSize: 16)
             Text(harness.displayName)
                 .font(bodyFont)
                 .lineLimit(1)
@@ -512,7 +512,7 @@ struct UsageBreakdownTables: View {
         _ column: UsageTableColumn
     ) -> some View {
         HStack(spacing: 7) {
-            ToolBrandBadge(tool: tool, iconSize: 13, containerSize: 16)
+            CompanyBrandBadge(tool: tool, iconSize: 13, containerSize: 16)
             Text(name)
                 .font(bodyFont)
                 .lineLimit(1)

--- a/Sources/VibeBarApp/Views/Workbench/UsageCompositionCards.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageCompositionCards.swift
@@ -68,7 +68,7 @@ struct UsageCompositionCards: View {
         let tint = Theme.providerAccent(for: company)
         return VStack(spacing: 5) {
             HStack(spacing: 7) {
-                ToolBrandBadge(tool: company, iconSize: 12, containerSize: 19)
+                CompanyBrandBadge(tool: company, iconSize: 12, containerSize: 19)
                 VStack(alignment: .leading, spacing: 1) {
                     Text(row.harness.displayName)
                         .font(.system(size: density.subtitleFontSize, weight: .semibold))

--- a/Sources/VibeBarApp/Views/Workbench/UsageFiltersBar.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageFiltersBar.swift
@@ -90,7 +90,7 @@ struct UsageFiltersBar: View {
             model.toggleHarnesses(group.harnessSet)
         } label: {
             HStack(spacing: 4) {
-                ToolBrandIconView(tool: group.company, size: max(9, density.segmentedFontSize - 1))
+                CompanyBrandIconView(tool: group.company, size: max(9, density.segmentedFontSize - 1))
                 Text(group.company.vendorName)
                     .font(.system(size: max(9, density.segmentedFontSize - 2), weight: .semibold))
                     .tracking(0.3)

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -42,6 +42,23 @@ portions is included in this repository at the local license link above.
   notice file is bundled.
 - Third-party code: none. The package has no dependencies of its own.
 
+## Bundled assets
+
+### Lobe Icons
+
+- Project: [lobehub/lobe-icons](https://github.com/lobehub/lobe-icons)
+- Use in Vibe Bar: `Resources/ProviderIcons/ProviderIcon-googleai.svg` is
+  Google's four-segment G taken from that project's `icons/google.svg`, with
+  the viewBox cropped to the mark and the brand colours dropped because the
+  renderer tints the shape. No other provider icon comes from this project.
+- License: [MIT](Resources/ThirdPartyLicenses/LobeIcons.txt)
+  ([upstream](https://github.com/lobehub/lobe-icons/blob/master/LICENSE))
+- Copyright: Copyright (c) 2023 LobeHub
+
+Brand marks in `Resources/ProviderIcons/` remain the trademarks of their
+respective owners; Vibe Bar draws them to identify the service a quota belongs
+to, and the license above covers only the copied vector artwork.
+
 ## Direct dependencies
 
 ### SweetCookieKit 0.5.2


### PR DESCRIPTION
Three brands the `ToolType` axis cannot name were drawn with a member's logo: the **SpaceXAI** tab wore Grok's slash, the **Google AI** tab wore Gemini's spark, and **Grok Bot** — whose quota arrives inside Cursor's account — wore Cursor's cursor.

## The rule

`ToolType` is the L2 axis: the thing whose quota is read. `BrandMark` names what sits off it, and resolves by the same seams the *labels* already use, so an icon can never disagree with its own caption:

| resolver | keyed by | matches |
|---|---|---|
| `BrandMark.company(for:)` | `coreProviderRepresentative` | `coreProviderTitle`, `vendorName`, `statusProviderName` |
| `BrandMark.subProvider(tool:bucketID:)` | the bucket | `quotaSubProviderName(bucketID:)` |

`CompanyBrandIconView` / `CompanyBrandBadge` for a surface that names a company; `QuotaBrandIconView` for a quota section. OpenAI and Anthropic are deliberately absent from `company(for:)` — `ProviderIcon-codex` and `ProviderIcon-claude` *are* those companies' marks, so their tabs were never wrong.

Wired: the popover tab strip, the Grok Bot card header, the Settings sidebar rows and section summaries, the menu-bar field/composer palettes, the mini-window picker, and the three Workbench surfaces whose own comments already said "the badge follows the L1 company".

## Pipeline

`ProviderBrandIcon` now keys its source and render caches on the resource name rather than on `ToolType`, and both `ToolType` and `BrandMark` resolve to one `MarkSource` (resource name, draw scale, optional inline SVG). A mark that is not a tool shares the cache, the tint compositing and the overshoot rule instead of duplicating them.

## Art and provenance

- **SpaceXAI**, **Grok Bot** — delivered by Codex against `docs/handover-brand-icons.md`, traced from `x.ai/icon.png` and the Grok Bot announcement image. Both claims verified before wiring: all three cited URLs return 200, and the Grok Bot eye slots land within 0.005 of the diameter of the official mark's (`(0.052, −0.162)` / `(0.287, −0.268)` official vs `(0.051, −0.167)` / `(0.290, −0.268)` ours).
- **Google AI** — the four-segment G from [lobehub/lobe-icons](https://github.com/lobehub/lobe-icons) (MIT), viewBox cropped to the mark, brand colours dropped because the renderer tints the shape.

All three draw at scale **1**, not the tools' 1.25 overshoot. That overshoot exists to clip an anti-aliased boundary off line work that stops short of the edge; these arrived fitted to their own canvas, and overshooting them crops the Grok Bot disc into a squircle, bites the right side off the G, and cuts the tips off the SpaceXAI wings — verified by rendering each through the real pipeline at the 13pt the tab strip uses.

`swift build`, `swift test` (2272 passed), `build_app.sh release`, entitlements empty, and the new SVG confirmed inside `.build/Vibe Bar.app/Contents/Resources/ProviderIcons/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)