### PR TITLE
Move Cursor into the SpaceXAI family's neutrals

### DIFF
--- a/Sources/VibeBarApp/Views/Theme.swift
+++ b/Sources/VibeBarApp/Views/Theme.swift
@@ -335,7 +335,13 @@ enum Theme {
         case .zai:         return Color(red: 0.26, green: 0.74, blue: 0.55)  // emerald
         case .minimax:     return Color(red: 0.97, green: 0.30, blue: 0.45)  // pink
         case .kimi:        return Color(red: 0.20, green: 0.20, blue: 0.20)  // ink
-        case .cursor:      return Color(red: 0.55, green: 0.55, blue: 0.96)  // periwinkle
+        // Cursor is in the SpaceXAI family (`coreProviderRepresentative`), so
+        // it wears that family's neutral rather than a hue of its own — which
+        // also matches its real monochrome mark. Its periwinkle sat 17° from
+        // AntiGravity's violet and 0° from Gemini's blue: three of the seven
+        // harnesses in one wedge, two of them from different companies.
+        // Separated from Grok's mid slate by lightness, not by hue.
+        case .cursor:      return adaptiveInkAccent
         case .mimo:        return Color(red: 0.97, green: 0.50, blue: 0.20)  // xiaomi orange
         case .iflytek:     return Color(red: 0.10, green: 0.37, blue: 0.75)  // iflytek blue
         case .tencentHunyuan:   return Color(red: 0.00, green: 0.49, blue: 0.91)  // tencent blue
@@ -359,6 +365,22 @@ enum Theme {
                     return NSColor(srgbRed: 0.68, green: 0.75, blue: 0.83, alpha: 1)
                 }
                 return NSColor(srgbRed: 0.30, green: 0.38, blue: 0.47, alpha: 1)
+            }
+        )
+    }
+
+    /// The SpaceXAI family's second neutral: near-ink on paper, near-paper on
+    /// ink. Far enough from `adaptiveNeutralAccent` in lightness to tell two
+    /// rows of one family apart (ΔE 23 in Aqua, 17 in Dark Aqua, measured
+    /// after `ProviderBrandIcon.brandAccent` lifts each to 3:1), while still
+    /// reading as the same neutral family rather than a colour of its own.
+    private static var adaptiveInkAccent: Color {
+        Color(
+            nsColor: NSColor(name: nil) { appearance in
+                if appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua {
+                    return NSColor(srgbRed: 0.88, green: 0.92, blue: 0.97, alpha: 1)
+                }
+                return NSColor(srgbRed: 0.13, green: 0.17, blue: 0.23, alpha: 1)
             }
         )
     }

