### PR TITLE
Give the composer segments and real groups

### DIFF
--- a/Resources/i18n/en.json
+++ b/Resources/i18n/en.json
@@ -779,52 +779,28 @@
     "comment": "Picker choosing a block's type weight.",
     "value": "Weight"
   },
-  "menuBar.composer.group.add": {
-    "comment": "Palette button adding an empty group to the strip.",
-    "value": "New group"
+  "menuBar.composer.group.bind": {
+    "comment": "Button that binds the selected blocks into one run",
+    "value": "Group"
   },
-  "menuBar.composer.group.addHelp": {
-    "comment": "Tooltip on the New group button.",
-    "value": "Each group is one column of the strip. Give a group a second row to stack that column."
+  "menuBar.composer.group.hint": {
+    "comment": "Explains how to bind blocks and what binding does",
+    "value": "Shift-click blocks that sit side by side in one row. A group moves as one — drag any block in it and the whole run goes."
   },
-  "menuBar.composer.group.addRow": {
-    "comment": "Menu item giving a group a second row.",
-    "value": "Add a second row"
+  "menuBar.composer.group.notAdjacent": {
+    "comment": "Shown when the selected blocks cannot be bound",
+    "value": "Only blocks side by side in one row can be grouped."
   },
-  "menuBar.composer.group.empty": {
-    "comment": "Shown inside a group that has no blocks yet.",
-    "value": "Empty group — drag a block in."
-  },
-  "menuBar.composer.group.mergeLeft": {
-    "comment": "Menu action folding a group into the one before it.",
-    "value": "Merge into the group before it"
-  },
-  "menuBar.composer.group.moveLeft": {
-    "comment": "Menu action moving a group one place earlier.",
-    "value": "Move left"
-  },
-  "menuBar.composer.group.moveRight": {
-    "comment": "Menu action moving a group one place later.",
-    "value": "Move right"
-  },
-  "menuBar.composer.group.remove": {
-    "comment": "Menu action deleting a group and the blocks in it.",
-    "value": "Remove group and its blocks"
-  },
-  "menuBar.composer.group.removeRow": {
-    "comment": "Menu item closing a group's second row; its blocks join the end of the first.",
-    "value": "Merge the second row up"
-  },
-  "menuBar.composer.group.splitHere": {
-    "comment": "Button starting a new group at the selected block.",
-    "value": "Start a group here"
-  },
-  "menuBar.composer.group.title": {
+  "menuBar.composer.group.selected": {
     "args": {
-      "index": "int"
+      "count": "int"
     },
-    "comment": "Header over one group of blocks. Index counts from 1.",
-    "value": "Group {index}"
+    "comment": "Caption above the grouping actions, counting the selected blocks",
+    "value": "{count, plural, one {1 block selected} other {# blocks selected}}"
+  },
+  "menuBar.composer.group.unbind": {
+    "comment": "Button that unbinds a run of blocks",
+    "value": "Ungroup"
   },
   "menuBar.composer.metric.displayPercent": {
     "comment": "Quota metric: whichever percentage the app-wide Used/Remaining setting selects.",
@@ -900,7 +876,7 @@
   },
   "menuBar.composer.preset.insertHelp": {
     "comment": "Tooltip on a saved group.",
-    "value": "Insert this group at the end of the strip."
+    "value": "Insert this segment at the end of the strip."
   },
   "menuBar.composer.preset.name": {
     "comment": "Text field for the name of a saved group.",
@@ -920,11 +896,11 @@
   },
   "menuBar.composer.preset.saveTitle": {
     "comment": "Title of the dialog naming a saved group.",
-    "value": "Save this group"
+    "value": "Save this segment"
   },
   "menuBar.composer.presets": {
     "comment": "Caption over the saved groups that can be inserted.",
-    "value": "Saved groups"
+    "value": "Saved segments"
   },
   "menuBar.composer.preview": {
     "comment": "Caption over the live preview of the composed strip.",
@@ -997,6 +973,53 @@
   "menuBar.composer.rule.whenUsedAtLeast": {
     "comment": "Visibility rule: show once a quota's used percentage reaches a threshold.",
     "value": "When used is at least"
+  },
+  "menuBar.composer.segment.add": {
+    "comment": "Palette button adding an empty group to the strip.",
+    "value": "New segment"
+  },
+  "menuBar.composer.segment.addHelp": {
+    "comment": "Tooltip on the New group button.",
+    "value": "Each segment is one column of the strip. Give a segment a second row to stack that column."
+  },
+  "menuBar.composer.segment.addRow": {
+    "comment": "Menu item giving a group a second row.",
+    "value": "Add a second row"
+  },
+  "menuBar.composer.segment.empty": {
+    "comment": "Shown inside a group that has no blocks yet.",
+    "value": "Empty segment — drag a block in."
+  },
+  "menuBar.composer.segment.mergeLeft": {
+    "comment": "Menu action folding a group into the one before it.",
+    "value": "Merge into the segment before it"
+  },
+  "menuBar.composer.segment.moveLeft": {
+    "comment": "Menu action moving a group one place earlier.",
+    "value": "Move left"
+  },
+  "menuBar.composer.segment.moveRight": {
+    "comment": "Menu action moving a group one place later.",
+    "value": "Move right"
+  },
+  "menuBar.composer.segment.remove": {
+    "comment": "Menu action deleting a group and the blocks in it.",
+    "value": "Remove segment and its blocks"
+  },
+  "menuBar.composer.segment.removeRow": {
+    "comment": "Menu item closing a group's second row; its blocks join the end of the first.",
+    "value": "Merge the second row up"
+  },
+  "menuBar.composer.segment.splitHere": {
+    "comment": "Button starting a new group at the selected block.",
+    "value": "Start a segment here"
+  },
+  "menuBar.composer.segment.title": {
+    "args": {
+      "index": "int"
+    },
+    "comment": "Header over one group of blocks. Index counts from 1.",
+    "value": "Segment {index}"
   },
   "menuBar.composer.selected": {
     "comment": "Caption over the controls for the selected block.",

--- a/Resources/i18n/zh-Hans.json
+++ b/Resources/i18n/zh-Hans.json
@@ -536,38 +536,20 @@
   "menuBar.composer.field.weight": {
     "value": "字重"
   },
-  "menuBar.composer.group.add": {
-    "value": "新建分组"
+  "menuBar.composer.group.bind": {
+    "value": "成组"
   },
-  "menuBar.composer.group.addHelp": {
-    "value": "每个分组是条带中的一列。为分组添加第二行可让该列上下堆叠。"
+  "menuBar.composer.group.hint": {
+    "value": "按住 Shift 点选同一行里相邻的积木。成组后它们作为整体移动 —— 拖其中任意一个，整组一起走。"
   },
-  "menuBar.composer.group.addRow": {
-    "value": "添加第二行"
+  "menuBar.composer.group.notAdjacent": {
+    "value": "只有同一行里相邻的积木才能成组。"
   },
-  "menuBar.composer.group.empty": {
-    "value": "空分组，可将积木拖入。"
+  "menuBar.composer.group.selected": {
+    "value": "{count, plural, other {已选 # 个积木}}"
   },
-  "menuBar.composer.group.mergeLeft": {
-    "value": "并入前一个分组"
-  },
-  "menuBar.composer.group.moveLeft": {
-    "value": "向左移动"
-  },
-  "menuBar.composer.group.moveRight": {
-    "value": "向右移动"
-  },
-  "menuBar.composer.group.remove": {
-    "value": "删除分组及其积木"
-  },
-  "menuBar.composer.group.removeRow": {
-    "value": "将第二行并入第一行"
-  },
-  "menuBar.composer.group.splitHere": {
-    "value": "从此处开始新分组"
-  },
-  "menuBar.composer.group.title": {
-    "value": "分组 {index}"
+  "menuBar.composer.group.unbind": {
+    "value": "解组"
   },
   "menuBar.composer.metric.displayPercent": {
     "value": "百分比（跟随设置）"
@@ -624,7 +606,7 @@
     "value": "添加积木"
   },
   "menuBar.composer.preset.insertHelp": {
-    "value": "在条带末尾插入该分组。"
+    "value": "在条带末尾插入该段。"
   },
   "menuBar.composer.preset.name": {
     "value": "名称"
@@ -639,10 +621,10 @@
     "value": "保存"
   },
   "menuBar.composer.preset.saveTitle": {
-    "value": "保存该分组"
+    "value": "保存该段"
   },
   "menuBar.composer.presets": {
-    "value": "已存分组"
+    "value": "已存的段"
   },
   "menuBar.composer.preview": {
     "value": "预览"
@@ -697,6 +679,39 @@
   },
   "menuBar.composer.rule.whenUsedAtLeast": {
     "value": "已用不低于"
+  },
+  "menuBar.composer.segment.add": {
+    "value": "新建段"
+  },
+  "menuBar.composer.segment.addHelp": {
+    "value": "每个段是条带中的一列。为段添加第二行可让该列上下堆叠。"
+  },
+  "menuBar.composer.segment.addRow": {
+    "value": "添加第二行"
+  },
+  "menuBar.composer.segment.empty": {
+    "value": "空段，可将积木拖入。"
+  },
+  "menuBar.composer.segment.mergeLeft": {
+    "value": "并入前一个段"
+  },
+  "menuBar.composer.segment.moveLeft": {
+    "value": "向左移动"
+  },
+  "menuBar.composer.segment.moveRight": {
+    "value": "向右移动"
+  },
+  "menuBar.composer.segment.remove": {
+    "value": "删除该段及其积木"
+  },
+  "menuBar.composer.segment.removeRow": {
+    "value": "将第二行并入第一行"
+  },
+  "menuBar.composer.segment.splitHere": {
+    "value": "从此处开始新的段"
+  },
+  "menuBar.composer.segment.title": {
+    "value": "段 {index}"
   },
   "menuBar.composer.selected": {
     "value": "已选积木"

--- a/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
+++ b/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
@@ -888,12 +888,12 @@ struct MenuBarComposerEditor: View {
                 HStack(spacing: 8) {
                     caption(L10n.MenuBar.composerSelected)
                     Spacer(minLength: 8)
-                    // Only where it would do something: a block that already
-                    // starts its segment has no segment to start, and a column is
-                    // cut through its top row — see `splitSegment`.
-                    if let location = composition.location(of: id),
-                       location.row == .top,
-                       location.offset > 0 {
+                    // Only where it would do something — the model's own
+                    // predicate, so a visible action is never a no-op. A block
+                    // that already starts its segment has none to start, a
+                    // column is cut through its top row, and a cut through a
+                    // bound run is refused.
+                    if composition.canSplitSegment(before: id) {
                         Button(L10n.MenuBar.composerSegmentSplitHere) {
                             mutate { $0.splitSegment(before: id) }
                         }

--- a/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
+++ b/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
@@ -151,11 +151,14 @@ struct MenuBarComposerEditor: View {
     var body: some View {
         let composition = displayedComposition
         let availability = composition.availability(liveFieldIds: liveFieldIds)
+        // One walk of the strip per body pass. Asking the composition per chip
+        // walked it once per chip — quadratic in a strip the user can grow.
+        let bound = composition.boundGroupIDs
 
         VStack(alignment: .leading, spacing: density.cardSpacing + 4) {
             templateRow(composition)
             previewRow(composition)
-            stripRow(composition, availability: availability)
+            stripRow(composition, availability: availability, bound: bound)
             paletteRow(composition)
             inspectorRow(composition, availability: availability)
             footerRow(availability: availability)
@@ -288,7 +291,8 @@ struct MenuBarComposerEditor: View {
 
     private func stripRow(
         _ composition: MenuBarComposition,
-        availability: MenuBarComposition.Availability
+        availability: MenuBarComposition.Availability,
+        bound: Set<UUID>
     ) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             caption(L10n.MenuBar.composerBlocks)
@@ -309,11 +313,11 @@ struct MenuBarComposerEditor: View {
                             .font(.caption)
                             .foregroundStyle(.tertiary)
                     } else {
-                        segmentFlow(composition, availability: availability)
+                        segmentFlow(composition, availability: availability, bound: bound)
                     }
                 }
             } else {
-                segmentFlow(composition, availability: availability)
+                segmentFlow(composition, availability: availability, bound: bound)
             }
             removeTarget
         }
@@ -323,11 +327,12 @@ struct MenuBarComposerEditor: View {
     /// strip can hold more columns than one line of this settings pane is wide.
     private func segmentFlow(
         _ composition: MenuBarComposition,
-        availability: MenuBarComposition.Availability
+        availability: MenuBarComposition.Availability,
+        bound: Set<UUID>
     ) -> some View {
         MenuBarChipFlow(spacing: 8, lineSpacing: 8) {
             ForEach(Array(composition.segments.enumerated()), id: \.element.id) { index, segment in
-                segmentBox(segment, index: index, of: composition, availability: availability)
+                segmentBox(segment, index: index, of: composition, availability: availability, bound: bound)
             }
         }
     }
@@ -337,7 +342,8 @@ struct MenuBarComposerEditor: View {
         _ segment: MenuBarSegment,
         index: Int,
         of composition: MenuBarComposition,
-        availability: MenuBarComposition.Availability
+        availability: MenuBarComposition.Availability,
+        bound: Set<UUID>
     ) -> some View {
         VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 4) {
@@ -397,12 +403,12 @@ struct MenuBarComposerEditor: View {
             // rather than a marker sitting among them. Each row is its own
             // drop target: dragging between the two rows of one segment and
             // dragging between segments are the same gesture.
-            rowStrip(segment, row: .top, availability: availability)
+            rowStrip(segment, row: .top, availability: availability, bound: bound)
             if segment.isStacked {
                 Rectangle()
                     .fill(Color.primary.opacity(0.10))
                     .frame(height: 0.5)
-                rowStrip(segment, row: .bottom, availability: availability)
+                rowStrip(segment, row: .bottom, availability: availability, bound: bound)
             }
         }
         .padding(.horizontal, 6)
@@ -422,7 +428,8 @@ struct MenuBarComposerEditor: View {
     private func rowStrip(
         _ segment: MenuBarSegment,
         row: MenuBarSegment.Row,
-        availability: MenuBarComposition.Availability
+        availability: MenuBarComposition.Availability,
+        bound: Set<UUID>
     ) -> some View {
         let address = MenuBarComposition.RowAddress(segment: segment.id, row: row)
         let tokens = segment[row]
@@ -456,11 +463,11 @@ struct MenuBarComposerEditor: View {
                     .foregroundStyle(.tertiary)
                     .frame(minWidth: 96, minHeight: 22, alignment: .leading)
                 } else {
-                    chipFlow(tokens, address: address, availability: availability)
+                    chipFlow(tokens, address: address, availability: availability, bound: bound)
                 }
             }
         } else {
-            chipFlow(tokens, address: address, availability: availability)
+            chipFlow(tokens, address: address, availability: availability, bound: bound)
         }
     }
 
@@ -475,11 +482,12 @@ struct MenuBarComposerEditor: View {
     private func chipFlow(
         _ tokens: [MenuBarToken],
         address: MenuBarComposition.RowAddress,
-        availability: MenuBarComposition.Availability
+        availability: MenuBarComposition.Availability,
+        bound: Set<UUID>
     ) -> some View {
         MenuBarChipFlow(spacing: 5, lineSpacing: 5) {
             ForEach(tokens) { token in
-                chip(token, availability: availability)
+                chip(token, availability: availability, bound: bound)
                     .onDrag {
                         // A queued colour or threshold has to land first:
                         // the drop writes this snapshot back wholesale, so
@@ -554,12 +562,13 @@ struct MenuBarComposerEditor: View {
 
     private func chip(
         _ token: MenuBarToken,
-        availability: MenuBarComposition.Availability
+        availability: MenuBarComposition.Availability,
+        bound: Set<UUID>
     ) -> some View {
         let isSelected = selection.contains(token.id)
         let isSilent = availability.silentTokenIds.contains(token.id)
         let isDegraded = availability.degradedTokenIds.contains(token.id)
-        let bound = isGrouped(token.id)
+        let isBound = token.groupID.map(bound.contains) ?? false
         return Button {
             selection = isSelected && selection.count == 1 ? [] : [token.id]
         } label: {
@@ -585,7 +594,7 @@ struct MenuBarComposerEditor: View {
             .background(
                 RoundedRectangle(cornerRadius: 5, style: .continuous)
                     .fill(
-                        bound
+                        isBound
                             ? Color.accentColor.opacity(isSelected ? 0.30 : 0.16)
                             : Color.primary.opacity(isSelected ? 0.14 : 0.06)
                     )
@@ -595,7 +604,7 @@ struct MenuBarComposerEditor: View {
                     .strokeBorder(
                         isSelected
                             ? Color.accentColor.opacity(0.8)
-                            : (bound
+                            : (isBound
                                 ? Color.accentColor.opacity(0.45)
                                 : Color.primary.opacity(0.10)),
                         lineWidth: 0.5
@@ -649,10 +658,6 @@ struct MenuBarComposerEditor: View {
     /// exists only to bind a run; every other control edits a single block.
     private var selectedID: UUID? {
         selection.count == 1 ? selection.first : nil
-    }
-
-    private func isGrouped(_ id: UUID) -> Bool {
-        displayedComposition.isGrouped(id)
     }
 
     private func symbol(for kind: MenuBarToken.Kind) -> String {

--- a/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
+++ b/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
@@ -28,7 +28,10 @@ struct MenuBarComposerEditor: View {
     /// Holds a debounced control's last change until a moment this view can
     /// observe — see `MenuBarPendingCommit`.
     @StateObject private var pendingCommit = PendingEditQueue()
-    @State private var selection: UUID?
+    /// The blocks the editor is acting on. More than one only while the user
+    /// is picking a run to bind: the inspector edits a single block, and
+    /// everything else that reads this wants the one.
+    @State private var selection: Set<UUID> = []
     @State private var draggedTokenId: UUID?
     /// The order the strip *would* have if the drag ended here.
     ///
@@ -63,7 +66,7 @@ struct MenuBarComposerEditor: View {
     @State private var dragCancelTask: Task<Void, Never>?
     @State private var isOverRemoveTarget = false
     @State private var isConfirmingReseed = false
-    /// The group whose "Save as preset…" dialog is open, and the name being
+    /// The segment whose "Save as preset…" dialog is open, and the name being
     /// typed into it.
     @State private var savingPresetFrom: UUID?
     @State private var presetDraftName = ""
@@ -264,7 +267,7 @@ struct MenuBarComposerEditor: View {
                         quotas: snapshots,
                         displayMode: settingsStore.settings.displayMode,
                         template: composition.template,
-                        highlighted: selection
+                        highlighted: selectedID
                     )
                     Text(L10n.MenuBar.composerPreviewGrounds)
                         .font(.caption2)
@@ -316,7 +319,7 @@ struct MenuBarComposerEditor: View {
         }
     }
 
-    /// The groups themselves wrap, the same way the chips inside them do — a
+    /// The segments themselves wrap, the same way the chips inside them do — a
     /// strip can hold more columns than one line of this settings pane is wide.
     private func segmentFlow(
         _ composition: MenuBarComposition,
@@ -329,7 +332,7 @@ struct MenuBarComposerEditor: View {
         }
     }
 
-    /// One group: a header that can move, save or remove it, then its blocks.
+    /// One segment: a header that can move, save or remove it, then its blocks.
     private func segmentBox(
         _ segment: MenuBarSegment,
         index: Int,
@@ -338,36 +341,36 @@ struct MenuBarComposerEditor: View {
     ) -> some View {
         VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 4) {
-                Text(L10n.MenuBar.composerGroupTitle(index: index + 1))
+                Text(L10n.MenuBar.composerSegmentTitle(index: index + 1))
                     .font(.system(size: 9, weight: .semibold))
                     .foregroundStyle(.tertiary)
                     .textCase(.uppercase)
                 Spacer(minLength: 4)
                 Menu {
-                    Button(L10n.MenuBar.composerGroupMoveLeft) {
+                    Button(L10n.MenuBar.composerSegmentMoveLeft) {
                         mutate { $0.moveSegment(segment.id, by: -1) }
                     }
                     .disabled(index == 0)
-                    Button(L10n.MenuBar.composerGroupMoveRight) {
+                    Button(L10n.MenuBar.composerSegmentMoveRight) {
                         mutate { $0.moveSegment(segment.id, by: 1) }
                     }
                     .disabled(index == composition.segments.count - 1)
-                    Button(L10n.MenuBar.composerGroupMergeLeft) {
+                    Button(L10n.MenuBar.composerSegmentMergeLeft) {
                         mutate { $0.mergeSegmentIntoPrevious(segment.id) }
                     }
                     .disabled(index == 0)
                     Divider()
-                    // The two row interactions, on the group rather than in
+                    // The two row interactions, on the segment rather than in
                     // the palette: a row is a container, so opening and
                     // closing one is something you do *to a column*. Removing
                     // one says where its blocks go, which is why the label
                     // says "merge" rather than "remove" — nothing is deleted.
                     if segment.isStacked {
-                        Button(L10n.MenuBar.composerGroupRemoveRow) {
+                        Button(L10n.MenuBar.composerSegmentRemoveRow) {
                             mutate { $0.removeRow(fromSegment: segment.id) }
                         }
                     } else {
-                        Button(L10n.MenuBar.composerGroupAddRow) {
+                        Button(L10n.MenuBar.composerSegmentAddRow) {
                             mutate { $0.addRow(toSegment: segment.id) }
                         }
                     }
@@ -378,10 +381,8 @@ struct MenuBarComposerEditor: View {
                     }
                     .disabled(segment.isEmpty)
                     Divider()
-                    Button(L10n.MenuBar.composerGroupRemove, role: .destructive) {
-                        if let selection, segment.tokens.contains(where: { $0.id == selection }) {
-                            self.selection = nil
-                        }
+                    Button(L10n.MenuBar.composerSegmentRemove, role: .destructive) {
+                        selection.subtract(segment.tokens.map(\.id))
                         mutate { $0.removeSegment(segment.id) }
                     }
                 } label: {
@@ -394,8 +395,8 @@ struct MenuBarComposerEditor: View {
             }
             // One list of chips per row, so a row is somewhere blocks live
             // rather than a marker sitting among them. Each row is its own
-            // drop target: dragging between the two rows of one group and
-            // dragging between groups are the same gesture.
+            // drop target: dragging between the two rows of one segment and
+            // dragging between segments are the same gesture.
             rowStrip(segment, row: .top, availability: availability)
             if segment.isStacked {
                 Rectangle()
@@ -416,7 +417,7 @@ struct MenuBarComposerEditor: View {
         )
     }
 
-    /// One row of one group: its chips, and the empty space after them.
+    /// One row of one segment: its chips, and the empty space after them.
     @ViewBuilder
     private func rowStrip(
         _ segment: MenuBarSegment,
@@ -443,13 +444,13 @@ struct MenuBarComposerEditor: View {
                     .contentShape(Rectangle())
                     .onDrop(of: [.text], delegate: chipDrop(.endOf(address)))
                 if tokens.isEmpty {
-                    // A group with one empty row is an empty group; an empty
+                    // A segment with one empty row is an empty segment; an empty
                     // row inside a stacked one is a row waiting to be filled.
                     // Two sentences, because they are two different situations.
                     Text(
                         segment.isStacked
                             ? L10n.MenuBar.composerRowEmpty
-                            : L10n.MenuBar.composerGroupEmpty
+                            : L10n.MenuBar.composerSegmentEmpty
                     )
                     .font(.caption2)
                     .foregroundStyle(.tertiary)
@@ -555,11 +556,12 @@ struct MenuBarComposerEditor: View {
         _ token: MenuBarToken,
         availability: MenuBarComposition.Availability
     ) -> some View {
-        let isSelected = selection == token.id
+        let isSelected = selection.contains(token.id)
         let isSilent = availability.silentTokenIds.contains(token.id)
         let isDegraded = availability.degradedTokenIds.contains(token.id)
+        let bound = isGrouped(token.id)
         return Button {
-            selection = isSelected ? nil : token.id
+            selection = isSelected && selection.count == 1 ? [] : [token.id]
         } label: {
             HStack(spacing: 4) {
                 if case let .logo(tool) = token.kind {
@@ -582,19 +584,75 @@ struct MenuBarComposerEditor: View {
             .padding(.vertical, 4)
             .background(
                 RoundedRectangle(cornerRadius: 5, style: .continuous)
-                    .fill(Color.primary.opacity(isSelected ? 0.14 : 0.06))
+                    .fill(
+                        bound
+                            ? Color.accentColor.opacity(isSelected ? 0.30 : 0.16)
+                            : Color.primary.opacity(isSelected ? 0.14 : 0.06)
+                    )
             )
             .overlay(
                 RoundedRectangle(cornerRadius: 5, style: .continuous)
                     .strokeBorder(
-                        isSelected ? Color.accentColor.opacity(0.8) : Color.primary.opacity(0.10),
+                        isSelected
+                            ? Color.accentColor.opacity(0.8)
+                            : (bound
+                                ? Color.accentColor.opacity(0.45)
+                                : Color.primary.opacity(0.10)),
                         lineWidth: 0.5
                     )
             )
             .opacity(isSilent ? 0.55 : 1)
         }
         .buttonStyle(.plain)
+        // Shift wins over the button's own tap, which is what lets one click
+        // pick a block and shift-click build the run to bind.
+        .highPriorityGesture(
+            TapGesture().modifiers(.shift).onEnded {
+                if selection.contains(token.id) {
+                    selection.remove(token.id)
+                } else {
+                    selection.insert(token.id)
+                }
+            }
+        )
         .help(chipHelp(token, isSilent: isSilent, isDegraded: isDegraded))
+    }
+
+    /// The actions for a multi-block selection: bind them, or say why not.
+    ///
+    /// Its own row rather than a mode: the inspector edits one block, and
+    /// picking several is a different thing to be doing.
+    private func groupBar(_ composition: MenuBarComposition) -> some View {
+        let ids = Array(selection)
+        let canBind = composition.canGroup(ids)
+        return VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                caption(L10n.MenuBar.composerGroupSelected(count: selection.count))
+                Spacer(minLength: 8)
+                Button(L10n.MenuBar.composerGroupBind) {
+                    mutate { $0.group(ids) }
+                    selection = []
+                }
+                .buttonStyle(.vibeBar)
+                .disabled(!canBind)
+                Button(L10n.Common.clear) { selection = [] }
+                    .buttonStyle(.vibeBar)
+            }
+            Text(canBind ? L10n.MenuBar.composerGroupHint : L10n.MenuBar.composerGroupNotAdjacent)
+                .font(.caption2)
+                .foregroundStyle(canBind ? .tertiary : .secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    /// The one selected block, when there is exactly one. Multi-selection
+    /// exists only to bind a run; every other control edits a single block.
+    private var selectedID: UUID? {
+        selection.count == 1 ? selection.first : nil
+    }
+
+    private func isGrouped(_ id: UUID) -> Bool {
+        displayedComposition.isGrouped(id)
     }
 
     private func symbol(for kind: MenuBarToken.Kind) -> String {
@@ -673,16 +731,16 @@ struct MenuBarComposerEditor: View {
                     MenuBarToken.newSeparator()
                 }
                 // No "New row" block here on purpose. A row is a place blocks
-                // live, not a block you insert — giving a group its second row
-                // is an action on the group, and it lives in the group's own
+                // live, not a block you insert — giving a segment its second row
+                // is an action on the segment, and it lives in the segment's own
                 // menu beside move, merge and remove.
                 paletteButton(
-                    title: L10n.MenuBar.composerGroupAdd,
+                    title: L10n.MenuBar.composerSegmentAdd,
                     icon: "rectangle.split.2x1"
                 ) {
                     addSegment()
                 }
-                .help(L10n.MenuBar.composerGroupAddHelp)
+                .help(L10n.MenuBar.composerSegmentAddHelp)
             }
             presetsRow()
         }
@@ -724,7 +782,7 @@ struct MenuBarComposerEditor: View {
         }
     }
 
-    /// The saved groups, if there are any. Click one to insert it at the end
+    /// The saved segments, if there are any. Click one to insert it at the end
     /// of the strip.
     @ViewBuilder
     private func presetsRow() -> some View {
@@ -823,26 +881,34 @@ struct MenuBarComposerEditor: View {
         _ composition: MenuBarComposition,
         availability: MenuBarComposition.Availability
     ) -> some View {
-        if let id = selection, let token = composition.token(id) {
+        if selection.count > 1 {
+            groupBar(composition)
+        } else if let id = selectedID, let token = composition.token(id) {
             VStack(alignment: .leading, spacing: 8) {
                 HStack(spacing: 8) {
                     caption(L10n.MenuBar.composerSelected)
                     Spacer(minLength: 8)
                     // Only where it would do something: a block that already
-                    // starts its group has no group to start, and a column is
+                    // starts its segment has no segment to start, and a column is
                     // cut through its top row — see `splitSegment`.
                     if let location = composition.location(of: id),
                        location.row == .top,
                        location.offset > 0 {
-                        Button(L10n.MenuBar.composerGroupSplitHere) {
+                        Button(L10n.MenuBar.composerSegmentSplitHere) {
                             mutate { $0.splitSegment(before: id) }
+                        }
+                        .buttonStyle(.vibeBar)
+                    }
+                    if composition.isGrouped(id) {
+                        Button(L10n.MenuBar.composerGroupUnbind) {
+                            mutate { $0.ungroup(id) }
                         }
                         .buttonStyle(.vibeBar)
                     }
                     Button(L10n.MenuBar.composerActionDuplicate) { mutate { $0.duplicate(id) } }
                         .buttonStyle(.vibeBar)
                     Button(L10n.MenuBar.composerActionRemove) {
-                        selection = nil
+                        selection = []
                         mutate { $0.remove(id) }
                     }
                     .buttonStyle(.vibeBar)
@@ -919,7 +985,7 @@ struct MenuBarComposerEditor: View {
             titleVisibility: .visible
         ) {
             Button(L10n.MenuBar.composerStartOverConfirm, role: .destructive) {
-                selection = nil
+                selection = []
                 var updated = item
                 updated.reseedComposedStrip(
                     template: composition.template,
@@ -978,7 +1044,7 @@ struct MenuBarComposerEditor: View {
         settingsStore.settings.setMenuBarItem(updated)
     }
 
-    /// Save the group the dialog was opened on, under the name that was typed.
+    /// Save the segment the dialog was opened on, under the name that was typed.
     ///
     /// The blocks are copied exactly as they are, quota ids and all: a preset
     /// naming a bucket this Mac stopped returning is a block the availability
@@ -1042,7 +1108,7 @@ struct MenuBarComposerEditor: View {
     }
 
     private func removeDragged(_ id: UUID) {
-        if selection == id { selection = nil }
+        selection.remove(id)
         // Start from the provisional order when there is one, so a block that
         // was dragged across the strip and then onto the bin does not
         // resurrect the intermediate order it passed through.
@@ -1056,7 +1122,7 @@ struct MenuBarComposerEditor: View {
     /// the end of the strip — which, in a stacked last column, is its bottom
     /// row rather than its top one.
     private var targetRow: MenuBarComposition.RowAddress? {
-        if let selection, let location = composition.location(of: selection) {
+        if let selectedID, let location = composition.location(of: selectedID) {
             return MenuBarComposition.RowAddress(
                 segment: composition.segments[location.segment].id,
                 row: location.row
@@ -1072,20 +1138,20 @@ struct MenuBarComposerEditor: View {
     private func add(_ token: MenuBarToken) {
         let row = targetRow
         mutate { $0.append(token, to: row) }
-        selection = token.id
+        selection = [token.id]
     }
 
     private func addSegment() {
         let segment = MenuBarSegment()
         mutate { $0.appendSegment(segment) }
-        // Nothing to select — the group is empty — but the next added block
+        // Nothing to select — the segment is empty — but the next added block
         // has to land in it rather than in whatever was selected before.
-        selection = nil
+        selection = []
     }
 
     private func insert(preset: MenuBarSegmentPreset) {
         mutate { $0.appendSegment(preset.segment()) }
-        selection = nil
+        selection = []
     }
 
     private func templateBinding() -> Binding<MenuBarComposition.Template> {
@@ -1773,7 +1839,7 @@ private struct DebouncedPercentStepper: View {
 /// A flattened index cannot say which side of a boundary it means, and a drag
 /// onto the first chip of a row has to land *in* that row or the gesture does
 /// nothing — so the target names the row instead. It is a row rather than a
-/// group because a stacked column has two of them, and the empty space after
+/// segment because a stacked column has two of them, and the empty space after
 /// the top row's last chip is not the same place as the empty space after the
 /// bottom row's.
 /// A palette block in flight, with the moment its drag began.
@@ -1808,7 +1874,7 @@ struct PendingPaletteBlock {
 enum MenuBarChipDropTarget {
     case before(UUID)
     case endOf(MenuBarComposition.RowAddress)
-    /// The strip with no groups left in it. A block landing here opens the
+    /// The strip with no segments left in it. A block landing here opens the
     /// first one — `append(_:to: nil)`.
     case newStrip
 }
@@ -1846,7 +1912,7 @@ private struct MenuBarChipDropDelegate: DropDelegate {
             case let .before(id):
                 guard let at = order.location(of: id) else { return }
                 // Into the target's own row first, so the move that follows
-                // is a same-row reorder and cannot leave an empty group
+                // is a same-row reorder and cannot leave an empty segment
                 // behind the way appending to a new one would.
                 order.append(new, to: MenuBarComposition.RowAddress(
                     segment: order.segments[at.segment].id,
@@ -1892,7 +1958,7 @@ private struct MenuBarChipDropDelegate: DropDelegate {
 private struct MenuBarChipRemoveDelegate: DropDelegate {
     @Binding var dragged: UUID?
     @Binding var isTargeted: Bool
-    @Binding var selection: UUID?
+    @Binding var selection: Set<UUID>
     let remove: (UUID) -> Void
     let entered: () -> Void
     let exited: () -> Void
@@ -1975,7 +2041,7 @@ struct MenuBarChipFlow: Layout {
     ///
     /// `.unspecified` asks "how wide would you like to be", and a subview
     /// that is itself a flow answers with every one of its own children on
-    /// one line — so a group box measured that way came out as wide as all
+    /// one line — so a segment box measured that way came out as wide as all
     /// its chips and ran off the pane. Proposing the width available makes
     /// an inner flow wrap inside it, which is the only honest measurement
     /// when a flow holds a flow.
@@ -1983,7 +2049,7 @@ struct MenuBarChipFlow: Layout {
         let intrinsic = subview.sizeThatFits(.unspecified)
         guard maxWidth.isFinite, intrinsic.width > maxWidth else { return intrinsic }
         // Only the ones that do not fit. Proposing the cap to everything
-        // makes any greedy subview — a group box, whose header holds a
+        // makes any greedy subview — a segment box, whose header holds a
         // Spacer — report the full width and take a line to itself, which
         // turns "wrap side by side" into "one per row" and makes the
         // composer taller for no reason.

--- a/Sources/VibeBarCore/Localization/L10n+Generated.swift
+++ b/Sources/VibeBarCore/Localization/L10n+Generated.swift
@@ -737,49 +737,25 @@ extension L10n {
         public static var composerFieldWeight: String {
             L10n.string("menuBar.composer.field.weight")
         }
-        /// `menuBar.composer.group.add` — New group
-        public static var composerGroupAdd: String {
-            L10n.string("menuBar.composer.group.add")
+        /// `menuBar.composer.group.bind` — Group
+        public static var composerGroupBind: String {
+            L10n.string("menuBar.composer.group.bind")
         }
-        /// `menuBar.composer.group.addHelp` — Each group is one column of the strip. Give a group a second row to stack that column.
-        public static var composerGroupAddHelp: String {
-            L10n.string("menuBar.composer.group.addHelp")
+        /// `menuBar.composer.group.hint` — Shift-click blocks that sit side by side in one row. A group moves as one — drag any block in it and the whole run goes.
+        public static var composerGroupHint: String {
+            L10n.string("menuBar.composer.group.hint")
         }
-        /// `menuBar.composer.group.addRow` — Add a second row
-        public static var composerGroupAddRow: String {
-            L10n.string("menuBar.composer.group.addRow")
+        /// `menuBar.composer.group.notAdjacent` — Only blocks side by side in one row can be grouped.
+        public static var composerGroupNotAdjacent: String {
+            L10n.string("menuBar.composer.group.notAdjacent")
         }
-        /// `menuBar.composer.group.empty` — Empty group — drag a block in.
-        public static var composerGroupEmpty: String {
-            L10n.string("menuBar.composer.group.empty")
+        /// `menuBar.composer.group.selected` — {count, plural, one {1 block selected} other {# blocks selected}}
+        public static func composerGroupSelected(count: Int) -> String {
+            L10n.string("menuBar.composer.group.selected", count)
         }
-        /// `menuBar.composer.group.mergeLeft` — Merge into the group before it
-        public static var composerGroupMergeLeft: String {
-            L10n.string("menuBar.composer.group.mergeLeft")
-        }
-        /// `menuBar.composer.group.moveLeft` — Move left
-        public static var composerGroupMoveLeft: String {
-            L10n.string("menuBar.composer.group.moveLeft")
-        }
-        /// `menuBar.composer.group.moveRight` — Move right
-        public static var composerGroupMoveRight: String {
-            L10n.string("menuBar.composer.group.moveRight")
-        }
-        /// `menuBar.composer.group.remove` — Remove group and its blocks
-        public static var composerGroupRemove: String {
-            L10n.string("menuBar.composer.group.remove")
-        }
-        /// `menuBar.composer.group.removeRow` — Merge the second row up
-        public static var composerGroupRemoveRow: String {
-            L10n.string("menuBar.composer.group.removeRow")
-        }
-        /// `menuBar.composer.group.splitHere` — Start a group here
-        public static var composerGroupSplitHere: String {
-            L10n.string("menuBar.composer.group.splitHere")
-        }
-        /// `menuBar.composer.group.title` — Group {index}
-        public static func composerGroupTitle(index: Int) -> String {
-            L10n.string("menuBar.composer.group.title", index)
+        /// `menuBar.composer.group.unbind` — Ungroup
+        public static var composerGroupUnbind: String {
+            L10n.string("menuBar.composer.group.unbind")
         }
         /// `menuBar.composer.metric.displayPercent` — Percent (follows setting)
         public static var composerMetricDisplayPercent: String {
@@ -853,7 +829,7 @@ extension L10n {
         public static var composerPalette: String {
             L10n.string("menuBar.composer.palette")
         }
-        /// `menuBar.composer.preset.insertHelp` — Insert this group at the end of the strip.
+        /// `menuBar.composer.preset.insertHelp` — Insert this segment at the end of the strip.
         public static var composerPresetInsertHelp: String {
             L10n.string("menuBar.composer.preset.insertHelp")
         }
@@ -873,11 +849,11 @@ extension L10n {
         public static var composerPresetSaveConfirm: String {
             L10n.string("menuBar.composer.preset.saveConfirm")
         }
-        /// `menuBar.composer.preset.saveTitle` — Save this group
+        /// `menuBar.composer.preset.saveTitle` — Save this segment
         public static var composerPresetSaveTitle: String {
             L10n.string("menuBar.composer.preset.saveTitle")
         }
-        /// `menuBar.composer.presets` — Saved groups
+        /// `menuBar.composer.presets` — Saved segments
         public static var composerPresets: String {
             L10n.string("menuBar.composer.presets")
         }
@@ -952,6 +928,50 @@ extension L10n {
         /// `menuBar.composer.rule.whenUsedAtLeast` — When used is at least
         public static var composerRuleWhenUsedAtLeast: String {
             L10n.string("menuBar.composer.rule.whenUsedAtLeast")
+        }
+        /// `menuBar.composer.segment.add` — New segment
+        public static var composerSegmentAdd: String {
+            L10n.string("menuBar.composer.segment.add")
+        }
+        /// `menuBar.composer.segment.addHelp` — Each segment is one column of the strip. Give a segment a second row to stack that column.
+        public static var composerSegmentAddHelp: String {
+            L10n.string("menuBar.composer.segment.addHelp")
+        }
+        /// `menuBar.composer.segment.addRow` — Add a second row
+        public static var composerSegmentAddRow: String {
+            L10n.string("menuBar.composer.segment.addRow")
+        }
+        /// `menuBar.composer.segment.empty` — Empty segment — drag a block in.
+        public static var composerSegmentEmpty: String {
+            L10n.string("menuBar.composer.segment.empty")
+        }
+        /// `menuBar.composer.segment.mergeLeft` — Merge into the segment before it
+        public static var composerSegmentMergeLeft: String {
+            L10n.string("menuBar.composer.segment.mergeLeft")
+        }
+        /// `menuBar.composer.segment.moveLeft` — Move left
+        public static var composerSegmentMoveLeft: String {
+            L10n.string("menuBar.composer.segment.moveLeft")
+        }
+        /// `menuBar.composer.segment.moveRight` — Move right
+        public static var composerSegmentMoveRight: String {
+            L10n.string("menuBar.composer.segment.moveRight")
+        }
+        /// `menuBar.composer.segment.remove` — Remove segment and its blocks
+        public static var composerSegmentRemove: String {
+            L10n.string("menuBar.composer.segment.remove")
+        }
+        /// `menuBar.composer.segment.removeRow` — Merge the second row up
+        public static var composerSegmentRemoveRow: String {
+            L10n.string("menuBar.composer.segment.removeRow")
+        }
+        /// `menuBar.composer.segment.splitHere` — Start a segment here
+        public static var composerSegmentSplitHere: String {
+            L10n.string("menuBar.composer.segment.splitHere")
+        }
+        /// `menuBar.composer.segment.title` — Segment {index}
+        public static func composerSegmentTitle(index: Int) -> String {
+            L10n.string("menuBar.composer.segment.title", index)
         }
         /// `menuBar.composer.selected` — Selected block
         public static var composerSelected: String {
@@ -6527,17 +6547,11 @@ extension L10n {
         "menuBar.composer.field.size",
         "menuBar.composer.field.verdicts",
         "menuBar.composer.field.weight",
-        "menuBar.composer.group.add",
-        "menuBar.composer.group.addHelp",
-        "menuBar.composer.group.addRow",
-        "menuBar.composer.group.empty",
-        "menuBar.composer.group.mergeLeft",
-        "menuBar.composer.group.moveLeft",
-        "menuBar.composer.group.moveRight",
-        "menuBar.composer.group.remove",
-        "menuBar.composer.group.removeRow",
-        "menuBar.composer.group.splitHere",
-        "menuBar.composer.group.title",
+        "menuBar.composer.group.bind",
+        "menuBar.composer.group.hint",
+        "menuBar.composer.group.notAdjacent",
+        "menuBar.composer.group.selected",
+        "menuBar.composer.group.unbind",
         "menuBar.composer.metric.displayPercent",
         "menuBar.composer.metric.forecastPercent",
         "menuBar.composer.metric.label",
@@ -6581,6 +6595,17 @@ extension L10n {
         "menuBar.composer.rule.whenForecast",
         "menuBar.composer.rule.whenRemainingAtMost",
         "menuBar.composer.rule.whenUsedAtLeast",
+        "menuBar.composer.segment.add",
+        "menuBar.composer.segment.addHelp",
+        "menuBar.composer.segment.addRow",
+        "menuBar.composer.segment.empty",
+        "menuBar.composer.segment.mergeLeft",
+        "menuBar.composer.segment.moveLeft",
+        "menuBar.composer.segment.moveRight",
+        "menuBar.composer.segment.remove",
+        "menuBar.composer.segment.removeRow",
+        "menuBar.composer.segment.splitHere",
+        "menuBar.composer.segment.title",
         "menuBar.composer.selected",
         "menuBar.composer.size.mini",
         "menuBar.composer.size.regular",
@@ -7933,6 +7958,7 @@ extension L10n {
         "common.updated.daysAgo",
         "common.updated.hoursAgo",
         "common.updated.minutesAgo",
+        "menuBar.composer.group.selected",
         "menuBar.composer.space.widthValue",
         "quota.forecast.metric.comparableCycles",
         "quota.forecast.metric.recentIntervals",

--- a/Sources/VibeBarCore/Models/MenuBarComposition.swift
+++ b/Sources/VibeBarCore/Models/MenuBarComposition.swift
@@ -1265,16 +1265,32 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
     private func contiguousRun(
         _ ids: [UUID]
     ) -> (segment: Int, row: MenuBarSegment.Row, offsets: [Int])? {
-        let unique = Set(ids)
-        guard unique.count > 1 else { return nil }
-        let placed = unique.compactMap { location(of: $0) }
-        guard placed.count == unique.count,
-              let first = placed.first,
-              placed.allSatisfy({ $0.segment == first.segment && $0.row == first.row })
-        else { return nil }
-        let offsets = placed.map(\.offset).sorted()
+        let wanted = Set(ids)
+        guard wanted.count > 1 else { return nil }
+        // One walk of the strip rather than `location(of:)` per id, which
+        // scans it each time: this runs on every redraw while a selection is
+        // being built, and a big selection on a big strip made that quadratic.
+        var home: (segment: Int, row: MenuBarSegment.Row)?
+        var offsets: [Int] = []
+        for segmentIndex in segments.indices {
+            for row in MenuBarSegment.Row.allCases {
+                for (offset, token) in segments[segmentIndex][row].enumerated()
+                where wanted.contains(token.id) {
+                    if let home {
+                        // A selection spanning two rows is not a run, and
+                        // finding that out early costs nothing.
+                        guard home == (segmentIndex, row) else { return nil }
+                    } else {
+                        home = (segmentIndex, row)
+                    }
+                    offsets.append(offset)
+                }
+            }
+        }
+        guard let home, offsets.count == wanted.count else { return nil }
+        offsets.sort()
         guard offsets.last! - offsets.first! == offsets.count - 1 else { return nil }
-        return (first.segment, first.row, offsets)
+        return (home.segment, home.row, offsets)
     }
 
     /// Unbind the run `id` belongs to. The blocks stay exactly where they are.
@@ -1351,6 +1367,10 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
     @discardableResult
     public mutating func appendSegment(_ segment: MenuBarSegment = MenuBarSegment()) -> UUID {
         segments.append(segment)
+        // Presets arrive through here, and they carry blocks this composition
+        // has never normalized: a preset whose own file lost one member's
+        // binding would land as a run with a stranger through it.
+        normalizeGroups()
         return segment.id
     }
 

--- a/Sources/VibeBarCore/Models/MenuBarComposition.swift
+++ b/Sources/VibeBarCore/Models/MenuBarComposition.swift
@@ -1211,8 +1211,27 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
     }
 
     /// Whether `id` is bound to at least one other block.
+    ///
+    /// Walks the strip, so a caller asking once per block is quadratic — the
+    /// editor draws every chip on every body pass and reads `boundGroupIDs`
+    /// once instead.
     public func isGrouped(_ id: UUID) -> Bool {
         groupedRun(of: id).count > 1
+    }
+
+    /// Every binding that is real: an id held by more than one block. One walk
+    /// of the strip, for callers that need the answer for all of them.
+    public var boundGroupIDs: Set<UUID> {
+        var counts: [UUID: Int] = [:]
+        for segment in segments {
+            for row in MenuBarSegment.Row.allCases {
+                for token in segment[row] {
+                    guard let group = token.groupID else { continue }
+                    counts[group, default: 0] += 1
+                }
+            }
+        }
+        return Set(counts.filter { $0.value > 1 }.keys)
     }
 
     /// Bind blocks that already sit side by side in one row.

--- a/Sources/VibeBarCore/Models/MenuBarComposition.swift
+++ b/Sources/VibeBarCore/Models/MenuBarComposition.swift
@@ -665,10 +665,22 @@ public struct MenuBarSegmentPreset: Identifiable, Codable, Equatable, Sendable {
     /// segment. Two insertions of one preset are two groups the editor can
     /// drag apart, the same rule `duplicate` follows.
     public func segment() -> MenuBarSegment {
+        // Fresh bindings as well as fresh identities, and one per original
+        // group so a run stays a run. Reusing the saved ids would make two
+        // copies of the same preset read as one group once they shared a row,
+        // and dragging either would move both.
+        var rebound: [UUID: UUID] = [:]
         func copies(_ tokens: [MenuBarToken]) -> [MenuBarToken] {
             tokens.map { token in
                 var copy = token
                 copy.id = UUID()
+                if let group = token.groupID {
+                    copy.groupID = rebound[group] ?? {
+                        let fresh = UUID()
+                        rebound[group] = fresh
+                        return fresh
+                    }()
+                }
                 return copy
             }
         }
@@ -859,6 +871,7 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
     /// that divider, so the two directions round-trip.
     public mutating func setTemplate(_ newTemplate: Template) {
         template = newTemplate
+        defer { normalizeGroups() }
         if newTemplate.seedsSecondRow {
             guard !segments.contains(where: \.isStacked) else { return }
             // The seam is looked for inside each group, longest first: a
@@ -1206,6 +1219,10 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
         for offset in run.offsets {
             segments[run.segment][run.row][offset].groupID = group
         }
+        // Binding B and C when A-B were bound leaves A holding an id nobody
+        // else has. It is not a group any more, and a stale one would be
+        // copied by `duplicate` and quietly bind the copy to nothing.
+        normalizeGroups()
         return group
     }
 
@@ -1254,25 +1271,46 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
     /// Every structural mutation ends here, which is what lets the operations
     /// above stay simple: they move blocks, and this decides what survives.
     public mutating func normalizeGroups() {
+        // Every id, everywhere. A row-local pass cannot see a four-block group
+        // cut 2+2 by a template change: each half is contiguous inside its own
+        // row, so both would survive holding the same id, and a later merge
+        // would fuse two runs the user never bound together.
+        struct Placement { var row: (segment: Int, row: MenuBarSegment.Row); var offsets: [Int] }
+        var seen: [UUID: Placement] = [:]
+        var doomed: Set<UUID> = []
         for segmentIndex in segments.indices {
             for row in MenuBarSegment.Row.allCases {
-                var runs: [UUID: [Int]] = [:]
                 for (offset, token) in segments[segmentIndex][row].enumerated() {
                     guard let group = token.groupID else { continue }
-                    runs[group, default: []].append(offset)
-                }
-                for offsets in runs.values {
-                    let contiguous = offsets.last! - offsets.first! == offsets.count - 1
-                    guard offsets.count < 2 || !contiguous else { continue }
-                    for offset in offsets {
-                        segments[segmentIndex][row][offset].groupID = nil
+                    if var placement = seen[group] {
+                        guard placement.row == (segmentIndex, row) else {
+                            doomed.insert(group)
+                            continue
+                        }
+                        placement.offsets.append(offset)
+                        seen[group] = placement
+                    } else {
+                        seen[group] = Placement(row: (segmentIndex, row), offsets: [offset])
                     }
                 }
             }
         }
-        // A group split across rows leaves a valid-looking run on each side;
-        // one of them is a single block, and the pass above has already
-        // dissolved it. The other is a genuine run of what is left.
+        for (group, placement) in seen {
+            let offsets = placement.offsets.sorted()
+            let contiguous = offsets.last! - offsets.first! == offsets.count - 1
+            if offsets.count < 2 || !contiguous { doomed.insert(group) }
+        }
+        guard !doomed.isEmpty else { return }
+        for segmentIndex in segments.indices {
+            for row in MenuBarSegment.Row.allCases {
+                for offset in segments[segmentIndex][row].indices {
+                    guard let group = segments[segmentIndex][row][offset].groupID,
+                          doomed.contains(group)
+                    else { continue }
+                    segments[segmentIndex][row][offset].groupID = nil
+                }
+            }
+        }
     }
 
     // MARK: Segments
@@ -1338,15 +1376,22 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
     /// cutting through a bottom row alone would leave one group with a hole
     /// where its first cell should be, which is not a column the strip can
     /// draw and not a shape the editor should let anyone build.
-    public mutating func splitSegment(before id: UUID) {
+    /// Whether `splitSegment(before:)` would do anything — the predicate the
+    /// button offering it reads, so a visible action is never a no-op.
+    ///
+    /// Never through a run: a group with half in each column would dissolve,
+    /// which is not what "start a segment here" says it does. A run's first
+    /// block may start a segment; a later member may not.
+    public func canSplitSegment(before id: UUID) -> Bool {
         guard let location = location(of: id),
               location.row == .top,
-              location.offset > 0,
-              // Never through a run: a group that ends up half in each column
-              // would dissolve, which is not what "start a segment here" says
-              // it does. The block starting a segment may be a run's first.
-              groupedRun(of: id).first == id
-        else { return }
+              location.offset > 0
+        else { return false }
+        return groupedRun(of: id).first == id
+    }
+
+    public mutating func splitSegment(before id: UUID) {
+        guard canSplitSegment(before: id), let location = location(of: id) else { return }
         let moved = Array(segments[location.segment].top[location.offset...])
         segments[location.segment].top.removeSubrange(location.offset...)
         let bottom = segments[location.segment].bottom

--- a/Sources/VibeBarCore/Models/MenuBarComposition.swift
+++ b/Sources/VibeBarCore/Models/MenuBarComposition.swift
@@ -1140,10 +1140,18 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
     /// the invariant the group is holding.
     public mutating func move(_ id: UUID, before target: UUID) {
         let run = groupedRun(of: id)
-        guard !run.contains(target) else { return }
+        // Both ends checked before anything is lifted. Validating the target
+        // afterwards could not recover: the source is already out, so the
+        // "put it back" lookup finds nothing and strands the run in a segment
+        // of its own — a move to nowhere would rearrange the strip.
+        guard !run.contains(target),
+              location(of: target) != nil,
+              let origin = location(of: id)
+        else { return }
         let lifted = lift(run)
-        guard !lifted.isEmpty, let destination = location(of: target) else {
-            reinsert(lifted, at: location(of: id))
+        guard !lifted.isEmpty else { return }
+        guard let destination = location(of: target) else {
+            reinsert(lifted, at: origin)
             return
         }
         segments[destination.segment][destination.row]

--- a/Sources/VibeBarCore/Models/MenuBarComposition.swift
+++ b/Sources/VibeBarCore/Models/MenuBarComposition.swift
@@ -1174,16 +1174,25 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
     /// Take a run of blocks out of the arrangement, in row order. Empty when
     /// the ids are not all present.
     private mutating func lift(_ ids: [UUID]) -> [MenuBarToken] {
-        let ordered = ids.compactMap { id -> (Location, MenuBarToken)? in
-            guard let at = location(of: id) else { return nil }
-            return (at, segments[at.segment][at.row][at.offset])
+        // One walk, like `contiguousRun`: this runs on every pointer crossing
+        // of a drag, and `location(of:)` per member scans the whole strip each
+        // time — quadratic in a group that spans most of it.
+        let wanted = Set(ids)
+        var found: [(Location, MenuBarToken)] = []
+        for segmentIndex in segments.indices {
+            for row in MenuBarSegment.Row.allCases {
+                for (offset, token) in segments[segmentIndex][row].enumerated()
+                where wanted.contains(token.id) {
+                    found.append((Location(segment: segmentIndex, row: row, offset: offset), token))
+                }
+            }
         }
-        guard ordered.count == ids.count else { return [] }
+        guard found.count == wanted.count else { return [] }
         // Back to front, so each removal leaves the offsets before it intact.
-        for (at, _) in ordered.sorted(by: { $0.0.offset > $1.0.offset }) {
+        for (at, _) in found.sorted(by: { $0.0.offset > $1.0.offset }) {
             segments[at.segment][at.row].remove(at: at.offset)
         }
-        return ordered.map(\.1)
+        return found.map(\.1)
     }
 
     /// Put a lifted run back where it came from, for a move that could not

--- a/Sources/VibeBarCore/Models/MenuBarComposition.swift
+++ b/Sources/VibeBarCore/Models/MenuBarComposition.swift
@@ -1788,6 +1788,13 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
             .map { $0.clamped(to: Self.fontScaleRange) }
         self.tokenSpacing = (try? c.decode(Double.self, forKey: .tokenSpacing))
             .map { $0.clamped(to: Self.tokenSpacingRange) }
+        // Settings are hand-editable and a decode is tolerant: one member's
+        // `groupID` can arrive missing or malformed while its siblings keep
+        // theirs, which leaves a group with a stranger through it. Nothing
+        // else would notice — `groupedRun` filters the row by id and does
+        // not check contiguity — so dragging one member would carry blocks
+        // across the one between them.
+        normalizeGroups()
     }
 
     public func encode(to encoder: Encoder) throws {

--- a/Sources/VibeBarCore/Models/MenuBarComposition.swift
+++ b/Sources/VibeBarCore/Models/MenuBarComposition.swift
@@ -347,17 +347,30 @@ public struct MenuBarToken: Identifiable, Codable, Hashable, Sendable {
     public var kind: Kind
     public var style: Style
     public var visibility: Visibility
+    /// The run of blocks this one is bound into, if any.
+    ///
+    /// Blocks sharing a `groupID` move as one — drag any member and the whole
+    /// run goes. `MenuBarComposition` keeps the invariant that they are always
+    /// side by side in one row: an edit that would scatter them dissolves the
+    /// group instead, because silently reordering the user's blocks to keep a
+    /// binding intact is the worse of the two.
+    ///
+    /// Not the segment: a segment is a column of the strip, and a group is a
+    /// handful of blocks inside one of its rows.
+    public var groupID: UUID?
 
     public init(
         id: UUID = UUID(),
         kind: Kind,
         style: Style = Style(),
-        visibility: Visibility = .always
+        visibility: Visibility = .always,
+        groupID: UUID? = nil
     ) {
         self.id = id
         self.kind = kind
         self.style = style
         self.visibility = visibility
+        self.groupID = groupID
     }
 
     // MARK: Palette
@@ -417,7 +430,7 @@ public struct MenuBarToken: Identifiable, Codable, Hashable, Sendable {
 
     /// The quota this token reads, if it is a quota token.
     private enum CodingKeys: String, CodingKey {
-        case id, kind, style, visibility
+        case id, kind, style, visibility, groupID
     }
 
     /// Same reasoning as `Style`: everything except the block's own identity
@@ -430,6 +443,9 @@ public struct MenuBarToken: Identifiable, Codable, Hashable, Sendable {
         self.kind = try c.decode(Kind.self, forKey: .kind)
         self.style = (try? c.decode(Style.self, forKey: .style)) ?? Style()
         self.visibility = (try? c.decode(Visibility.self, forKey: .visibility)) ?? .always
+        // Absent in every settings file written before groups existed, and a
+        // block that arrives unbound is simply a block on its own.
+        self.groupID = try? c.decode(UUID.self, forKey: .groupID)
     }
 
     public var quotaFieldId: String? {
@@ -1078,6 +1094,9 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
     public mutating func remove(_ id: UUID) -> Bool {
         guard let location = location(of: id) else { return false }
         segments[location.segment][location.row].remove(at: location.offset)
+        // Removing one member leaves the rest bound; removing the
+        // second-to-last leaves a group of one, which is not a group.
+        normalizeGroups()
         return true
     }
 
@@ -1090,6 +1109,8 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
         guard let location = location(of: id) else { return nil }
         var copy = segments[location.segment][location.row][location.offset]
         copy.id = UUID()
+        // The copy lands inside the run, so it joins it rather than splitting
+        // it — carrying `groupID` over is what keeps that true.
         segments[location.segment][location.row].insert(copy, at: location.offset + 1)
         return copy.id
     }
@@ -1100,36 +1121,161 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
     /// Row-relative rather than flattened, because a flattened index cannot
     /// say which side of a boundary it means — and a drag onto the first chip
     /// of a row has to land *in* that row or the gesture does nothing.
+    ///
+    /// A grouped block brings its whole run: that is what being in a group
+    /// means, and dragging one member out of the middle of one would break
+    /// the invariant the group is holding.
     public mutating func move(_ id: UUID, before target: UUID) {
-        guard id != target,
-              let from = location(of: id),
-              let destination = location(of: target)
-        else { return }
-        let token = segments[from.segment][from.row].remove(at: from.offset)
-        var offset = destination.offset
-        // Dragging rightwards past the target lands *on* it once the source
-        // has been lifted out; dragging leftwards lands in front of it.
-        if from.segment == destination.segment, from.row == destination.row,
-           from.offset < destination.offset {
-            offset -= 1
+        let run = groupedRun(of: id)
+        guard !run.contains(target) else { return }
+        let lifted = lift(run)
+        guard !lifted.isEmpty, let destination = location(of: target) else {
+            reinsert(lifted, at: location(of: id))
+            return
         }
-        let row = segments[destination.segment][destination.row]
         segments[destination.segment][destination.row]
-            .insert(token, at: Swift.max(0, Swift.min(offset, row.count)))
+            .insert(contentsOf: lifted, at: destination.offset)
+        normalizeGroups()
     }
 
     /// Move `id` to the end of a row — the trailing landing strip a drag aims
     /// at when it is past every chip.
     public mutating func move(_ id: UUID, toEndOf address: RowAddress) {
         guard let destination = segmentIndex(of: address.segment),
-              address.row == .top || segments[destination].isStacked,
-              let from = location(of: id)
+              address.row == .top || segments[destination].isStacked
         else { return }
-        let token = segments[from.segment][from.row].remove(at: from.offset)
-        segments[destination][address.row].append(token)
+        let lifted = lift(groupedRun(of: id))
+        guard !lifted.isEmpty else { return }
+        segments[destination][address.row].append(contentsOf: lifted)
+        normalizeGroups()
     }
 
-    // MARK: Groups
+    /// Take a run of blocks out of the arrangement, in row order. Empty when
+    /// the ids are not all present.
+    private mutating func lift(_ ids: [UUID]) -> [MenuBarToken] {
+        let ordered = ids.compactMap { id -> (Location, MenuBarToken)? in
+            guard let at = location(of: id) else { return nil }
+            return (at, segments[at.segment][at.row][at.offset])
+        }
+        guard ordered.count == ids.count else { return [] }
+        // Back to front, so each removal leaves the offsets before it intact.
+        for (at, _) in ordered.sorted(by: { $0.0.offset > $1.0.offset }) {
+            segments[at.segment][at.row].remove(at: at.offset)
+        }
+        return ordered.map(\.1)
+    }
+
+    /// Put a lifted run back where it came from, for a move that could not
+    /// find its destination after the lift.
+    private mutating func reinsert(_ tokens: [MenuBarToken], at location: Location?) {
+        guard !tokens.isEmpty else { return }
+        guard let location else {
+            segments.append(MenuBarSegment(tokens: tokens))
+            return
+        }
+        let row = segments[location.segment][location.row]
+        segments[location.segment][location.row]
+            .insert(contentsOf: tokens, at: Swift.max(0, Swift.min(location.offset, row.count)))
+    }
+
+    // MARK: Blocks bound together
+
+    /// The run `id` belongs to, in row order — `[id]` alone when it is not
+    /// bound to anything.
+    public func groupedRun(of id: UUID) -> [UUID] {
+        guard let at = location(of: id),
+              let group = segments[at.segment][at.row][at.offset].groupID
+        else { return [id] }
+        return segments[at.segment][at.row].filter { $0.groupID == group }.map(\.id)
+    }
+
+    /// Whether `id` is bound to at least one other block.
+    public func isGrouped(_ id: UUID) -> Bool {
+        groupedRun(of: id).count > 1
+    }
+
+    /// Bind blocks that already sit side by side in one row.
+    ///
+    /// Refused rather than repaired when they do not: two blocks with a third
+    /// between them are not a run, and quietly moving that third one is an
+    /// edit the user did not ask for. Returns the new group's id.
+    @discardableResult
+    public mutating func group(_ ids: [UUID]) -> UUID? {
+        guard let run = contiguousRun(ids) else { return nil }
+        let group = UUID()
+        for offset in run.offsets {
+            segments[run.segment][run.row][offset].groupID = group
+        }
+        return group
+    }
+
+    /// Whether `group(_:)` would bind these. One predicate, so the button that
+    /// offers the action and the action itself cannot disagree about it.
+    public func canGroup(_ ids: [UUID]) -> Bool {
+        contiguousRun(ids) != nil
+    }
+
+    /// Where these blocks are, if they are two or more sitting side by side in
+    /// one row. `nil` says they are not a run — which is a refusal, not a
+    /// problem to fix by moving them.
+    private func contiguousRun(
+        _ ids: [UUID]
+    ) -> (segment: Int, row: MenuBarSegment.Row, offsets: [Int])? {
+        let unique = Set(ids)
+        guard unique.count > 1 else { return nil }
+        let placed = unique.compactMap { location(of: $0) }
+        guard placed.count == unique.count,
+              let first = placed.first,
+              placed.allSatisfy({ $0.segment == first.segment && $0.row == first.row })
+        else { return nil }
+        let offsets = placed.map(\.offset).sorted()
+        guard offsets.last! - offsets.first! == offsets.count - 1 else { return nil }
+        return (first.segment, first.row, offsets)
+    }
+
+    /// Unbind the run `id` belongs to. The blocks stay exactly where they are.
+    public mutating func ungroup(_ id: UUID) {
+        guard let at = location(of: id),
+              let group = segments[at.segment][at.row][at.offset].groupID
+        else { return }
+        for index in segments[at.segment][at.row].indices
+        where segments[at.segment][at.row][index].groupID == group {
+            segments[at.segment][at.row][index].groupID = nil
+        }
+    }
+
+    /// Dissolve every binding that is no longer true.
+    ///
+    /// Two ways a group stops being one: an edit scattered its members — into
+    /// another row, or with a stranger dropped between them — or it is down to
+    /// its last block. Both dissolve rather than repair, so an edit never
+    /// silently reorders the strip to preserve a binding.
+    ///
+    /// Every structural mutation ends here, which is what lets the operations
+    /// above stay simple: they move blocks, and this decides what survives.
+    public mutating func normalizeGroups() {
+        for segmentIndex in segments.indices {
+            for row in MenuBarSegment.Row.allCases {
+                var runs: [UUID: [Int]] = [:]
+                for (offset, token) in segments[segmentIndex][row].enumerated() {
+                    guard let group = token.groupID else { continue }
+                    runs[group, default: []].append(offset)
+                }
+                for offsets in runs.values {
+                    let contiguous = offsets.last! - offsets.first! == offsets.count - 1
+                    guard offsets.count < 2 || !contiguous else { continue }
+                    for offset in offsets {
+                        segments[segmentIndex][row][offset].groupID = nil
+                    }
+                }
+            }
+        }
+        // A group split across rows leaves a valid-looking run on each side;
+        // one of them is a single block, and the pass above has already
+        // dissolved it. The other is a genuine run of what is left.
+    }
+
+    // MARK: Segments
 
     public func segmentIndex(of id: UUID) -> Int? {
         segments.firstIndex { $0.id == id }
@@ -1195,7 +1341,11 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
     public mutating func splitSegment(before id: UUID) {
         guard let location = location(of: id),
               location.row == .top,
-              location.offset > 0
+              location.offset > 0,
+              // Never through a run: a group that ends up half in each column
+              // would dissolve, which is not what "start a segment here" says
+              // it does. The block starting a segment may be a run's first.
+              groupedRun(of: id).first == id
         else { return }
         let moved = Array(segments[location.segment].top[location.offset...])
         segments[location.segment].top.removeSubrange(location.offset...)
@@ -1205,6 +1355,7 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
             MenuBarSegment(top: moved, bottom: bottom),
             at: location.segment + 1
         )
+        normalizeGroups()
     }
 
     /// Fold a group into the one before it. The inverse of `splitSegment`.
@@ -1222,6 +1373,7 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
         } else {
             segments[index - 1].bottom?.append(contentsOf: bottom)
         }
+        normalizeGroups()
     }
 
     // MARK: Availability

--- a/Sources/VibeBarCore/Models/MenuBarSettings.swift
+++ b/Sources/VibeBarCore/Models/MenuBarSettings.swift
@@ -308,14 +308,14 @@ public struct MenuBarItemSettings: Codable, Equatable, Identifiable, Sendable {
         // default instead of discarding the settings blob.
         let rawStyles = try c.decodeIfPresent([String: String].self, forKey: .fieldStyles) ?? [:]
         self.fieldStyles = rawStyles.compactMapValues(MenuBarFieldStyle.init(rawValue:))
-        // Absent in every settings file written before group merging existed;
+        // Absent in every settings file written before segment merging existed;
         // off is the layout those bars were arranged against.
         self.mergesGroupWindows = try c.decodeIfPresent(Bool.self, forKey: .mergesGroupWindows) ?? false
         // Absent for every item that predates the composer, and lossy on
         // purpose: an unreadable strip falls back to the field-based bar
         // instead of taking the whole settings file down.
         self.composition = try? c.decodeIfPresent(MenuBarComposition.self, forKey: .composition)
-        // Absent before saved groups existed, and lossy per entry for the same
+        // Absent before saved segments existed, and lossy per entry for the same
         // reason the strip is: one unreadable preset must not cost the rest of
         // the library, let alone the item around it.
         let storedPresets = (try? c.decodeIfPresent([LossyMenuBarSegmentPreset].self, forKey: .segmentPresets))

--- a/Sources/VibeBarCore/Resources/en.lproj/Localizable.strings
+++ b/Sources/VibeBarCore/Resources/en.lproj/Localizable.strings
@@ -521,38 +521,17 @@
 /* Picker choosing a block's type weight. */
 "menuBar.composer.field.weight" = "Weight";
 
-/* Palette button adding an empty group to the strip. */
-"menuBar.composer.group.add" = "New group";
+/* Button that binds the selected blocks into one run */
+"menuBar.composer.group.bind" = "Group";
 
-/* Tooltip on the New group button. */
-"menuBar.composer.group.addHelp" = "Each group is one column of the strip. Give a group a second row to stack that column.";
+/* Explains how to bind blocks and what binding does */
+"menuBar.composer.group.hint" = "Shift-click blocks that sit side by side in one row. A group moves as one — drag any block in it and the whole run goes.";
 
-/* Menu item giving a group a second row. */
-"menuBar.composer.group.addRow" = "Add a second row";
+/* Shown when the selected blocks cannot be bound */
+"menuBar.composer.group.notAdjacent" = "Only blocks side by side in one row can be grouped.";
 
-/* Shown inside a group that has no blocks yet. */
-"menuBar.composer.group.empty" = "Empty group — drag a block in.";
-
-/* Menu action folding a group into the one before it. */
-"menuBar.composer.group.mergeLeft" = "Merge into the group before it";
-
-/* Menu action moving a group one place earlier. */
-"menuBar.composer.group.moveLeft" = "Move left";
-
-/* Menu action moving a group one place later. */
-"menuBar.composer.group.moveRight" = "Move right";
-
-/* Menu action deleting a group and the blocks in it. */
-"menuBar.composer.group.remove" = "Remove group and its blocks";
-
-/* Menu item closing a group's second row; its blocks join the end of the first. */
-"menuBar.composer.group.removeRow" = "Merge the second row up";
-
-/* Button starting a new group at the selected block. */
-"menuBar.composer.group.splitHere" = "Start a group here";
-
-/* Header over one group of blocks. Index counts from 1. */
-"menuBar.composer.group.title" = "Group %1$lld";
+/* Button that unbinds a run of blocks */
+"menuBar.composer.group.unbind" = "Ungroup";
 
 /* Quota metric: whichever percentage the app-wide Used/Remaining setting selects. */
 "menuBar.composer.metric.displayPercent" = "Percent (follows setting)";
@@ -609,7 +588,7 @@
 "menuBar.composer.palette" = "Add a block";
 
 /* Tooltip on a saved group. */
-"menuBar.composer.preset.insertHelp" = "Insert this group at the end of the strip.";
+"menuBar.composer.preset.insertHelp" = "Insert this segment at the end of the strip.";
 
 /* Text field for the name of a saved group. */
 "menuBar.composer.preset.name" = "Name";
@@ -624,10 +603,10 @@
 "menuBar.composer.preset.saveConfirm" = "Save";
 
 /* Title of the dialog naming a saved group. */
-"menuBar.composer.preset.saveTitle" = "Save this group";
+"menuBar.composer.preset.saveTitle" = "Save this segment";
 
 /* Caption over the saved groups that can be inserted. */
-"menuBar.composer.presets" = "Saved groups";
+"menuBar.composer.presets" = "Saved segments";
 
 /* Caption over the live preview of the composed strip. */
 "menuBar.composer.preview" = "Preview";
@@ -682,6 +661,39 @@
 
 /* Visibility rule: show once a quota's used percentage reaches a threshold. */
 "menuBar.composer.rule.whenUsedAtLeast" = "When used is at least";
+
+/* Palette button adding an empty group to the strip. */
+"menuBar.composer.segment.add" = "New segment";
+
+/* Tooltip on the New group button. */
+"menuBar.composer.segment.addHelp" = "Each segment is one column of the strip. Give a segment a second row to stack that column.";
+
+/* Menu item giving a group a second row. */
+"menuBar.composer.segment.addRow" = "Add a second row";
+
+/* Shown inside a group that has no blocks yet. */
+"menuBar.composer.segment.empty" = "Empty segment — drag a block in.";
+
+/* Menu action folding a group into the one before it. */
+"menuBar.composer.segment.mergeLeft" = "Merge into the segment before it";
+
+/* Menu action moving a group one place earlier. */
+"menuBar.composer.segment.moveLeft" = "Move left";
+
+/* Menu action moving a group one place later. */
+"menuBar.composer.segment.moveRight" = "Move right";
+
+/* Menu action deleting a group and the blocks in it. */
+"menuBar.composer.segment.remove" = "Remove segment and its blocks";
+
+/* Menu item closing a group's second row; its blocks join the end of the first. */
+"menuBar.composer.segment.removeRow" = "Merge the second row up";
+
+/* Button starting a new group at the selected block. */
+"menuBar.composer.segment.splitHere" = "Start a segment here";
+
+/* Header over one group of blocks. Index counts from 1. */
+"menuBar.composer.segment.title" = "Segment %1$lld";
 
 /* Caption over the controls for the selected block. */
 "menuBar.composer.selected" = "Selected block";

--- a/Sources/VibeBarCore/Resources/en.lproj/Localizable.stringsdict
+++ b/Sources/VibeBarCore/Resources/en.lproj/Localizable.stringsdict
@@ -99,6 +99,22 @@
 			<string>%1$lld minutes</string>
 		</dict>
 	</dict>
+	<key>menuBar.composer.group.selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>1 block selected</string>
+			<key>other</key>
+			<string>%1$lld blocks selected</string>
+		</dict>
+	</dict>
 	<key>menuBar.composer.space.widthValue</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.strings
@@ -521,38 +521,17 @@
 /* Picker choosing a block's type weight. */
 "menuBar.composer.field.weight" = "字重";
 
-/* Palette button adding an empty group to the strip. */
-"menuBar.composer.group.add" = "新建分组";
+/* Button that binds the selected blocks into one run */
+"menuBar.composer.group.bind" = "成组";
 
-/* Tooltip on the New group button. */
-"menuBar.composer.group.addHelp" = "每个分组是条带中的一列。为分组添加第二行可让该列上下堆叠。";
+/* Explains how to bind blocks and what binding does */
+"menuBar.composer.group.hint" = "按住 Shift 点选同一行里相邻的积木。成组后它们作为整体移动 —— 拖其中任意一个，整组一起走。";
 
-/* Menu item giving a group a second row. */
-"menuBar.composer.group.addRow" = "添加第二行";
+/* Shown when the selected blocks cannot be bound */
+"menuBar.composer.group.notAdjacent" = "只有同一行里相邻的积木才能成组。";
 
-/* Shown inside a group that has no blocks yet. */
-"menuBar.composer.group.empty" = "空分组，可将积木拖入。";
-
-/* Menu action folding a group into the one before it. */
-"menuBar.composer.group.mergeLeft" = "并入前一个分组";
-
-/* Menu action moving a group one place earlier. */
-"menuBar.composer.group.moveLeft" = "向左移动";
-
-/* Menu action moving a group one place later. */
-"menuBar.composer.group.moveRight" = "向右移动";
-
-/* Menu action deleting a group and the blocks in it. */
-"menuBar.composer.group.remove" = "删除分组及其积木";
-
-/* Menu item closing a group's second row; its blocks join the end of the first. */
-"menuBar.composer.group.removeRow" = "将第二行并入第一行";
-
-/* Button starting a new group at the selected block. */
-"menuBar.composer.group.splitHere" = "从此处开始新分组";
-
-/* Header over one group of blocks. Index counts from 1. */
-"menuBar.composer.group.title" = "分组 %1$lld";
+/* Button that unbinds a run of blocks */
+"menuBar.composer.group.unbind" = "解组";
 
 /* Quota metric: whichever percentage the app-wide Used/Remaining setting selects. */
 "menuBar.composer.metric.displayPercent" = "百分比（跟随设置）";
@@ -609,7 +588,7 @@
 "menuBar.composer.palette" = "添加积木";
 
 /* Tooltip on a saved group. */
-"menuBar.composer.preset.insertHelp" = "在条带末尾插入该分组。";
+"menuBar.composer.preset.insertHelp" = "在条带末尾插入该段。";
 
 /* Text field for the name of a saved group. */
 "menuBar.composer.preset.name" = "名称";
@@ -624,10 +603,10 @@
 "menuBar.composer.preset.saveConfirm" = "保存";
 
 /* Title of the dialog naming a saved group. */
-"menuBar.composer.preset.saveTitle" = "保存该分组";
+"menuBar.composer.preset.saveTitle" = "保存该段";
 
 /* Caption over the saved groups that can be inserted. */
-"menuBar.composer.presets" = "已存分组";
+"menuBar.composer.presets" = "已存的段";
 
 /* Caption over the live preview of the composed strip. */
 "menuBar.composer.preview" = "预览";
@@ -682,6 +661,39 @@
 
 /* Visibility rule: show once a quota's used percentage reaches a threshold. */
 "menuBar.composer.rule.whenUsedAtLeast" = "已用不低于";
+
+/* Palette button adding an empty group to the strip. */
+"menuBar.composer.segment.add" = "新建段";
+
+/* Tooltip on the New group button. */
+"menuBar.composer.segment.addHelp" = "每个段是条带中的一列。为段添加第二行可让该列上下堆叠。";
+
+/* Menu item giving a group a second row. */
+"menuBar.composer.segment.addRow" = "添加第二行";
+
+/* Shown inside a group that has no blocks yet. */
+"menuBar.composer.segment.empty" = "空段，可将积木拖入。";
+
+/* Menu action folding a group into the one before it. */
+"menuBar.composer.segment.mergeLeft" = "并入前一个段";
+
+/* Menu action moving a group one place earlier. */
+"menuBar.composer.segment.moveLeft" = "向左移动";
+
+/* Menu action moving a group one place later. */
+"menuBar.composer.segment.moveRight" = "向右移动";
+
+/* Menu action deleting a group and the blocks in it. */
+"menuBar.composer.segment.remove" = "删除该段及其积木";
+
+/* Menu item closing a group's second row; its blocks join the end of the first. */
+"menuBar.composer.segment.removeRow" = "将第二行并入第一行";
+
+/* Button starting a new group at the selected block. */
+"menuBar.composer.segment.splitHere" = "从此处开始新的段";
+
+/* Header over one group of blocks. Index counts from 1. */
+"menuBar.composer.segment.title" = "段 %1$lld";
 
 /* Caption over the controls for the selected block. */
 "menuBar.composer.selected" = "已选积木";

--- a/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.stringsdict
+++ b/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.stringsdict
@@ -87,6 +87,20 @@
 			<string>%1$lld 分钟</string>
 		</dict>
 	</dict>
+	<key>menuBar.composer.group.selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>other</key>
+			<string>已选 %1$lld 个积木</string>
+		</dict>
+	</dict>
 	<key>menuBar.composer.space.widthValue</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
+++ b/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
@@ -3230,6 +3230,22 @@ final class MenuBarCompositionTests: XCTestCase {
         XCTAssertEqual(composition, before)
     }
 
+    func testBoundGroupIDsAgreesWithAskingBlockByBlock() {
+        var (composition, tokens) = composedRun()
+        composition.group([tokens[1].id, tokens[2].id])
+        // The editor reads the set once per redraw instead of walking the
+        // strip per chip; the two must say the same thing.
+        let bound = composition.boundGroupIDs
+        for token in tokens {
+            let stored = composition.token(token.id)?.groupID
+            XCTAssertEqual(
+                stored.map(bound.contains) ?? false,
+                composition.isGrouped(token.id)
+            )
+        }
+        XCTAssertEqual(bound.count, 1)
+    }
+
     func testUngroupingLeavesEveryBlockWhereItWas() {
         var (composition, tokens) = composedRun()
         composition.group([tokens[1].id, tokens[2].id])

--- a/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
+++ b/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
@@ -3246,6 +3246,29 @@ final class MenuBarCompositionTests: XCTestCase {
         XCTAssertEqual(bound.count, 1)
     }
 
+    func testAGroupThatDecodesWithAGapIsNotAGroup() throws {
+        var (composition, tokens) = composedRun()
+        composition.group([tokens[0].id, tokens[1].id, tokens[2].id])
+        var object = try JSONSerialization.jsonObject(
+            with: try JSONEncoder().encode(composition)
+        ) as! [String: Any]
+        // What a hand-edited or partly written settings file looks like: the
+        // middle member loses its binding, the two around it keep theirs.
+        var segments = object["segments"] as! [[String: Any]]
+        var top = segments[0]["top"] as! [[String: Any]]
+        top[1].removeValue(forKey: "groupID")
+        segments[0]["top"] = top
+        object["segments"] = segments
+
+        let reloaded = try JSONDecoder().decode(
+            MenuBarComposition.self,
+            from: try JSONSerialization.data(withJSONObject: object)
+        )
+        XCTAssertFalse(reloaded.isGrouped(tokens[0].id),
+                       "a run with a stranger through it must not survive a reload")
+        XCTAssertEqual(reloaded.groupedRun(of: tokens[0].id), [tokens[0].id])
+    }
+
     func testUngroupingLeavesEveryBlockWhereItWas() {
         var (composition, tokens) = composedRun()
         composition.group([tokens[1].id, tokens[2].id])

--- a/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
+++ b/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
@@ -3059,4 +3059,136 @@ final class MenuBarCompositionTests: XCTestCase {
         canvas.availableHeight = 24
         return canvas
     }
+
+    // MARK: - Blocks bound together
+
+    /// Three blocks side by side, the middle two bound.
+    private func composedRun() -> (MenuBarComposition, [MenuBarToken]) {
+        let tokens = [
+            MenuBarToken.newLogo(.claude),
+            MenuBarToken.newText(),
+            MenuBarToken.newQuota(fieldId: "claude.five_hour"),
+            MenuBarToken.newSeparator()
+        ]
+        var composition = MenuBarComposition(isEnabled: true)
+        composition.segments = [MenuBarSegment(tokens: tokens)]
+        return (composition, tokens)
+    }
+
+    func testBlocksSideBySideInOneRowCanBeBound() {
+        var (composition, tokens) = composedRun()
+        let group = composition.group([tokens[1].id, tokens[2].id])
+        XCTAssertNotNil(group)
+        XCTAssertEqual(composition.groupedRun(of: tokens[1].id), [tokens[1].id, tokens[2].id])
+        XCTAssertTrue(composition.isGrouped(tokens[2].id))
+        XCTAssertFalse(composition.isGrouped(tokens[0].id))
+    }
+
+    func testTheGroupButtonAndTheGroupOperationAgree() {
+        var (composition, tokens) = composedRun()
+        let adjacent = [tokens[1].id, tokens[2].id]
+        let apart = [tokens[0].id, tokens[2].id]
+        let alone = [tokens[0].id]
+        XCTAssertTrue(composition.canGroup(adjacent))
+        XCTAssertFalse(composition.canGroup(apart))
+        XCTAssertFalse(composition.canGroup(alone))
+        XCTAssertNotNil(composition.group(adjacent))
+        var other = composition
+        XCTAssertNil(other.group(apart))
+        XCTAssertNil(other.group(alone))
+    }
+
+    func testBlocksWithAStrangerBetweenThemAreRefusedRatherThanRearranged() {
+        var (composition, tokens) = composedRun()
+        XCTAssertNil(composition.group([tokens[0].id, tokens[2].id]))
+        XCTAssertEqual(composition.segments.first?.top.map(\.id), tokens.map(\.id),
+                       "a refused binding must not move anything")
+        XCTAssertFalse(composition.isGrouped(tokens[0].id))
+    }
+
+    func testDraggingOneMemberBringsTheWholeRun() {
+        var (composition, tokens) = composedRun()
+        composition.group([tokens[1].id, tokens[2].id])
+        composition.move(tokens[2].id, before: tokens[0].id)
+        XCTAssertEqual(
+            composition.segments.first?.top.map(\.id),
+            [tokens[1].id, tokens[2].id, tokens[0].id, tokens[3].id]
+        )
+        XCTAssertTrue(composition.isGrouped(tokens[1].id), "the run stays bound after the move")
+    }
+
+    func testARunDraggedToTheEndOfARowArrivesInOrder() {
+        var (composition, tokens) = composedRun()
+        composition.group([tokens[0].id, tokens[1].id])
+        let address = MenuBarComposition.RowAddress(
+            segment: composition.segments[0].id, row: .top
+        )
+        composition.move(tokens[0].id, toEndOf: address)
+        XCTAssertEqual(
+            composition.segments.first?.top.map(\.id),
+            [tokens[2].id, tokens[3].id, tokens[0].id, tokens[1].id]
+        )
+    }
+
+    func testDroppingABlockIntoTheMiddleOfARunDissolvesIt() {
+        var (composition, tokens) = composedRun()
+        composition.group([tokens[1].id, tokens[2].id])
+        composition.move(tokens[3].id, before: tokens[2].id)
+        XCTAssertEqual(
+            composition.segments.first?.top.map(\.id),
+            [tokens[0].id, tokens[1].id, tokens[3].id, tokens[2].id]
+        )
+        XCTAssertFalse(composition.isGrouped(tokens[1].id),
+                       "a run with a stranger through it is not a run")
+    }
+
+    func testARunDownToOneBlockIsNoLongerAGroup() {
+        var (composition, tokens) = composedRun()
+        composition.group([tokens[1].id, tokens[2].id])
+        composition.remove(tokens[2].id)
+        XCTAssertFalse(composition.isGrouped(tokens[1].id))
+        XCTAssertEqual(composition.groupedRun(of: tokens[1].id), [tokens[1].id])
+    }
+
+    func testAThirdMemberLeavesTheOthersBound() {
+        var (composition, tokens) = composedRun()
+        composition.group([tokens[1].id, tokens[2].id, tokens[3].id])
+        composition.remove(tokens[3].id)
+        XCTAssertEqual(composition.groupedRun(of: tokens[1].id), [tokens[1].id, tokens[2].id])
+    }
+
+    func testASegmentIsNotSplitThroughARun() {
+        var (composition, tokens) = composedRun()
+        composition.group([tokens[1].id, tokens[2].id])
+        composition.splitSegment(before: tokens[2].id)
+        XCTAssertEqual(composition.segments.count, 1, "the cut would have halved the run")
+        composition.splitSegment(before: tokens[1].id)
+        XCTAssertEqual(composition.segments.count, 2, "a run may start a segment")
+        XCTAssertTrue(composition.isGrouped(tokens[1].id))
+    }
+
+    func testUngroupingLeavesEveryBlockWhereItWas() {
+        var (composition, tokens) = composedRun()
+        composition.group([tokens[1].id, tokens[2].id])
+        composition.ungroup(tokens[2].id)
+        XCTAssertEqual(composition.segments.first?.top.map(\.id), tokens.map(\.id))
+        XCTAssertFalse(composition.isGrouped(tokens[1].id))
+    }
+
+    func testABindingSurvivesASaveAndReload() throws {
+        var (composition, tokens) = composedRun()
+        let group = try XCTUnwrap(composition.group([tokens[1].id, tokens[2].id]))
+        let data = try JSONEncoder().encode(composition)
+        let reloaded = try JSONDecoder().decode(MenuBarComposition.self, from: data)
+        XCTAssertEqual(reloaded.segments.first?.top[1].groupID, group)
+        XCTAssertEqual(reloaded.groupedRun(of: tokens[1].id), [tokens[1].id, tokens[2].id])
+    }
+
+    func testABlockFromBeforeGroupsExistedDecodesUnbound() throws {
+        let json = Data("""
+        {"id":"11111111-1111-1111-1111-111111111111","kind":{"case":"appIcon"}}
+        """.utf8)
+        let token = try JSONDecoder().decode(MenuBarToken.self, from: json)
+        XCTAssertNil(token.groupID)
+    }
 }

--- a/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
+++ b/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
@@ -3167,6 +3167,59 @@ final class MenuBarCompositionTests: XCTestCase {
         XCTAssertTrue(composition.isGrouped(tokens[1].id))
     }
 
+    func testRebindingAnOverlappingRunLeavesNoStragglers() {
+        var (composition, tokens) = composedRun()
+        composition.group([tokens[0].id, tokens[1].id])
+        composition.group([tokens[1].id, tokens[2].id])
+        XCTAssertEqual(composition.groupedRun(of: tokens[1].id), [tokens[1].id, tokens[2].id])
+        XCTAssertFalse(composition.isGrouped(tokens[0].id))
+        let copy = try? XCTUnwrap(composition.duplicate(tokens[0].id))
+        XCTAssertNotNil(copy)
+        XCTAssertNil(composition.token(copy!)?.groupID,
+                     "a stale binding must not be copied onto the duplicate")
+    }
+
+    func testARunCutAcrossTwoRowsIsDissolvedWholesale() {
+        var (composition, tokens) = composedRun()
+        composition.group([tokens[0].id, tokens[1].id, tokens[2].id, tokens[3].id])
+        // What a template change does: the seam moves half the row down.
+        var segment = composition.segments[0]
+        let moved = Array(segment.top[2...])
+        segment.top.removeSubrange(2...)
+        segment.bottom = moved
+        composition.segments[0] = segment
+        composition.normalizeGroups()
+        for token in tokens {
+            XCTAssertFalse(composition.isGrouped(token.id),
+                           "each half looks contiguous on its own, but the run is gone")
+        }
+    }
+
+    func testTheSamePresetInsertedTwiceMakesTwoSeparateRuns() throws {
+        var (composition, tokens) = composedRun()
+        composition.group([tokens[1].id, tokens[2].id])
+        let preset = MenuBarSegmentPreset(name: "run", segment: composition.segments[0])
+        let first = preset.segment()
+        let second = preset.segment()
+        let firstGroups = Set(first.top.compactMap(\.groupID))
+        let secondGroups = Set(second.top.compactMap(\.groupID))
+        XCTAssertEqual(firstGroups.count, 1)
+        XCTAssertEqual(secondGroups.count, 1)
+        XCTAssertTrue(firstGroups.isDisjoint(with: secondGroups),
+                      "two copies of one preset must not share a binding")
+    }
+
+    func testTheSplitButtonAndTheSplitAgree() {
+        var (composition, tokens) = composedRun()
+        composition.group([tokens[1].id, tokens[2].id])
+        XCTAssertFalse(composition.canSplitSegment(before: tokens[0].id), "already first")
+        XCTAssertTrue(composition.canSplitSegment(before: tokens[1].id), "a run may start one")
+        XCTAssertFalse(composition.canSplitSegment(before: tokens[2].id), "would halve the run")
+        let before = composition.segments.count
+        composition.splitSegment(before: tokens[2].id)
+        XCTAssertEqual(composition.segments.count, before)
+    }
+
     func testUngroupingLeavesEveryBlockWhereItWas() {
         var (composition, tokens) = composedRun()
         composition.group([tokens[1].id, tokens[2].id])

--- a/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
+++ b/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
@@ -3220,6 +3220,16 @@ final class MenuBarCompositionTests: XCTestCase {
         XCTAssertEqual(composition.segments.count, before)
     }
 
+    func testAMoveToAnUnknownTargetChangesNothing() {
+        var (composition, tokens) = composedRun()
+        composition.group([tokens[1].id, tokens[2].id])
+        let before = composition
+        composition.move(tokens[1].id, before: UUID())
+        XCTAssertEqual(composition, before, "a move to nowhere must not rearrange the strip")
+        composition.move(tokens[0].id, before: UUID())
+        XCTAssertEqual(composition, before)
+    }
+
     func testUngroupingLeavesEveryBlockWhereItWas() {
         var (composition, tokens) = composedRun()
         composition.group([tokens[1].id, tokens[2].id])

--- a/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
+++ b/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
@@ -3269,6 +3269,34 @@ final class MenuBarCompositionTests: XCTestCase {
         XCTAssertEqual(reloaded.groupedRun(of: tokens[0].id), [tokens[0].id])
     }
 
+    func testASelectionAcrossTwoRowsIsNotARun() {
+        var (composition, tokens) = composedRun()
+        var segment = composition.segments[0]
+        let moved = Array(segment.top[2...])
+        segment.top.removeSubrange(2...)
+        segment.bottom = moved
+        composition.segments[0] = segment
+        XCTAssertFalse(composition.canGroup([tokens[1].id, tokens[2].id]),
+                       "one block per row is not side by side")
+        XCTAssertNil(composition.group([tokens[1].id, tokens[2].id]))
+    }
+
+    func testAPresetCarryingABrokenRunLandsUnbound() {
+        var (composition, tokens) = composedRun()
+        composition.group([tokens[0].id, tokens[1].id, tokens[2].id])
+        var segment = composition.segments[0]
+        // What a preset file with one member's binding lost looks like.
+        segment.top[1].groupID = nil
+        let preset = MenuBarSegmentPreset(name: "broken", segment: segment)
+
+        var target = MenuBarComposition(isEnabled: true)
+        target.appendSegment(preset.segment())
+        let landed = target.segments[0].top
+        XCTAssertFalse(target.isGrouped(landed[0].id),
+                       "two blocks with a stranger between them are not a run")
+        XCTAssertTrue(landed.allSatisfy { $0.groupID == nil })
+    }
+
     func testUngroupingLeavesEveryBlockWhereItWas() {
         var (composition, tokens) = composedRun()
         composition.group([tokens[1].id, tokens[2].id])


### PR DESCRIPTION
AQ: *"segment是segment group是group"* — *"group比如图3，红框这几个我组成一个group，挪动就一起挪动"*.

Right on both counts, and the first was in the second's way.

## The word was spent on the wrong thing

The composer's top-level container is a `MenuBarSegment` in the model and has been labelled **"GROUP 1"** in the UI since it shipped — "New group", "Remove group and its blocks", "Saved groups". So there was no word left for a run of blocks bound together, which is what a group should mean here.

Fourteen strings move from `menuBar.composer.group.*` to `menuBar.composer.segment.*`, plus the comments that used the same wrong word. Quota groups keep it — those really are groups.

## A group is a run that moves as one

Shift-click blocks that sit side by side in one row, then **Group**. They are bound, drawn with a shared accent, and dragging any of them brings the whole run. A selected member's inspector offers **Ungroup**.

`MenuBarToken.groupID` holds the binding. `MenuBarComposition` holds one invariant: **a group's members are always contiguous within one row**, and every edit that would scatter them dissolves the group rather than repairing it. An edit must never silently reorder the user's strip to keep a binding alive. So:

- a stranger dropped through a run unbinds it;
- a run down to its last block stops being a group;
- "Start a segment here" refuses a cut that would halve one;
- binding blocks that are not already side by side is refused, not fixed by moving the block in between.

`canGroup` is the predicate `group` itself uses, so the button offering the action and the action cannot disagree.

Multi-selection exists only for this. `selection` is a `Set` now, but the inspector still edits exactly one block and every other control reads the single one. Shift takes priority over the chip's own tap, so one click still picks a block.

## Verification

Thirteen model tests, including a save-and-reload and a block written before any of this existed. `swift build`, `swift test` (2286 pass), `./Scripts/build_app.sh release`.

And driven in the built app, not just compiled: shift-clicking two chips raises the "2 blocks selected" bar, Group tints them, dragging one carries **both** from the second row to the third, and Ungroup appears on a member.

🤖 Generated with [Claude Code](https://claude.com/claude-code)