### PR TITLE
Bump the build number to 70 for a Dev release

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -26,7 +26,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.6.2</string>
 	<key>CFBundleVersion</key>
-	<string>69</string>
+	<string>70</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
`CFBundleVersion` 69 → 70, same user-facing `1.6.2`. Tag `v1.6.2-dev.70` follows once this is on `main`.

Both changes since dev.69 are regressions that build shipped:

- **#332** every drag in the menu-bar composer was dead — palette blocks *and* reordering existing chips. A private `UTType` the app does not declare meant the drop targets refused their own payload. Verified fixed by dragging in the running app, not by building it.
- **#331** the SpaceXAI, Google AI and Grok Bot marks drew a faint frame around themselves, because they were the only icons authored without the margin the 1.25 overshoot crops away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)