--- a/Tests/VibeBarCoreTests/DesignTokenContractTests.swift
+++ b/Tests/VibeBarCoreTests/DesignTokenContractTests.swift
@@ -80,6 +80,9 @@ final class DesignTokenContractTests: XCTestCase {
         let contractAccents = try XCTUnwrap(
             contract()["providerAccent"] as? [String: Any]
         )
+        // Not literals in the palette, so the `red:`/`green:`/`blue:` scrape
+        // below cannot see them.
+        let appearanceDependentAccents: Set<String> = ["grok", "cursor"]
 
         let block = try XCTUnwrap(slice(
             source,
@@ -95,9 +98,12 @@ final class DesignTokenContractTests: XCTestCase {
             else { continue }
             found[tool] = hex(red, green, blue)
         }
-        // Grok resolves per appearance, so the contract stores two values.
-        XCTAssertNotNil(contractAccents["grok"] as? [String: String],
-                        "grok is appearance-dependent and must carry both values")
+        // The SpaceXAI family's two neutrals resolve per appearance, so the
+        // contract stores both values for each rather than one hex.
+        for tool in appearanceDependentAccents {
+            XCTAssertNotNil(contractAccents[tool] as? [String: String],
+                            "\(tool) is appearance-dependent and must carry both values")
+        }
 
         for (tool, colour) in found {
             XCTAssertEqual(
@@ -106,7 +112,7 @@ final class DesignTokenContractTests: XCTestCase {
             )
         }
         let contractNames = Set(contractAccents.keys)
-        let themeNames = Set(found.keys).union(["grok"])
+        let themeNames = Set(found.keys).union(appearanceDependentAccents)
         XCTAssertEqual(
             contractNames, themeNames,
             "the contract and Theme.providerAccent list different providers"
@@ -148,23 +154,33 @@ final class DesignTokenContractTests: XCTestCase {
         XCTAssertEqual(used["warningAtOrAbove"] as? Int, 70)
     }
 
-    /// Grok resolves per appearance, so both halves must come from
-    /// `adaptiveNeutralAccent` rather than being typed in. The first version
-    /// of this contract had a hand-written light value that did not match the
-    /// source, and nothing here noticed.
-    func testGrokAccentMatchesBothAppearances() throws {
+    /// The SpaceXAI family's two neutrals resolve per appearance, so both
+    /// halves of each must come from its own declaration rather than being
+    /// typed in. The first version of this contract had a hand-written light
+    /// value for Grok that did not match the source, and nothing here noticed.
+    func testTheAppearanceDependentAccentsMatchBothAppearances() throws {
         let source = try themeSource()
-        let block = try XCTUnwrap(slice(
-            source, from: "private static var adaptiveNeutralAccent", to: "static func barColor"
-        ))
-        let values = matches(block, #"srgbRed: ([\d.]+), green: ([\d.]+), blue: ([\d.]+)"#)
-            .map { hex($0[0], $0[1], $0[2]) }
-        XCTAssertEqual(values.count, 2, "expected a dark and a light value")
-
+        // Each is sliced to the *next* declaration: sharing one slice would
+        // let either one's pair satisfy the other's assertion.
+        let neutrals: [(tool: String, from: String, to: String)] = [
+            ("grok",
+             "private static var adaptiveNeutralAccent",
+             "private static var adaptiveInkAccent"),
+            ("cursor",
+             "private static var adaptiveInkAccent",
+             "static func barColor"),
+        ]
         let accents = try XCTUnwrap(contract()["providerAccent"] as? [String: Any])
-        let grok = try XCTUnwrap(accents["grok"] as? [String: String])
-        XCTAssertEqual(grok["dark"], values[0])
-        XCTAssertEqual(grok["light"], values[1])
+        for neutral in neutrals {
+            let block = try XCTUnwrap(slice(source, from: neutral.from, to: neutral.to))
+            let values = matches(block, #"srgbRed: ([\d.]+), green: ([\d.]+), blue: ([\d.]+)"#)
+                .map { hex($0[0], $0[1], $0[2]) }
+            XCTAssertEqual(values.count, 2, "\(neutral.tool): expected a dark and a light value")
+
+            let contractValue = try XCTUnwrap(accents[neutral.tool] as? [String: String])
+            XCTAssertEqual(contractValue["dark"], values[0], neutral.tool)
+            XCTAssertEqual(contractValue["light"], values[1], neutral.tool)
+        }
     }
 
     /// The card recipe is what makes a card in one client look like a card in

--- a/Tests/VibeBarCoreTests/DesignTokenContractTests.swift
+++ b/Tests/VibeBarCoreTests/DesignTokenContractTests.swift
@@ -162,16 +162,33 @@ final class DesignTokenContractTests: XCTestCase {
         let source = try themeSource()
         // Each is sliced to the *next* declaration: sharing one slice would
         // let either one's pair satisfy the other's assertion.
-        let neutrals: [(tool: String, from: String, to: String)] = [
-            ("grok",
+        let neutrals: [(tool: String, helper: String, from: String, to: String)] = [
+            ("grok", "adaptiveNeutralAccent",
              "private static var adaptiveNeutralAccent",
              "private static var adaptiveInkAccent"),
-            ("cursor",
+            ("cursor", "adaptiveInkAccent",
              "private static var adaptiveInkAccent",
              "static func barColor"),
         ]
         let accents = try XCTUnwrap(contract()["providerAccent"] as? [String: Any])
+        // The palette itself, so a case rewired to the *other* neutral is
+        // caught. Reading the helper alone would leave both tests passing
+        // while the app drew one pair and the contract published another.
+        let palette = try XCTUnwrap(slice(
+            source,
+            from: "static func providerAccent",
+            to: "private static var adaptiveNeutralAccent"
+        ))
         for neutral in neutrals {
+            let mapping = palette
+                .split(separator: "\n")
+                .first { $0.contains("case .\(neutral.tool):") }
+            XCTAssertNotNil(mapping, "\(neutral.tool) has no case in providerAccent")
+            XCTAssertTrue(
+                mapping?.contains("return \(neutral.helper)") == true,
+                "\(neutral.tool) must resolve through \(neutral.helper)"
+            )
+
             let block = try XCTUnwrap(slice(source, from: neutral.from, to: neutral.to))
             let values = matches(block, #"srgbRed: ([\d.]+), green: ([\d.]+), blue: ([\d.]+)"#)
                 .map { hex($0[0], $0[1], $0[2]) }

--- a/docs/contracts/design-tokens-v1.json
+++ b/docs/contracts/design-tokens-v1.json
@@ -12,7 +12,7 @@
     "surplus": "#338FE0",
     "watch": "#F59E33"
   },
-  "note": "Visual tokens both Vibe Bar clients render from. Extracted from the native Theme.swift, which remains the source of truth: change it there, regenerate this file, and both lanes' tests report whether either drifted. A provider that is teal in one client and green in the other is two providers as far as the reader is concerned. Colours are the Swift rounding of each channel \u2014 Int(value * 255 + 0.5) \u2014 so a lane using banker's rounding will disagree on the .5 cases and the tests will say so.",
+  "note": "Visual tokens both Vibe Bar clients render from. Extracted from the native Theme.swift, which remains the source of truth: change it there, regenerate this file, and both lanes' tests report whether either drifted. A provider that is teal in one client and green in the other is two providers as far as the reader is concerned. Colours are the Swift rounding of each channel — Int(value * 255 + 0.5) — so a lane using banker's rounding will disagree on the .5 cases and the tests will say so.",
   "providerAccent": {
     "alibaba": "#FF9E33",
     "alibabaTokenPlan": "#FF7A2E",
@@ -21,7 +21,10 @@
     "claude": "#ED6666",
     "codex": "#4DC7BD",
     "copilot": "#757575",
-    "cursor": "#8C8CF5",
+    "cursor": {
+      "dark": "#E0EBF7",
+      "light": "#212B3B"
+    },
     "gemini": "#579EF5",
     "grok": {
       "dark": "#ADBFD4",


### PR DESCRIPTION
AQ, on the Sessions list: *"Cursor为啥和agy是一个颜色"* — then *"cursor应该是spacexai一组的吧"*.

Both hold up.

## The collision is real

Measured on the lifted glyph tints, on the row they are actually drawn on:

| pair | Aqua ΔE | Dark Aqua ΔE |
|---|---|---|
| Cursor ↔ AntiGravity | 27.2 | 23.4 |
| Cursor ↔ Gemini | 19.5 | 21.8 |
| every other pair of the five coloured harnesses | 45.5 – 93.6 | — |

Cursor's periwinkle is hue 240°, AntiGravity's violet 257°, Gemini's blue 213° — three of the seven harnesses inside a 45° wedge, and the two closest of them belong to different companies.

## Where it should sit

`ToolType.cursor.coreProviderRepresentative` is `.grok`; `grokFamily` is `[.grok, .cursor]`. Cursor is SpaceXAI's, and it was wearing a colour that made it read as AntiGravity's sibling.

So it takes the family's neutral rather than a hue of its own — which is also faithful to Cursor's real mark, a monochrome cube. `adaptiveInkAccent` is near-ink in Aqua (`#212B3B`) and near-paper in Dark Aqua (`#E0EBF7`); Grok keeps the mid slate. They separate by lightness: ΔE 23.4 and 16.6.

The cost, stated plainly: three of the seven rows are now neutral (Cursor, Grok Build, Grok Bot), and they are told apart by their marks and by lightness rather than by hue. That is the trade this direction makes.

## Contract

`docs/contracts/design-tokens-v1.json` stores `cursor` as a `{light, dark}` pair now, the way `grok` already did — the other client reads the same file. `testTheAppearanceDependentAccentsMatchBothAppearances` slices each declaration separately, so one neutral's pair can no longer satisfy the other's assertion.

## Verification

`swift build`, `swift test` (2273 pass), `./Scripts/build_app.sh release`, `codesign -d --entitlements -` → empty dict. Rendered all seven harness marks at list size in both appearances, alternate rows selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)