### PR TITLE
Bump the build number to 69 for a Dev release

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -26,7 +26,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.6.2</string>
 	<key>CFBundleVersion</key>
-	<string>68</string>
+	<string>69</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
`CFBundleVersion` 68 → 69, same user-facing `1.6.2`. Tag `v1.6.2-dev.69` follows once this is on `main`.

Ships since dev.68:

- **#322** the menu-bar strip stops charging itself for padding it never reserves — the Custom strip was drawn ~8% smaller than Default
- **#323** the "Show title text" toggle retires
- **#324** SpaceXAI, Google AI and Grok Bot get their own marks
- **#325** the session lists draw their harness mark in the brand's colour, lifted to 3:1 against the row it lands on
- **#326** a block can be dragged straight out of the palette to where it goes
- **#327** Grok Bot sessions stop borrowing Grok's mark
- **#328** Grok Bot joins the SpaceXAI roster, and Cursor's cookie row becomes a sibling of Grok's rather than a cousin
- **#329** Cursor moves into the SpaceXAI family's neutrals, out of the blue-violet wedge it shared with Gemini and AntiGravity

🤖 Generated with [Claude Code](https://claude.com/claude-code)