### PR TITLE
Give the Grok Bot card its own name and mark

### DIFF
--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -2041,7 +2041,9 @@ struct ProviderQuotaCard: View {
                     }
                 }
                 HStack(alignment: .center, spacing: 6) {
-                    ToolBrandIconView(tool: tool, size: 13)
+                    // Bucket-aware, like the name beside it: drawing `tool`
+                    // here put Cursor's cube next to the word "Grok Bot".
+                    QuotaBrandIconView(tool: tool, bucketID: scopedBucketID, size: 13)
                         .opacity(0.85)
                     Text(subProviderTitle)
                         .font(.system(size: max(10, density.subtitleFontSize), weight: .semibold))
@@ -2154,8 +2156,20 @@ struct ProviderQuotaCard: View {
         displayBuckets(from: resolvedQuota)
     }
 
+    /// The one bucket this card is scoped to, when it is scoped to one.
+    ///
+    /// That is how a SubProvider riding another company's account gets its own
+    /// identity: Grok Bot's quota arrives as Cursor's `grok_bot_weekly`, so a
+    /// card built for that bucket alone is Grok Bot's card, not Cursor's. A
+    /// card scoped to several buckets — Cursor Models is two — is still the
+    /// account holder's, and resolves to it.
+    private var scopedBucketID: String? {
+        guard let includedBucketIDs, includedBucketIDs.count == 1 else { return nil }
+        return includedBucketIDs.first
+    }
+
     private var subProviderTitle: String {
-        tool.quotaSubProviderName()
+        tool.quotaSubProviderName(bucketID: scopedBucketID)
     }
 
     private func displayBuckets(from quota: AccountQuota?) -> [QuotaBucket] {


### PR DESCRIPTION
Spotted while capturing screenshots: the Grok Bot card in the SpaceXAI page wears Cursor's cube.

## Cause

`ProviderQuotaCard`'s SubProvider header resolved both its title and its icon from `tool` alone:

```swift
ToolBrandIconView(tool: tool, size: 13)
Text(subProviderTitle)          // tool.quotaSubProviderName()
```

The card built for Grok Bot is `ProviderQuotaCard(tool: .cursor, includedBucketIDs: ["grok_bot_weekly"])`, so both fall back to the account holder: Cursor's name *and* Cursor's mark on Grok Bot's quota.

## Fix

The card already knows its scope. When that is exactly one bucket, the bucket resolves both — the seam `quotaSubProviderName(bucketID:)` and `BrandMark.subProvider` already exist for, and which `QuotaGroupCard` and the mini window already use. A card scoped to several buckets, as Cursor Models is (`["models", "other_models"]`), is still the account holder's and keeps resolving to it.

## Verification, and its limit

`swift build`, `swift test` (2274 pass). The rule this leans on is already pinned in `ProviderPlanDisplayTests`: `ToolType.cursor.quotaSubProviderName(bucketID: "grok_bot_weekly") == "Grok Bot"`.

**I could not render the card to check it visually.** The Cursor and Grok Bot cards only appear when a Cursor *account* is configured — `showsCursor` requires `source != .notConfigured` — and the demo home has the Cursor quota (buckets `models`, `other_models`, `grok_bot_weekly`) but no configured account, so both cards stay hidden in demo mode. The change is two lines against a seam that is tested, but the pixels are unconfirmed; worth an eyeball in a real build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)