### PR TITLE
Draw Grok Bot sessions with Grok Bot's own mark

### DIFF
--- a/Sources/VibeBarApp/ProviderBrandIcon.swift
+++ b/Sources/VibeBarApp/ProviderBrandIcon.swift
@@ -632,6 +632,18 @@ enum BrandMark: String, CaseIterable, Hashable {
         }
     }
 
+    /// Whose palette entry tints this mark when a surface asks for colour.
+    ///
+    /// The marks have no accents of their own — `Theme.providerAccent` is
+    /// keyed by `ToolType` — so each borrows the one its company already
+    /// owns. Grok Bot is xAI's app, so it takes xAI's.
+    var accentTool: ToolType {
+        switch self {
+        case .spaceXAI, .grokBot: return .grok
+        case .googleAI:           return .gemini
+        }
+    }
+
     var markSource: ProviderBrandIcon.MarkSource {
         ProviderBrandIcon.MarkSource(
             resourceName: providerIconResourceName,
@@ -646,13 +658,18 @@ struct BrandMarkIconView: View {
     @Environment(\.colorScheme) private var colorScheme
     let mark: BrandMark
     var size: CGFloat = 16
+    /// Paint the mark in its company's colour — same terms, and the same
+    /// 3:1 lift, as `ToolBrandIconView.brandColored`.
+    var brandColored: Bool = false
 
     var body: some View {
         Group {
             if let image = ProviderBrandIcon.image(
                 for: mark,
                 size: NSSize(width: size, height: size),
-                tint: NSColor.labelColor,
+                tint: brandColored
+                    ? ProviderBrandIcon.brandAccent(for: mark.accentTool)
+                    : NSColor.labelColor,
                 appearance: nsAppearance(for: colorScheme)
             ) {
                 Image(nsImage: image)
@@ -665,7 +682,7 @@ struct BrandMarkIconView: View {
             }
         }
         .frame(width: size, height: size)
-        .foregroundStyle(.primary)
+        .foregroundStyle(brandColored ? Theme.providerAccent(for: mark.accentTool) : .primary)
         .accessibilityHidden(true)
     }
 
@@ -720,6 +737,50 @@ struct QuotaBrandIconView: View {
         } else {
             ToolBrandIconView(tool: tool, size: size)
         }
+    }
+}
+
+/// The mark a **harness** wears — the CLI or app a session came from.
+///
+/// Almost every harness is drawn as its own tool: Cursor gets Cursor's mark
+/// rather than xAI's, AntiGravity its own rather than Gemini's, while the
+/// chip that *groups* them still says "SpaceXAI" / "Google AI". Grok Bot is
+/// the one harness with no tool of its own — its quota rides in on Cursor's
+/// `grok_bot_weekly` bucket — so it is resolved to its own `BrandMark`
+/// instead of borrowing the account holder's mark or Grok Build's.
+struct HarnessBrandIconView: View {
+    let harness: Harness
+    var size: CGFloat = 16
+    var brandColored: Bool = false
+
+    var body: some View {
+        if let mark = harness.brandMark {
+            BrandMarkIconView(mark: mark, size: size, brandColored: brandColored)
+        } else {
+            ToolBrandIconView(tool: harness.quotaTool, size: size, brandColored: brandColored)
+        }
+    }
+}
+
+/// `HarnessBrandIconView` in the badge frame the session lists align on.
+struct HarnessBrandBadge: View {
+    let harness: Harness
+    var iconSize: CGFloat = 17
+    var containerSize: CGFloat = 24
+    var brandColored: Bool = false
+
+    var body: some View {
+        HarnessBrandIconView(harness: harness, size: iconSize, brandColored: brandColored)
+            .frame(width: containerSize, height: containerSize, alignment: .center)
+            .accessibilityHidden(true)
+    }
+}
+
+extension Harness {
+    /// The mark this harness wears when its quota tool is the wrong answer.
+    /// `nil` — the usual case — means "draw `quotaTool`".
+    var brandMark: BrandMark? {
+        self == .grokBot ? .grokBot : nil
     }
 }
 

--- a/Sources/VibeBarApp/Views/Workbench/SessionListView.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SessionListView.swift
@@ -198,8 +198,8 @@ private struct SessionRow: View {
                 // Brand-coloured on purpose: this list is scanned for
                 // "which harness was that", and colour finds a row faster
                 // than a 15pt silhouette does.
-                ToolBrandBadge(
-                    tool: summary.effectiveHarness.brandTool,
+                HarnessBrandBadge(
+                    harness: summary.effectiveHarness,
                     iconSize: 15,
                     containerSize: 20,
                     brandColored: true

--- a/Sources/VibeBarApp/Views/Workbench/SessionManagerPage.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SessionManagerPage.swift
@@ -15,28 +15,14 @@ extension SessionProvider {
         case .gemini:                .gemini
         case .antigravity:           .antigravity
         // Grok Bot is xAI's own app; it borrows Cursor's *quota* plumbing,
-        // never its brand. See `Harness.brandTool`.
+        // never its brand. This is the row *tint*, so xAI's colour is the
+        // right one even though the mark is Grok Bot's own — see
+        // `HarnessBrandIconView`.
         case .grokBot:               .grok
         }
     }
 
     var accent: Color { Theme.providerAccent(for: tool) }
-}
-
-extension Harness {
-    /// The brand this harness is drawn as — its own L2 tool, not the L1
-    /// company. Cursor gets the Cursor mark rather than Grok's, and
-    /// AntiGravity its own rather than Gemini's, while the *chip* that
-    /// groups them still says "SpaceXAI" / "Google AI".
-    ///
-    /// Grok Bot is the one harness whose quota tool is the wrong answer: its
-    /// weekly bucket rides in on Cursor's adapter, but a Grok Bot session was
-    /// produced by an xAI app and drawing it with Cursor's mark would say it
-    /// came from Cursor. There is no Grok Bot asset in `Resources/ProviderIcons`,
-    /// so it wears the Grok mark — the nearest brand that is actually true.
-    var brandTool: ToolType {
-        self == .grokBot ? .grok : quotaTool
-    }
 }
 
 /// The Workbench's Sessions page.
@@ -398,7 +384,7 @@ struct SessionFiltersBar: View {
                         // *user's* accent colour, which can be any hue, so no
                         // fixed brand tint can be guaranteed legible on it —
                         // and the label spells the harness out anyway.
-                        ToolBrandIconView(tool: harness.brandTool, size: 12)
+                        HarnessBrandIconView(harness: harness, size: 12)
                     }
                 }
             }

--- a/Sources/VibeBarApp/Views/Workbench/TranscriptView.swift
+++ b/Sources/VibeBarApp/Views/Workbench/TranscriptView.swift
@@ -524,8 +524,8 @@ struct SessionMetadataHeader: View {
     var body: some View {
         VStack(alignment: .leading, spacing: max(7, density.cardSpacing)) {
             HStack(alignment: .center, spacing: 10) {
-                ToolBrandBadge(
-                    tool: summary.effectiveHarness.brandTool,
+                HarnessBrandBadge(
+                    harness: summary.effectiveHarness,
                     iconSize: 20,
                     containerSize: 26,
                     brandColored: true

--- a/Sources/VibeBarApp/Views/Workbench/UsageFiltersBar.swift
+++ b/Sources/VibeBarApp/Views/Workbench/UsageFiltersBar.swift
@@ -127,7 +127,7 @@ struct UsageFiltersBar: View {
             }
         } label: {
             HStack(spacing: 5) {
-                ToolBrandIconView(tool: harness.brandTool, size: density.segmentedFontSize + 1)
+                HarnessBrandIconView(harness: harness, size: density.segmentedFontSize + 1)
                 Text(harness.displayName)
                     .font(.system(size: max(10, density.segmentedFontSize - 1), weight: .semibold))
                     .lineLimit(1)

--- a/Sources/VibeBarCore/Models/Harness+Quota.swift
+++ b/Sources/VibeBarCore/Models/Harness+Quota.swift
@@ -27,8 +27,8 @@ extension Harness {
         case .cursor:                   .cursor
         // Grok Bot has no tool of its own: its quota arrives as Cursor's
         // `grok_bot_weekly` bucket, which is also where the L1 company comes
-        // from. The Sessions badge deliberately draws the Grok mark instead
-        // — see `Harness.brandTool`.
+        // from. It does have its own brand mark, which is what the Sessions
+        // badge draws — see `HarnessBrandIconView` in the app target.
         case .grokBot:                  .cursor
         }
     }


### PR DESCRIPTION
AQ, looking at the Sessions list: *"这里没有新家的logo吗"*.

The company marks (SpaceXAI, Google AI) correctly do not appear there — that list is the **harness** axis, so each row wears its own L2 product mark. But Grok Bot was a real omission. It was drawn with Grok's slash, and the comment beside the mapping said why:

> There is no Grok Bot asset in `Resources/ProviderIcons`, so it wears the Grok mark — the nearest brand that is actually true.

#324 shipped that asset. So the substitution retires.

## What changed

`Harness.brandTool` is gone. In its place `HarnessBrandIconView` / `HarnessBrandBadge` take the harness itself and resolve it: Grok Bot to its own `BrandMark`, everything else to its `quotaTool`. Four call sites move over — the Sessions list rows, the transcript header, and the harness filter menus on both Sessions and Usage.

`BrandMarkIconView` gains the same `brandColored` opt-in `ToolBrandIconView` has, tinted through `BrandMark.accentTool` — the marks have no palette entries of their own, so each borrows its company's. Grok Bot takes xAI's, which is also what the selected row is already tinted with.

`SessionProvider.tool` still maps `.grokBot → .grok`. That one is the row *tint*, and xAI's colour is the right answer there even though the mark is now Grok Bot's own; its comment says so.

## Verification

`swift build`, `swift test` (2274 pass), `./Scripts/build_app.sh release`, `codesign -d --entitlements -` → empty dict.

Rendered the seven harness marks at their list size, light and dark, alternate rows shown selected — Grok Bot's disc is now distinct from Grok Build's slash at 15pt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)