### PR TITLE
Show the real surface in both layout editors

### DIFF
--- a/Resources/i18n/en.json
+++ b/Resources/i18n/en.json
@@ -3151,6 +3151,14 @@
     "comment": "Settings row label for the in-app language override",
     "value": "Language"
   },
+  "settings.layout.openStudio": {
+    "comment": "Button that opens the full-size layout studio window",
+    "value": "Open Studio"
+  },
+  "settings.layout.openStudioHelp": {
+    "comment": "Tooltip for the studio button",
+    "value": "Arrange this surface beside a full-size, live preview of it."
+  },
   "settings.layout.preview": {
     "comment": "Caption over the live popover preview in the layout editor",
     "value": "Preview"
@@ -3158,6 +3166,14 @@
   "settings.layout.previewUnavailable": {
     "comment": "Shown when a layout page has no popover tab to draw",
     "value": "This page has no popover tab to preview."
+  },
+  "settings.layout.studioLive": {
+    "comment": "Caption marking the studio preview as live",
+    "value": "Live"
+  },
+  "settings.layout.studioTitle": {
+    "comment": "Title of the layout studio window",
+    "value": "Layout Studio"
   },
   "settings.mcp.allowRefresh": {
     "comment": "Toggle label",

--- a/Resources/i18n/en.json
+++ b/Resources/i18n/en.json
@@ -3151,6 +3151,14 @@
     "comment": "Settings row label for the in-app language override",
     "value": "Language"
   },
+  "settings.layout.preview": {
+    "comment": "Caption over the live popover preview in the layout editor",
+    "value": "Preview"
+  },
+  "settings.layout.previewUnavailable": {
+    "comment": "Shown when a layout page has no popover tab to draw",
+    "value": "This page has no popover tab to preview."
+  },
   "settings.mcp.allowRefresh": {
     "comment": "Toggle label",
     "value": "Allow agents to refresh quota"
@@ -3412,6 +3420,10 @@
     },
     "comment": "Ordinal badge showing a field's place in the order",
     "value": "{position}"
+  },
+  "settings.miniWindow.preview": {
+    "comment": "Caption over the live mini-window preview in Settings",
+    "value": "Preview"
   },
   "settings.miniWindow.removeFromWindow": {
     "comment": "Tooltip on a row's remove control",

--- a/Resources/i18n/en.json
+++ b/Resources/i18n/en.json
@@ -3167,13 +3167,21 @@
     "comment": "Shown when a layout page has no popover tab to draw",
     "value": "This page has no popover tab to preview."
   },
-  "settings.layout.studioLive": {
-    "comment": "Caption marking the studio preview as live",
-    "value": "Live"
-  },
   "settings.layout.studioTitle": {
     "comment": "Title of the layout studio window",
     "value": "Layout Studio"
+  },
+  "settings.layout.studioToggleInspector": {
+    "comment": "Tooltip for the button that hides the studio's controls",
+    "value": "Show or hide the controls"
+  },
+  "settings.layout.studioZoomActual": {
+    "comment": "Zoom control: draw the surface at its own size",
+    "value": "Actual size"
+  },
+  "settings.layout.studioZoomFit": {
+    "comment": "Zoom control: shrink the surface to fit the stage",
+    "value": "Fit"
   },
   "settings.mcp.allowRefresh": {
     "comment": "Toggle label",

--- a/Resources/i18n/zh-Hans.json
+++ b/Resources/i18n/zh-Hans.json
@@ -2123,11 +2123,17 @@
   "settings.layout.previewUnavailable": {
     "value": "该页面没有可预览的 popover 标签页。"
   },
-  "settings.layout.studioLive": {
-    "value": "实时"
-  },
   "settings.layout.studioTitle": {
     "value": "布局工作台"
+  },
+  "settings.layout.studioToggleInspector": {
+    "value": "显示或隐藏控件"
+  },
+  "settings.layout.studioZoomActual": {
+    "value": "实际大小"
+  },
+  "settings.layout.studioZoomFit": {
+    "value": "适应"
   },
   "settings.mcp.allowRefresh": {
     "value": "允许 agent 刷新额度"

--- a/Resources/i18n/zh-Hans.json
+++ b/Resources/i18n/zh-Hans.json
@@ -2111,11 +2111,23 @@
   "settings.language.title": {
     "value": "语言"
   },
+  "settings.layout.openStudio": {
+    "value": "打开工作台"
+  },
+  "settings.layout.openStudioHelp": {
+    "value": "在整尺寸的实时预览旁边排布这个界面。"
+  },
   "settings.layout.preview": {
     "value": "预览"
   },
   "settings.layout.previewUnavailable": {
     "value": "该页面没有可预览的 popover 标签页。"
+  },
+  "settings.layout.studioLive": {
+    "value": "实时"
+  },
+  "settings.layout.studioTitle": {
+    "value": "布局工作台"
   },
   "settings.mcp.allowRefresh": {
     "value": "允许 agent 刷新额度"

--- a/Resources/i18n/zh-Hans.json
+++ b/Resources/i18n/zh-Hans.json
@@ -2111,6 +2111,12 @@
   "settings.language.title": {
     "value": "语言"
   },
+  "settings.layout.preview": {
+    "value": "预览"
+  },
+  "settings.layout.previewUnavailable": {
+    "value": "该页面没有可预览的 popover 标签页。"
+  },
   "settings.mcp.allowRefresh": {
     "value": "允许 agent 刷新额度"
   },
@@ -2302,6 +2308,9 @@
   },
   "settings.miniWindow.position": {
     "value": "{position}"
+  },
+  "settings.miniWindow.preview": {
+    "value": "预览"
   },
   "settings.miniWindow.removeFromWindow": {
     "value": "从此窗口移除"

--- a/Sources/VibeBarApp/Controllers/DockActivationController.swift
+++ b/Sources/VibeBarApp/Controllers/DockActivationController.swift
@@ -14,6 +14,11 @@ final class DockActivationController {
     enum DockToken: String, Hashable {
         case workbench
         case onboarding
+        /// The layout studio outlives the Workbench that opened it, so it
+        /// cannot borrow the Workbench's token: closing the Workbench would
+        /// drop the app back to `.accessory` and leave a window on screen that
+        /// nothing can bring back to the front.
+        case layoutStudio
     }
 
     private var tokens: Set<DockToken> = []

--- a/Sources/VibeBarApp/Controllers/LayoutStudioWindowController.swift
+++ b/Sources/VibeBarApp/Controllers/LayoutStudioWindowController.swift
@@ -1,0 +1,85 @@
+import AppKit
+import SwiftUI
+import VibeBarCore
+
+/// The window the layout editors hand off to when a picture is not enough.
+///
+/// Settings shows a skeleton: it fits the room a pane has, and structure is
+/// what arranging mostly needs. Seeing the real surface needs the surface's own
+/// width — a popover page and a mini window each want more than a settings
+/// column has left over, and squeezing one in crowds the controls it is
+/// supposed to help. So the full-size preview is a separate place rather than a
+/// second thing competing for the same pane.
+///
+/// One window for both subjects. The two editors differ in what they arrange,
+/// not in what the room is for.
+@MainActor
+final class LayoutStudioWindowController: NSObject {
+    static let shared = LayoutStudioWindowController()
+    static let frameAutosaveName = "VibeBarLayoutStudioWindow"
+
+    /// What the studio is arranging.
+    enum Subject: Hashable {
+        case popoverPage(PageLayoutPageID)
+        case miniWindow(UUID)
+    }
+
+    private var window: NSWindow?
+    private let model = LayoutStudioModel()
+
+    func open(subject: Subject, environment: AppEnvironment) {
+        model.subject = subject
+
+        if let window {
+            if window.isMiniaturized { window.deminiaturize(nil) }
+            window.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+
+        let hosting = NSHostingController(
+            rootView: LayoutStudioView(model: model)
+                .environmentObject(environment)
+                .environmentObject(environment.accountStore)
+                .environmentObject(environment.settingsStore)
+                .environmentObject(environment.quotaService)
+                .environmentObject(environment.serviceStatus)
+                .environmentObject(environment.costService)
+                .environmentObject(environment.remoteProbeService)
+                .environmentObject(environment.pageLayout)
+                .environmentObject(environment.workbenchServices)
+        )
+        let initialSize = NSSize(width: 1160, height: 800)
+        let win = NSWindow(
+            contentRect: NSRect(origin: .zero, size: initialSize),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        win.title = L10n.Settings.layoutStudioTitle
+        win.titlebarAppearsTransparent = true
+        win.isReleasedWhenClosed = false
+        win.contentViewController = hosting
+        win.setContentSize(initialSize)
+        win.center()
+        win.minSize = NSSize(width: 900, height: 620)
+        if !DemoMode.isEnabled {
+            win.setFrameAutosaveName(Self.frameAutosaveName)
+        }
+        self.window = win
+
+        win.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    func close() {
+        window?.close()
+    }
+}
+
+/// What the studio is looking at. Owned by the controller so reopening the
+/// window on another subject re-points the view rather than rebuilding it.
+@MainActor
+final class LayoutStudioModel: ObservableObject {
+    @Published var subject: LayoutStudioWindowController.Subject = .popoverPage(.overview)
+}

--- a/Sources/VibeBarApp/Controllers/LayoutStudioWindowController.swift
+++ b/Sources/VibeBarApp/Controllers/LayoutStudioWindowController.swift
@@ -49,7 +49,7 @@ final class LayoutStudioWindowController: NSObject {
                 .environmentObject(environment.pageLayout)
                 .environmentObject(environment.workbenchServices)
         )
-        let initialSize = NSSize(width: 1160, height: 800)
+        let initialSize = NSSize(width: 1320, height: 860)
         let win = NSWindow(
             contentRect: NSRect(origin: .zero, size: initialSize),
             styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
@@ -57,12 +57,35 @@ final class LayoutStudioWindowController: NSObject {
             defer: false
         )
         win.title = L10n.Settings.layoutStudioTitle
+        // The chrome gets out of the way of the surface on the stage: no
+        // titlebar band, no opaque ground. The view's own materials are what
+        // the window shows, and they only read as materials if something is
+        // behind them.
         win.titlebarAppearsTransparent = true
+        win.titleVisibility = .hidden
+        win.isMovableByWindowBackground = true
+        win.isOpaque = false
+        win.backgroundColor = .clear
         win.isReleasedWhenClosed = false
-        win.contentViewController = hosting
+
+        let effect = NSVisualEffectView()
+        effect.material = .underWindowBackground
+        effect.blendingMode = .behindWindow
+        effect.state = .active
+        effect.autoresizingMask = [.width, .height]
+        let container = NSView(frame: NSRect(origin: .zero, size: initialSize))
+        effect.frame = container.bounds
+        container.addSubview(effect)
+        hosting.view.frame = container.bounds
+        hosting.view.autoresizingMask = [.width, .height]
+        container.addSubview(hosting.view)
+        let shell = NSViewController()
+        shell.view = container
+        shell.addChild(hosting)
+        win.contentViewController = shell
         win.setContentSize(initialSize)
         win.center()
-        win.minSize = NSSize(width: 900, height: 620)
+        win.minSize = NSSize(width: 1000, height: 620)
         if !DemoMode.isEnabled {
             win.setFrameAutosaveName(Self.frameAutosaveName)
         }

--- a/Sources/VibeBarApp/Controllers/LayoutStudioWindowController.swift
+++ b/Sources/VibeBarApp/Controllers/LayoutStudioWindowController.swift
@@ -29,6 +29,9 @@ final class LayoutStudioWindowController: NSObject {
 
     func open(subject: Subject, environment: AppEnvironment) {
         model.subject = subject
+        // Before the window exists: switching activation policy reorders the
+        // app's windows, and doing it afterwards can drop the new one behind.
+        DockActivationController.shared.acquire(.layoutStudio)
 
         if let window {
             if window.isMiniaturized { window.deminiaturize(nil) }
@@ -91,12 +94,19 @@ final class LayoutStudioWindowController: NSObject {
         }
         self.window = win
 
+        win.delegate = self
         win.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
     }
 
     func close() {
         window?.close()
+    }
+}
+
+extension LayoutStudioWindowController: NSWindowDelegate {
+    func windowWillClose(_ notification: Notification) {
+        DockActivationController.shared.release(.layoutStudio)
     }
 }
 

--- a/Sources/VibeBarApp/Views/LayoutEditorView.swift
+++ b/Sources/VibeBarApp/Views/LayoutEditorView.swift
@@ -27,6 +27,7 @@ import VibeBarCore
 ///   packer or the balancer, and a drag deciding it would be discarded on the
 ///   next measurement.
 struct LayoutEditorView: View {
+    @Environment(\.isInLayoutStudio) private var isInLayoutStudio
     @EnvironmentObject private var environment: AppEnvironment
     @EnvironmentObject private var settingsStore: SettingsStore
     @EnvironmentObject private var layoutModel: PageLayoutModel
@@ -133,7 +134,7 @@ struct LayoutEditorView: View {
                         mode: mode,
                         descriptors: descriptors
                     )
-                    preview(page: page)
+                    previewColumnStack(page: page, arrangement: arrangement, blocks: blocks)
                 }
             }
             Text(footnote(page: page, mode: mode))
@@ -1252,38 +1253,41 @@ struct LayoutEditorView: View {
 
     // MARK: - Preview
 
-    private func preview(page: PageLayoutPageID) -> some View {
-        // The popover itself, drawn at the width it opens at and scaled to
-        // fit. This used to be a stack of grey rectangles standing in for the
-        // cards: it showed the *shape* the segment boxes produce, which is
-        // true but is not what anyone is arranging for. The boxes beside it
-        // say what the ordering constraint is; this says what it looks like.
-        VStack(alignment: .leading, spacing: 6) {
-            Text(L10n.Settings.layoutPreview)
+    private func preview(
+        arrangement: PageLayoutArrangement,
+        blocks: [PageLayoutModuleID: Block]
+    ) -> some View {
+        // Exactly what the popover will draw: the two continuous columns, from
+        // the same arrangement call the popover makes. The zones beside this
+        // show the segment boxes; this shows what they produce, which is a page
+        // with no boundary in it at all.
+        let flowed = arrangement.flattened
+        let pageHeight = (0..<PageLayoutConfig.columnCount)
+            .map { index in flowed.column(index).reduce(0.0) { $0 + (blocks[$1]?.height ?? 0) } }
+            .max() ?? 0
+        let scale = min(0.12, Self.previewColumnHeight / max(1, pageHeight))
+        let width: CGFloat = 150
+        let gap: CGFloat = 4
+        let leftWidth = (width - gap) * ratioFraction(arrangement.ratio)
+        return VStack(alignment: .leading, spacing: 6) {
+            Text("Preview")
                 .font(.system(size: 11, weight: .semibold))
                 .foregroundStyle(.secondary)
-            Group {
-                if let tab = OverviewPage.allCases.first(where: { $0.layoutPageID == page }) {
-                    ScaledPreview(width: Self.previewWidth, maxHeight: Self.previewColumnHeight) {
-                        PopoverRoot(
-                            width: Self.popoverPreviewWidth,
-                            onContentHeightChange: { _ in },
-                            onToggleMiniWindow: {},
-                            initialPage: tab
-                        )
-                    }
-                    // `PopoverRoot` applies `initialPage` once, on a state it
-                    // owns; without a new identity, switching the page picker
-                    // would leave the preview on the page it opened with.
-                    .id(tab)
-                } else {
-                    Text(L10n.Settings.layoutPreviewUnavailable)
-                        .font(.caption2)
-                        .foregroundStyle(.tertiary)
-                        .frame(width: Self.previewWidth, alignment: .leading)
+            VStack(alignment: .leading, spacing: 5) {
+                // Stand-in for the popover's title band, so the preview reads
+                // as the popover rather than as two loose stacks.
+                RoundedRectangle(cornerRadius: 2, style: .continuous)
+                    .fill(Color.primary.opacity(0.14))
+                    .frame(height: 7)
+                HStack(alignment: .top, spacing: gap) {
+                    previewColumn(flowed.column(0), blocks: blocks, scale: scale)
+                        .frame(width: leftWidth)
+                    previewColumn(flowed.column(1), blocks: blocks, scale: scale)
+                        .frame(width: max(0, width - gap - leftWidth))
                 }
             }
             .padding(7)
+            .frame(width: width + 14, alignment: .topLeading)
             .background(
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
                     .fill(Color.primary.opacity(0.05))
@@ -1293,13 +1297,47 @@ struct LayoutEditorView: View {
                     .stroke(Color.primary.opacity(0.10), lineWidth: 0.7)
             )
         }
-        .fixedSize(horizontal: true, vertical: false)
     }
 
-    /// What the popover actually opens at, so the preview wraps and packs its
-    /// columns exactly as the real page will before being scaled down.
-    private static let popoverPreviewWidth: CGFloat = 420
-    private static let previewWidth: CGFloat = 210
+    /// The schematic, and the way out to the full-size one.
+    ///
+    /// The skeleton is what belongs here: it fits the space a settings pane
+    /// has, and reading structure is what arranging needs. Seeing the real
+    /// thing needs room this pane does not have — that is the studio's job.
+    private func previewColumnStack(
+        page: PageLayoutPageID,
+        arrangement: PageLayoutArrangement,
+        blocks: [PageLayoutModuleID: Block]
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            preview(arrangement: arrangement, blocks: blocks)
+            if !isInLayoutStudio {
+                LayoutStudioButton {
+                    LayoutStudioWindowController.shared.open(
+                        subject: .popoverPage(page),
+                        environment: environment
+                    )
+                }
+            }
+        }
+    }
+
+    private func previewColumn(
+        _ moduleIDs: [PageLayoutModuleID],
+        blocks: [PageLayoutModuleID: Block],
+        scale: Double
+    ) -> some View {
+        VStack(spacing: 2) {
+            ForEach(moduleIDs, id: \.self) { moduleID in
+                if let block = blocks[moduleID] {
+                    RoundedRectangle(cornerRadius: 2, style: .continuous)
+                        .fill(block.descriptor.accent.color.opacity(0.55))
+                        .frame(height: max(3, CGFloat(block.height * scale)))
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .top)
+    }
 
     private func ratioFraction(_ ratio: PageColumnRatio) -> CGFloat {
         CGFloat(ratio.leftFraction)

--- a/Sources/VibeBarApp/Views/LayoutEditorView.swift
+++ b/Sources/VibeBarApp/Views/LayoutEditorView.swift
@@ -40,7 +40,12 @@ struct LayoutEditorView: View {
     @EnvironmentObject private var quotaService: QuotaService
     @EnvironmentObject private var costService: CostUsageService
 
+    /// Which page this editor opens on. Settings leaves it alone and the
+    /// editor remembers its own; the studio names one, because the controls
+    /// and the surface on the stage have to be the same page.
+    var initialPage: PageLayoutPageID?
     @State private var selectedPage: PageLayoutPageID = .overview
+    @State private var hasAppliedInitialPage = false
     @State private var drag: DragState?
     /// Live frames of every block, keyed by page *and* module: switching pages
     /// must not let a module that exists on both (Service Status, say) keep the
@@ -100,6 +105,7 @@ struct LayoutEditorView: View {
 
     var body: some View {
         let pages = PageModuleCatalog.editablePages(settings: settingsStore.settings)
+        let _ = applyInitialPageIfNeeded()
         let page = pages.contains { $0.page == selectedPage } ? selectedPage : .overview
         let descriptors = PageModuleCatalog.descriptors(
             for: page,
@@ -170,6 +176,14 @@ struct LayoutEditorView: View {
             drag = nil
             pendingSegments = 0
         }
+    }
+
+    /// Once, and only when a caller named one — a later pick inside the
+    /// editor must not be snapped back.
+    private func applyInitialPageIfNeeded() {
+        guard let initialPage, !hasAppliedInitialPage else { return }
+        hasAppliedInitialPage = true
+        selectedPage = initialPage
     }
 
     // MARK: - Page picker

--- a/Sources/VibeBarApp/Views/LayoutEditorView.swift
+++ b/Sources/VibeBarApp/Views/LayoutEditorView.swift
@@ -68,7 +68,9 @@ struct LayoutEditorView: View {
     private static let blockSpacing: CGFloat = 5
     /// Height the taller column is scaled to fit.
     private static let editorColumnHeight: Double = 430
-    private static let previewColumnHeight: Double = 132
+    /// How tall the scaled preview may get before it is cut off at the
+    /// top of the page, which is the part being arranged.
+    private static let previewColumnHeight: CGFloat = 300
 
     private struct DragState {
         let moduleID: PageLayoutModuleID
@@ -131,7 +133,7 @@ struct LayoutEditorView: View {
                         mode: mode,
                         descriptors: descriptors
                     )
-                    preview(arrangement: arrangement, blocks: blocks)
+                    preview(page: page)
                 }
             }
             Text(footnote(page: page, mode: mode))
@@ -1250,41 +1252,38 @@ struct LayoutEditorView: View {
 
     // MARK: - Preview
 
-    private func preview(
-        arrangement: PageLayoutArrangement,
-        blocks: [PageLayoutModuleID: Block]
-    ) -> some View {
-        // Exactly what the popover will draw: the two continuous columns, from
-        // the same arrangement call the popover makes. The zones beside this
-        // show the segment boxes; this shows what they produce, which is a page
-        // with no boundary in it at all.
-        let flowed = arrangement.flattened
-        let pageHeight = (0..<PageLayoutConfig.columnCount)
-            .map { index in flowed.column(index).reduce(0.0) { $0 + (blocks[$1]?.height ?? 0) } }
-            .max() ?? 0
-        let scale = min(0.12, Self.previewColumnHeight / max(1, pageHeight))
-        let width: CGFloat = 150
-        let gap: CGFloat = 4
-        let leftWidth = (width - gap) * ratioFraction(arrangement.ratio)
-        return VStack(alignment: .leading, spacing: 6) {
-            Text("Preview")
+    private func preview(page: PageLayoutPageID) -> some View {
+        // The popover itself, drawn at the width it opens at and scaled to
+        // fit. This used to be a stack of grey rectangles standing in for the
+        // cards: it showed the *shape* the segment boxes produce, which is
+        // true but is not what anyone is arranging for. The boxes beside it
+        // say what the ordering constraint is; this says what it looks like.
+        VStack(alignment: .leading, spacing: 6) {
+            Text(L10n.Settings.layoutPreview)
                 .font(.system(size: 11, weight: .semibold))
                 .foregroundStyle(.secondary)
-            VStack(alignment: .leading, spacing: 5) {
-                // Stand-in for the popover's title band, so the preview reads
-                // as the popover rather than as two loose stacks.
-                RoundedRectangle(cornerRadius: 2, style: .continuous)
-                    .fill(Color.primary.opacity(0.14))
-                    .frame(height: 7)
-                HStack(alignment: .top, spacing: gap) {
-                    previewColumn(flowed.column(0), blocks: blocks, scale: scale)
-                        .frame(width: leftWidth)
-                    previewColumn(flowed.column(1), blocks: blocks, scale: scale)
-                        .frame(width: max(0, width - gap - leftWidth))
+            Group {
+                if let tab = OverviewPage.allCases.first(where: { $0.layoutPageID == page }) {
+                    ScaledPreview(width: Self.previewWidth, maxHeight: Self.previewColumnHeight) {
+                        PopoverRoot(
+                            width: Self.popoverPreviewWidth,
+                            onContentHeightChange: { _ in },
+                            onToggleMiniWindow: {},
+                            initialPage: tab
+                        )
+                    }
+                    // `PopoverRoot` applies `initialPage` once, on a state it
+                    // owns; without a new identity, switching the page picker
+                    // would leave the preview on the page it opened with.
+                    .id(tab)
+                } else {
+                    Text(L10n.Settings.layoutPreviewUnavailable)
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                        .frame(width: Self.previewWidth, alignment: .leading)
                 }
             }
             .padding(7)
-            .frame(width: width + 14, alignment: .topLeading)
             .background(
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
                     .fill(Color.primary.opacity(0.05))
@@ -1294,24 +1293,13 @@ struct LayoutEditorView: View {
                     .stroke(Color.primary.opacity(0.10), lineWidth: 0.7)
             )
         }
+        .fixedSize(horizontal: true, vertical: false)
     }
 
-    private func previewColumn(
-        _ moduleIDs: [PageLayoutModuleID],
-        blocks: [PageLayoutModuleID: Block],
-        scale: Double
-    ) -> some View {
-        VStack(spacing: 2) {
-            ForEach(moduleIDs, id: \.self) { moduleID in
-                if let block = blocks[moduleID] {
-                    RoundedRectangle(cornerRadius: 2, style: .continuous)
-                        .fill(block.descriptor.accent.color.opacity(0.55))
-                        .frame(height: max(3, CGFloat(block.height * scale)))
-                }
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .top)
-    }
+    /// What the popover actually opens at, so the preview wraps and packs its
+    /// columns exactly as the real page will before being scaled down.
+    private static let popoverPreviewWidth: CGFloat = 420
+    private static let previewWidth: CGFloat = 210
 
     private func ratioFraction(_ ratio: PageColumnRatio) -> CGFloat {
         CGFloat(ratio.leftFraction)

--- a/Sources/VibeBarApp/Views/LayoutStudioView.swift
+++ b/Sources/VibeBarApp/Views/LayoutStudioView.swift
@@ -1,0 +1,117 @@
+import SwiftUI
+import VibeBarCore
+
+/// The immersive half of the layout editors: the surface at full size, with
+/// the controls that shape it alongside.
+///
+/// The proportions are the whole point. In Settings the controls have the room
+/// and the preview is a thumbnail; here it is the other way round, because the
+/// question being asked is different — "is this the arrangement I want" rather
+/// than "which cards are where".
+struct LayoutStudioView: View {
+    @ObservedObject var model: LayoutStudioModel
+
+    @EnvironmentObject private var environment: AppEnvironment
+    @EnvironmentObject private var settingsStore: SettingsStore
+
+    /// Wide enough that neither surface is scaled down at a usual window size:
+    /// the popover opens at 420 and a mini window at rather less, so the panel
+    /// only shrinks them when the user makes the window small.
+    private static let stageWidth: CGFloat = 520
+
+    var body: some View {
+        HSplitView {
+            stage
+                .frame(minWidth: 380, idealWidth: 560)
+            controls
+                .frame(minWidth: 460)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(WorkbenchPorcelain.windowFill(for: colorSchemeKey))
+    }
+
+    @Environment(\.colorScheme) private var scheme
+    private var colorSchemeKey: ColorScheme { scheme }
+
+    // MARK: - Stage
+
+    private var stage: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                Text(subjectTitle)
+                    .font(.system(size: 13, weight: .semibold))
+                Spacer(minLength: 8)
+                Text(L10n.Settings.layoutStudioLive)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+            ScrollView([.vertical]) {
+                surface
+                    .padding(.bottom, 12)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        }
+        .padding(16)
+    }
+
+    @ViewBuilder
+    private var surface: some View {
+        switch model.subject {
+        case let .popoverPage(page):
+            if let tab = OverviewPage.allCases.first(where: { $0.layoutPageID == page }) {
+                ScaledPreview(width: Self.stageWidth, maxHeight: 3000) {
+                    PopoverRoot(
+                        width: 420,
+                        onContentHeightChange: { _ in },
+                        onToggleMiniWindow: {},
+                        initialPage: tab
+                    )
+                }
+                // `PopoverRoot` applies `initialPage` to state it owns, once.
+                .id(tab)
+            } else {
+                Text(L10n.Settings.layoutPreviewUnavailable)
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+        case let .miniWindow(id):
+            ScaledPreview(width: Self.stageWidth, maxHeight: 3000) {
+                MiniQuotaWindowView(configID: id, onClose: {}, onToggleDisplayMode: {})
+            }
+            .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(.background.secondary)
+            )
+        }
+    }
+
+    private var subjectTitle: String {
+        switch model.subject {
+        case let .popoverPage(page):
+            return OverviewPage.allCases.first { $0.layoutPageID == page }?.label
+                ?? L10n.Popover.tabOverview
+        case let .miniWindow(id):
+            return settingsStore.settings.miniWindow.config(id: id)?.name ?? "Mini"
+        }
+    }
+
+    // MARK: - Controls
+
+    private var controls: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 14) {
+                // The same editors Settings shows. One place decides what a
+                // control does; this decides how much room it gets.
+                switch model.subject {
+                case .popoverPage:
+                    LayoutEditorView()
+                case .miniWindow:
+                    MiniWindowsSettingsSection()
+                }
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .environment(\.isInLayoutStudio, true)
+    }
+}

--- a/Sources/VibeBarApp/Views/LayoutStudioView.swift
+++ b/Sources/VibeBarApp/Views/LayoutStudioView.swift
@@ -1,103 +1,251 @@
 import SwiftUI
 import VibeBarCore
 
-/// The immersive half of the layout editors: the surface at full size, with
-/// the controls that shape it alongside.
+/// The immersive half of the layout editors: the surface at full size, on a
+/// stage, with the controls that shape it alongside.
 ///
-/// The proportions are the whole point. In Settings the controls have the room
-/// and the preview is a thumbnail; here it is the other way round, because the
-/// question being asked is different — "is this the arrangement I want" rather
-/// than "which cards are where".
+/// The proportions carry the meaning. In Settings the controls own the room
+/// and the preview is a skeleton; here it inverts, because the question is
+/// different — "is this the arrangement I want" rather than "which cards are
+/// where". So the surface gets the light, the chrome gets out of the way, and
+/// everything that changes does so by moving rather than by cutting.
 struct LayoutStudioView: View {
     @ObservedObject var model: LayoutStudioModel
 
     @EnvironmentObject private var environment: AppEnvironment
     @EnvironmentObject private var settingsStore: SettingsStore
+    @Environment(\.colorScheme) private var scheme
 
-    /// Wide enough that neither surface is scaled down at a usual window size:
-    /// the popover opens at 420 and a mini window at rather less, so the panel
-    /// only shrinks them when the user makes the window small.
-    private static let stageWidth: CGFloat = 520
+    @State private var zoom: Zoom = .fit
+    @State private var isInspectorShown = true
 
-    var body: some View {
-        HSplitView {
-            stage
-                .frame(minWidth: 380, idealWidth: 560)
-            controls
-                .frame(minWidth: 460)
+    /// How much room the stage has. Measured, not assumed: "fit" has to mean
+    /// the width actually available, or the surface is drawn wider than the
+    /// stage and cut off at its edge.
+    @State private var stageWidth: CGFloat = 520
+    private static let stagePadding: CGFloat = 28
+
+    enum Zoom: Hashable, CaseIterable {
+        case fit, actual
+
+        var label: String {
+            switch self {
+            case .fit:    return L10n.Settings.layoutStudioZoomFit
+            case .actual: return L10n.Settings.layoutStudioZoomActual
+            }
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(WorkbenchPorcelain.windowFill(for: colorSchemeKey))
     }
 
-    @Environment(\.colorScheme) private var scheme
-    private var colorSchemeKey: ColorScheme { scheme }
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            backdrop
+            HStack(spacing: 0) {
+                stage
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .onGeometryChange(for: CGFloat.self) { $0.size.width } action: {
+                        stageWidth = max(200, $0 - Self.stagePadding * 2)
+                    }
+                if isInspectorShown {
+                    inspector
+                        // Wide enough for the layout editor's card names: at
+                        // 420 they truncated to "Ope…", which is exactly the
+                        // information the pane exists to show.
+                        .frame(width: 520)
+                        .transition(.move(edge: .trailing).combined(with: .opacity))
+                }
+            }
+            .safeAreaInset(edge: .top, spacing: 0) { toolbar }
+        }
+        .animation(.smooth(duration: 0.28), value: isInspectorShown)
+        .animation(.smooth(duration: 0.28), value: model.subject)
+        .animation(.smooth(duration: 0.22), value: zoom)
+    }
+
+    // MARK: - Ground
+
+    /// A soft wash rather than a flat fill: the stage reads as a lit surface
+    /// with the window's material showing through at the edges, which is what
+    /// keeps the eye on the thing being arranged.
+    private var backdrop: some View {
+        LinearGradient(
+            colors: scheme == .dark
+                ? [Color.black.opacity(0.34), Color.black.opacity(0.08)]
+                : [Color.white.opacity(0.55), Color.white.opacity(0.16)],
+            startPoint: .top,
+            endPoint: .bottom
+        )
+        .ignoresSafeArea()
+    }
+
+    // MARK: - Toolbar
+
+    private var toolbar: some View {
+        HStack(spacing: 10) {
+            subjectPicker
+            Spacer(minLength: 12)
+            Picker("", selection: $zoom) {
+                ForEach(Zoom.allCases, id: \.self) { Text($0.label).tag($0) }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .frame(width: 150)
+            Button {
+                isInspectorShown.toggle()
+            } label: {
+                Image(systemName: isInspectorShown
+                    ? "sidebar.trailing"
+                    : "sidebar.leading")
+            }
+            .buttonStyle(.plain)
+            .help(L10n.Settings.layoutStudioToggleInspector)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(.ultraThinMaterial)
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(Color.primary.opacity(0.08)).frame(height: 0.5)
+        }
+    }
+
+    /// Every surface the studio can arrange, in one row. Switching is what a
+    /// studio is for — the alternative is closing the window and opening it
+    /// again from another settings pane.
+    private var subjectPicker: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 6) {
+                ForEach(subjects, id: \.self) { subject in
+                    subjectChip(subject)
+                }
+            }
+            .padding(.vertical, 1)
+        }
+        .frame(maxWidth: 520, alignment: .leading)
+    }
+
+    private var subjects: [LayoutStudioWindowController.Subject] {
+        let pages = OverviewPage.allCases
+            .compactMap(\.layoutPageID)
+            .map(LayoutStudioWindowController.Subject.popoverPage)
+        let windows = settingsStore.settings.miniWindow.windows
+            .map { LayoutStudioWindowController.Subject.miniWindow($0.id) }
+        return pages + windows
+    }
+
+    private func subjectChip(_ subject: LayoutStudioWindowController.Subject) -> some View {
+        let isCurrent = subject == model.subject
+        return Button {
+            model.subject = subject
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: icon(for: subject))
+                    .font(.system(size: 10, weight: .semibold))
+                Text(title(for: subject))
+                    .font(.system(size: 11, weight: .medium))
+                    .lineLimit(1)
+            }
+            .padding(.horizontal, 9)
+            .padding(.vertical, 5)
+            .background {
+                if isCurrent {
+                    // One shape that slides between chips rather than seven
+                    // that fade — the selection reads as a thing that moved.
+                    RoundedRectangle(cornerRadius: 7, style: .continuous)
+                        .fill(Color.accentColor.opacity(0.22))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                                .strokeBorder(Color.accentColor.opacity(0.45), lineWidth: 0.5)
+                        )
+                        .matchedGeometryEffect(id: "studio.subject", in: chipNamespace)
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(isCurrent ? Color.primary : Color.secondary)
+    }
+
+    @Namespace private var chipNamespace
 
     // MARK: - Stage
 
     private var stage: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(spacing: 8) {
-                Text(subjectTitle)
-                    .font(.system(size: 13, weight: .semibold))
-                Spacer(minLength: 8)
-                Text(L10n.Settings.layoutStudioLive)
-                    .font(.caption2)
-                    .foregroundStyle(.tertiary)
-            }
-            ScrollView([.vertical]) {
-                surface
-                    .padding(.bottom, 12)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        ScrollView([.vertical, .horizontal]) {
+            surface
+                .padding(Self.stagePadding)
+                .frame(maxWidth: .infinity, alignment: .center)
         }
-        .padding(16)
+        .scrollBounceBehavior(.basedOnSize)
     }
 
     @ViewBuilder
     private var surface: some View {
-        switch model.subject {
-        case let .popoverPage(page):
-            if let tab = OverviewPage.allCases.first(where: { $0.layoutPageID == page }) {
-                ScaledPreview(width: Self.stageWidth, maxHeight: 3000) {
-                    PopoverRoot(
-                        width: 420,
-                        onContentHeightChange: { _ in },
-                        onToggleMiniWindow: {},
-                        initialPage: tab
-                    )
+        Group {
+            switch model.subject {
+            case let .popoverPage(page):
+                if let tab = OverviewPage.allCases.first(where: { $0.layoutPageID == page }) {
+                    lit {
+                        ScaledPreview(width: stageContentWidth, maxHeight: 4000) {
+                            PopoverRoot(
+                                width: 420,
+                                onContentHeightChange: { _ in },
+                                onToggleMiniWindow: {},
+                                initialPage: tab
+                            )
+                        }
+                    }
+                    // `PopoverRoot` applies `initialPage` to state it owns,
+                    // once, so the page only follows the picker with a new
+                    // identity behind it.
+                    .id(tab)
+                } else {
+                    Text(L10n.Settings.layoutPreviewUnavailable)
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
                 }
-                // `PopoverRoot` applies `initialPage` to state it owns, once.
-                .id(tab)
-            } else {
-                Text(L10n.Settings.layoutPreviewUnavailable)
-                    .font(.caption)
-                    .foregroundStyle(.tertiary)
+            case let .miniWindow(id):
+                lit {
+                    ScaledPreview(width: stageContentWidth, maxHeight: 4000) {
+                        MiniQuotaWindowView(configID: id, onClose: {}, onToggleDisplayMode: {})
+                    }
+                }
+                .id(id)
             }
-        case let .miniWindow(id):
-            ScaledPreview(width: Self.stageWidth, maxHeight: 3000) {
-                MiniQuotaWindowView(configID: id, onClose: {}, onToggleDisplayMode: {})
-            }
+        }
+        .transition(.asymmetric(
+            insertion: .opacity.combined(with: .scale(scale: 0.985, anchor: .top)),
+            removal: .opacity
+        ))
+    }
+
+    private var stageContentWidth: CGFloat {
+        switch zoom {
+        case .fit:    return stageWidth
+        case .actual: return 10_000   // never shrinks: `ScaledPreview` caps at 1×
+        }
+    }
+
+    /// The surface, lifted off the ground.
+    ///
+    /// A shadow and a hairline, not a frame: the point is that the thing on
+    /// the stage is the real surface, so it keeps its own corners and gets
+    /// only the light around it.
+    private func lit<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
+        content()
             .background(
-                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
                     .fill(.background.secondary)
             )
-        }
+            .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .strokeBorder(Color.primary.opacity(0.10), lineWidth: 0.5)
+            )
+            .shadow(color: .black.opacity(scheme == .dark ? 0.55 : 0.18), radius: 24, y: 12)
     }
 
-    private var subjectTitle: String {
-        switch model.subject {
-        case let .popoverPage(page):
-            return OverviewPage.allCases.first { $0.layoutPageID == page }?.label
-                ?? L10n.Popover.tabOverview
-        case let .miniWindow(id):
-            return settingsStore.settings.miniWindow.config(id: id)?.name ?? "Mini"
-        }
-    }
+    // MARK: - Inspector
 
-    // MARK: - Controls
-
-    private var controls: some View {
+    private var inspector: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 14) {
                 // The same editors Settings shows. One place decides what a
@@ -113,5 +261,28 @@ struct LayoutStudioView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .environment(\.isInLayoutStudio, true)
+        .background(.ultraThinMaterial)
+        .overlay(alignment: .leading) {
+            Rectangle().fill(Color.primary.opacity(0.08)).frame(width: 0.5)
+        }
+    }
+
+    // MARK: - Naming
+
+    private func title(for subject: LayoutStudioWindowController.Subject) -> String {
+        switch subject {
+        case let .popoverPage(page):
+            return OverviewPage.allCases.first { $0.layoutPageID == page }?.label
+                ?? L10n.Popover.tabOverview
+        case let .miniWindow(id):
+            return settingsStore.settings.miniWindow.config(id: id)?.name ?? "Mini"
+        }
+    }
+
+    private func icon(for subject: LayoutStudioWindowController.Subject) -> String {
+        switch subject {
+        case .popoverPage: return "rectangle.portrait.on.rectangle.portrait"
+        case .miniWindow:  return "macwindow"
+        }
     }
 }

--- a/Sources/VibeBarApp/Views/LayoutStudioView.swift
+++ b/Sources/VibeBarApp/Views/LayoutStudioView.swift
@@ -166,6 +166,15 @@ struct LayoutStudioView: View {
 
     @Namespace private var chipNamespace
 
+    /// Same rule `StatusItemController` uses: one stable width for every tab,
+    /// so a page switch never reflows.
+    private static func popoverWidth(for settings: AppSettings) -> CGFloat {
+        max(
+            Theme.overviewDensity(for: settings.popoverDensity).popoverWidth,
+            Theme.detailDensity(for: settings.popoverDensity).popoverWidth
+        )
+    }
+
     // MARK: - Stage
 
     private var stage: some View {
@@ -186,7 +195,11 @@ struct LayoutStudioView: View {
                     lit {
                         ScaledPreview(width: stageContentWidth, maxHeight: 4000) {
                             PopoverRoot(
-                                width: 420,
+                                // The width the popover actually opens at.
+                                // A guessed 420 put 860-point columns inside a
+                                // 420-point shell, so the preview reflowed
+                                // differently from the thing it is a preview of.
+                                width: Self.popoverWidth(for: settingsStore.settings),
                                 onContentHeightChange: { _ in },
                                 onToggleMiniWindow: {},
                                 initialPage: tab
@@ -251,10 +264,16 @@ struct LayoutStudioView: View {
                 // The same editors Settings shows. One place decides what a
                 // control does; this decides how much room it gets.
                 switch model.subject {
-                case .popoverPage:
-                    LayoutEditorView()
-                case .miniWindow:
-                    MiniWindowsSettingsSection()
+                case let .popoverPage(page):
+                    // Identity per subject: the editors keep their own
+                    // selection in `@State`, so without a rebuild the controls
+                    // would go on editing whatever the last one was while the
+                    // stage showed something else.
+                    LayoutEditorView(initialPage: page)
+                        .id(page)
+                case let .miniWindow(id):
+                    MiniWindowsSettingsSection(initialWindowID: id)
+                        .id(id)
                 }
             }
             .padding(16)

--- a/Sources/VibeBarApp/Views/MiniWindowsSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/MiniWindowsSettingsSection.swift
@@ -18,7 +18,11 @@ struct MiniWindowsSettingsSection: View {
     @EnvironmentObject private var settingsStore: SettingsStore
     @EnvironmentObject private var quotaService: QuotaService
 
+    /// Which window this editor opens on — see `LayoutEditorView.initialPage`
+    /// for why the studio names one.
+    var initialWindowID: UUID?
     @State private var selectedWindowID: UUID?
+    @State private var hasAppliedInitialWindow = false
     @State private var arrangeFrames: [String: CGRect] = [:]
     @State private var drag: DragState?
     /// Whether name edits below write the shared names or this window's
@@ -63,7 +67,8 @@ struct MiniWindowsSettingsSection: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        let _ = applyInitialWindowIfNeeded()
+        return VStack(alignment: .leading, spacing: 12) {
             windowChips()
             if let config = selectedWindow {
                 windowDetail(config)
@@ -80,6 +85,12 @@ struct MiniWindowsSettingsSection: View {
         .onReceive(quotaService.$lastSuccessByAccount) { _ in
             rebuildLiveness()
         }
+    }
+
+    private func applyInitialWindowIfNeeded() {
+        guard let initialWindowID, !hasAppliedInitialWindow else { return }
+        hasAppliedInitialWindow = true
+        selectedWindowID = initialWindowID
     }
 
     private func rebuildRegistryCaches() {

--- a/Sources/VibeBarApp/Views/MiniWindowsSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/MiniWindowsSettingsSection.swift
@@ -13,6 +13,7 @@ extension Notification.Name {
 /// runtime-discovered buckets — and its own arrangement, reordered by drag
 /// the way the Layout editor arranges popover cards.
 struct MiniWindowsSettingsSection: View {
+    @Environment(\.isInLayoutStudio) private var isInLayoutStudio
     @EnvironmentObject private var environment: AppEnvironment
     @EnvironmentObject private var settingsStore: SettingsStore
     @EnvironmentObject private var quotaService: QuotaService
@@ -31,10 +32,6 @@ struct MiniWindowsSettingsSection: View {
     @State private var mergedOptionsById: [String: MenuBarFieldOption] = [:]
     /// Field ids whose bucket the live quota cache currently returns.
     @State private var liveFieldIds: Set<String> = []
-    /// How much room the preview has. Measured rather than fixed: the styles
-    /// range from a narrow rail to a row that wants the width of a screen, and
-    /// a guessed number shrinks the wide ones to illegibility.
-    @State private var previewWidth: CGFloat = 480
 
     private enum NamingScope: Hashable {
         case shared
@@ -254,7 +251,7 @@ struct MiniWindowsSettingsSection: View {
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
         }
-        windowPreview(config)
+        windowSkeleton(config)
 
         if namingScope == .style {
             Text(L10n.Settings.miniWindowOverridesStyle(mode: config.displayMode.label))
@@ -278,32 +275,67 @@ struct MiniWindowsSettingsSection: View {
     /// renaming a field lands here immediately — which is the whole point of
     /// arranging something you cannot see. Its two callbacks are inert; this
     /// is a picture of the window, not a second copy of it to drive.
-    private func windowPreview(_ config: MiniWindowConfig) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(L10n.Settings.miniWindowPreview)
-                .font(.system(size: 10, weight: .semibold))
-                .foregroundStyle(.tertiary)
-                .textCase(.uppercase)
-                .tracking(0.6)
-            ScaledPreview(width: previewWidth) {
-                MiniQuotaWindowView(
-                    configID: config.id,
-                    onClose: {},
-                    onToggleDisplayMode: {}
+    /// A skeleton of the window, and the way out to the real one.
+    ///
+    /// Deliberately not the live view. This pane's width belongs to the
+    /// controls, and a mini window laid out at its own width either spills
+    /// over them or shrinks past reading — the skeleton fits, and what it
+    /// shows is exactly what this pane edits: how many fields there are, how
+    /// they fold into SubProviders, and in what order. Seeing the real thing
+    /// is the studio's job.
+    private func windowSkeleton(_ config: MiniWindowConfig) -> some View {
+        let groups = arrangeGroups(arrangeRows(config))
+        return VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                Text(L10n.Settings.miniWindowPreview)
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(.tertiary)
+                    .textCase(.uppercase)
+                    .tracking(0.6)
+                Spacer(minLength: 8)
+                if !isInLayoutStudio {
+                    LayoutStudioButton {
+                        LayoutStudioWindowController.shared.open(
+                            subject: .miniWindow(config.id),
+                            environment: environment
+                        )
+                    }
+                }
+            }
+            if groups.isEmpty {
+                Text(L10n.Settings.miniWindowNoFieldsSelected)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            } else {
+                MenuBarChipFlow(spacing: 8, lineSpacing: 6) {
+                    ForEach(groups) { group in
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(subProviderDisplayName(group))
+                                .font(.system(size: 8, weight: .semibold))
+                                .foregroundStyle(.tertiary)
+                                .lineLimit(1)
+                            HStack(spacing: 3) {
+                                ForEach(group.rows) { row in
+                                    Capsule()
+                                        .fill(Theme.providerAccent(for: group.tool).opacity(0.55))
+                                        .frame(width: 16, height: 5)
+                                }
+                            }
+                        }
+                    }
+                }
+                .padding(7)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .fill(Color.primary.opacity(0.05))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .stroke(Color.primary.opacity(0.10), lineWidth: 0.7)
                 )
             }
-            .padding(6)
-            .background(
-                RoundedRectangle(cornerRadius: 10, style: .continuous)
-                    .fill(.background.secondary)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 10, style: .continuous)
-                    .strokeBorder(Color.primary.opacity(0.12), lineWidth: 0.5)
-            )
-            .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .onGeometryChange(for: CGFloat.self) { $0.size.width } action: { previewWidth = max(120, $0 - 12) }
     }
 
     private func modePicker(_ config: MiniWindowConfig) -> some View {

--- a/Sources/VibeBarApp/Views/MiniWindowsSettingsSection.swift
+++ b/Sources/VibeBarApp/Views/MiniWindowsSettingsSection.swift
@@ -31,6 +31,10 @@ struct MiniWindowsSettingsSection: View {
     @State private var mergedOptionsById: [String: MenuBarFieldOption] = [:]
     /// Field ids whose bucket the live quota cache currently returns.
     @State private var liveFieldIds: Set<String> = []
+    /// How much room the preview has. Measured rather than fixed: the styles
+    /// range from a narrow rail to a row that wants the width of a screen, and
+    /// a guessed number shrinks the wide ones to illegibility.
+    @State private var previewWidth: CGFloat = 480
 
     private enum NamingScope: Hashable {
         case shared
@@ -250,6 +254,8 @@ struct MiniWindowsSettingsSection: View {
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
         }
+        windowPreview(config)
+
         if namingScope == .style {
             Text(L10n.Settings.miniWindowOverridesStyle(mode: config.displayMode.label))
                 .font(.caption)
@@ -263,6 +269,41 @@ struct MiniWindowsSettingsSection: View {
             .foregroundStyle(.secondary)
             .fixedSize(horizontal: false, vertical: true)
         notShownList(config)
+    }
+
+    /// The window itself, drawn beside the list that arranges it.
+    ///
+    /// The real view, not a mock: `MiniQuotaWindowView` re-reads its config
+    /// from settings on every render, so picking a style, dragging a row or
+    /// renaming a field lands here immediately — which is the whole point of
+    /// arranging something you cannot see. Its two callbacks are inert; this
+    /// is a picture of the window, not a second copy of it to drive.
+    private func windowPreview(_ config: MiniWindowConfig) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(L10n.Settings.miniWindowPreview)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.tertiary)
+                .textCase(.uppercase)
+                .tracking(0.6)
+            ScaledPreview(width: previewWidth) {
+                MiniQuotaWindowView(
+                    configID: config.id,
+                    onClose: {},
+                    onToggleDisplayMode: {}
+                )
+            }
+            .padding(6)
+            .background(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .fill(.background.secondary)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .strokeBorder(Color.primary.opacity(0.12), lineWidth: 0.5)
+            )
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .onGeometryChange(for: CGFloat.self) { $0.size.width } action: { previewWidth = max(120, $0 - 12) }
     }
 
     private func modePicker(_ config: MiniWindowConfig) -> some View {

--- a/Sources/VibeBarApp/Views/ScaledPreview.swift
+++ b/Sources/VibeBarApp/Views/ScaledPreview.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import VibeBarCore
 
 /// A real view, drawn at its natural size and shrunk to fit a width.
 ///
@@ -39,5 +40,37 @@ struct ScaledPreview<Content: View>: View {
             .clipped()
             .allowsHitTesting(false)
             .accessibilityHidden(true)
+    }
+}
+
+private struct LayoutStudioKey: EnvironmentKey {
+    static let defaultValue = false
+}
+
+extension EnvironmentValues {
+    /// Whether the editor being drawn is already inside the studio.
+    ///
+    /// The door out of Settings is the same view, so without this it offers
+    /// to open the room it is standing in.
+    var isInLayoutStudio: Bool {
+        get { self[LayoutStudioKey.self] }
+        set { self[LayoutStudioKey.self] = newValue }
+    }
+}
+
+/// The door from a settings pane to the full-size editor.
+struct LayoutStudioButton: View {
+    let open: () -> Void
+
+    var body: some View {
+        Button(action: open) {
+            Label(
+                L10n.Settings.layoutOpenStudio,
+                systemImage: "rectangle.inset.filled.on.rectangle"
+            )
+            .font(.caption)
+        }
+        .buttonStyle(.vibeBar)
+        .help(L10n.Settings.layoutOpenStudioHelp)
     }
 }

--- a/Sources/VibeBarApp/Views/ScaledPreview.swift
+++ b/Sources/VibeBarApp/Views/ScaledPreview.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+/// A real view, drawn at its natural size and shrunk to fit a width.
+///
+/// Settings has room for a picture of a surface, not for the surface itself:
+/// a mini window lays out at the width its panel opens at and a Workbench page
+/// at the width of a window. Constraining either with `.frame(width:)` does not
+/// make it narrower — it lays out at its own width and spills over whatever is
+/// beside it. So it is measured at its natural size and scaled.
+///
+/// The content is inert here. These previews exist to be looked at while the
+/// controls beside them are used; a live second copy would let a double-click
+/// cycle a style out from under the picker that set it.
+struct ScaledPreview<Content: View>: View {
+    let width: CGFloat
+    /// Nothing taller than this is worth showing in a settings pane; a page
+    /// that runs longer is shown from the top, which is the part being
+    /// arranged.
+    var maxHeight: CGFloat = 420
+    @ViewBuilder var content: Content
+
+    @State private var natural: CGSize = .zero
+
+    private var scale: CGFloat {
+        guard natural.width > 0 else { return 1 }
+        return min(1, width / natural.width)
+    }
+
+    var body: some View {
+        content
+            .fixedSize()
+            .onGeometryChange(for: CGSize.self) { $0.size } action: { natural = $0 }
+            .scaleEffect(scale, anchor: .topLeading)
+            .frame(
+                width: natural.width > 0 ? natural.width * scale : width,
+                height: natural.height > 0 ? min(natural.height * scale, maxHeight) : nil,
+                alignment: .topLeading
+            )
+            .clipped()
+            .allowsHitTesting(false)
+            .accessibilityHidden(true)
+    }
+}

--- a/Sources/VibeBarCore/Localization/L10n+Generated.swift
+++ b/Sources/VibeBarCore/Localization/L10n+Generated.swift
@@ -2868,13 +2868,21 @@ extension L10n {
         public static var layoutPreviewUnavailable: String {
             L10n.string("settings.layout.previewUnavailable")
         }
-        /// `settings.layout.studioLive` — Live
-        public static var layoutStudioLive: String {
-            L10n.string("settings.layout.studioLive")
-        }
         /// `settings.layout.studioTitle` — Layout Studio
         public static var layoutStudioTitle: String {
             L10n.string("settings.layout.studioTitle")
+        }
+        /// `settings.layout.studioToggleInspector` — Show or hide the controls
+        public static var layoutStudioToggleInspector: String {
+            L10n.string("settings.layout.studioToggleInspector")
+        }
+        /// `settings.layout.studioZoomActual` — Actual size
+        public static var layoutStudioZoomActual: String {
+            L10n.string("settings.layout.studioZoomActual")
+        }
+        /// `settings.layout.studioZoomFit` — Fit
+        public static var layoutStudioZoomFit: String {
+            L10n.string("settings.layout.studioZoomFit")
         }
         /// `settings.mcp.allowRefresh` — Allow agents to refresh quota
         public static var mcpAllowRefresh: String {
@@ -7048,8 +7056,10 @@ extension L10n {
         "settings.layout.openStudioHelp",
         "settings.layout.preview",
         "settings.layout.previewUnavailable",
-        "settings.layout.studioLive",
         "settings.layout.studioTitle",
+        "settings.layout.studioToggleInspector",
+        "settings.layout.studioZoomActual",
+        "settings.layout.studioZoomFit",
         "settings.mcp.allowRefresh",
         "settings.mcp.allowRefreshDetail",
         "settings.mcp.allowSkills",

--- a/Sources/VibeBarCore/Localization/L10n+Generated.swift
+++ b/Sources/VibeBarCore/Localization/L10n+Generated.swift
@@ -2852,6 +2852,14 @@ extension L10n {
         public static var languageTitle: String {
             L10n.string("settings.language.title")
         }
+        /// `settings.layout.preview` — Preview
+        public static var layoutPreview: String {
+            L10n.string("settings.layout.preview")
+        }
+        /// `settings.layout.previewUnavailable` — This page has no popover tab to preview.
+        public static var layoutPreviewUnavailable: String {
+            L10n.string("settings.layout.previewUnavailable")
+        }
         /// `settings.mcp.allowRefresh` — Allow agents to refresh quota
         public static var mcpAllowRefresh: String {
             L10n.string("settings.mcp.allowRefresh")
@@ -3107,6 +3115,10 @@ extension L10n {
         /// `settings.miniWindow.position` — {position}
         public static func miniWindowPosition(position: Int) -> String {
             L10n.string("settings.miniWindow.position", position)
+        }
+        /// `settings.miniWindow.preview` — Preview
+        public static var miniWindowPreview: String {
+            L10n.string("settings.miniWindow.preview")
         }
         /// `settings.miniWindow.removeFromWindow` — Remove from this window
         public static var miniWindowRemoveFromWindow: String {
@@ -7016,6 +7028,8 @@ extension L10n {
         "settings.language.caption",
         "settings.language.system",
         "settings.language.title",
+        "settings.layout.preview",
+        "settings.layout.previewUnavailable",
         "settings.mcp.allowRefresh",
         "settings.mcp.allowRefreshDetail",
         "settings.mcp.allowSkills",
@@ -7080,6 +7094,7 @@ extension L10n {
         "settings.miniWindow.overridesStyle",
         "settings.miniWindow.overridesWindow",
         "settings.miniWindow.position",
+        "settings.miniWindow.preview",
         "settings.miniWindow.removeFromWindow",
         "settings.miniWindow.removeHelp",
         "settings.miniWindow.stripDensity",

--- a/Sources/VibeBarCore/Localization/L10n+Generated.swift
+++ b/Sources/VibeBarCore/Localization/L10n+Generated.swift
@@ -2852,6 +2852,14 @@ extension L10n {
         public static var languageTitle: String {
             L10n.string("settings.language.title")
         }
+        /// `settings.layout.openStudio` — Open Studio
+        public static var layoutOpenStudio: String {
+            L10n.string("settings.layout.openStudio")
+        }
+        /// `settings.layout.openStudioHelp` — Arrange this surface beside a full-size, live preview of it.
+        public static var layoutOpenStudioHelp: String {
+            L10n.string("settings.layout.openStudioHelp")
+        }
         /// `settings.layout.preview` — Preview
         public static var layoutPreview: String {
             L10n.string("settings.layout.preview")
@@ -2859,6 +2867,14 @@ extension L10n {
         /// `settings.layout.previewUnavailable` — This page has no popover tab to preview.
         public static var layoutPreviewUnavailable: String {
             L10n.string("settings.layout.previewUnavailable")
+        }
+        /// `settings.layout.studioLive` — Live
+        public static var layoutStudioLive: String {
+            L10n.string("settings.layout.studioLive")
+        }
+        /// `settings.layout.studioTitle` — Layout Studio
+        public static var layoutStudioTitle: String {
+            L10n.string("settings.layout.studioTitle")
         }
         /// `settings.mcp.allowRefresh` — Allow agents to refresh quota
         public static var mcpAllowRefresh: String {
@@ -7028,8 +7044,12 @@ extension L10n {
         "settings.language.caption",
         "settings.language.system",
         "settings.language.title",
+        "settings.layout.openStudio",
+        "settings.layout.openStudioHelp",
         "settings.layout.preview",
         "settings.layout.previewUnavailable",
+        "settings.layout.studioLive",
+        "settings.layout.studioTitle",
         "settings.mcp.allowRefresh",
         "settings.mcp.allowRefreshDetail",
         "settings.mcp.allowSkills",

--- a/Sources/VibeBarCore/Resources/en.lproj/Localizable.strings
+++ b/Sources/VibeBarCore/Resources/en.lproj/Localizable.strings
@@ -2057,11 +2057,23 @@
 /* Settings row label for the in-app language override */
 "settings.language.title" = "Language";
 
+/* Button that opens the full-size layout studio window */
+"settings.layout.openStudio" = "Open Studio";
+
+/* Tooltip for the studio button */
+"settings.layout.openStudioHelp" = "Arrange this surface beside a full-size, live preview of it.";
+
 /* Caption over the live popover preview in the layout editor */
 "settings.layout.preview" = "Preview";
 
 /* Shown when a layout page has no popover tab to draw */
 "settings.layout.previewUnavailable" = "This page has no popover tab to preview.";
+
+/* Caption marking the studio preview as live */
+"settings.layout.studioLive" = "Live";
+
+/* Title of the layout studio window */
+"settings.layout.studioTitle" = "Layout Studio";
 
 /* Toggle label */
 "settings.mcp.allowRefresh" = "Allow agents to refresh quota";

--- a/Sources/VibeBarCore/Resources/en.lproj/Localizable.strings
+++ b/Sources/VibeBarCore/Resources/en.lproj/Localizable.strings
@@ -2069,11 +2069,17 @@
 /* Shown when a layout page has no popover tab to draw */
 "settings.layout.previewUnavailable" = "This page has no popover tab to preview.";
 
-/* Caption marking the studio preview as live */
-"settings.layout.studioLive" = "Live";
-
 /* Title of the layout studio window */
 "settings.layout.studioTitle" = "Layout Studio";
+
+/* Tooltip for the button that hides the studio's controls */
+"settings.layout.studioToggleInspector" = "Show or hide the controls";
+
+/* Zoom control: draw the surface at its own size */
+"settings.layout.studioZoomActual" = "Actual size";
+
+/* Zoom control: shrink the surface to fit the stage */
+"settings.layout.studioZoomFit" = "Fit";
 
 /* Toggle label */
 "settings.mcp.allowRefresh" = "Allow agents to refresh quota";

--- a/Sources/VibeBarCore/Resources/en.lproj/Localizable.strings
+++ b/Sources/VibeBarCore/Resources/en.lproj/Localizable.strings
@@ -2057,6 +2057,12 @@
 /* Settings row label for the in-app language override */
 "settings.language.title" = "Language";
 
+/* Caption over the live popover preview in the layout editor */
+"settings.layout.preview" = "Preview";
+
+/* Shown when a layout page has no popover tab to draw */
+"settings.layout.previewUnavailable" = "This page has no popover tab to preview.";
+
 /* Toggle label */
 "settings.mcp.allowRefresh" = "Allow agents to refresh quota";
 
@@ -2248,6 +2254,9 @@
 
 /* Ordinal badge showing a field's place in the order */
 "settings.miniWindow.position" = "%1$lld";
+
+/* Caption over the live mini-window preview in Settings */
+"settings.miniWindow.preview" = "Preview";
 
 /* Tooltip on a row's remove control */
 "settings.miniWindow.removeFromWindow" = "Remove from this window";

--- a/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.strings
@@ -2069,11 +2069,17 @@
 /* Shown when a layout page has no popover tab to draw */
 "settings.layout.previewUnavailable" = "该页面没有可预览的 popover 标签页。";
 
-/* Caption marking the studio preview as live */
-"settings.layout.studioLive" = "实时";
-
 /* Title of the layout studio window */
 "settings.layout.studioTitle" = "布局工作台";
+
+/* Tooltip for the button that hides the studio's controls */
+"settings.layout.studioToggleInspector" = "显示或隐藏控件";
+
+/* Zoom control: draw the surface at its own size */
+"settings.layout.studioZoomActual" = "实际大小";
+
+/* Zoom control: shrink the surface to fit the stage */
+"settings.layout.studioZoomFit" = "适应";
 
 /* Toggle label */
 "settings.mcp.allowRefresh" = "允许 agent 刷新额度";

--- a/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.strings
@@ -2057,11 +2057,23 @@
 /* Settings row label for the in-app language override */
 "settings.language.title" = "语言";
 
+/* Button that opens the full-size layout studio window */
+"settings.layout.openStudio" = "打开工作台";
+
+/* Tooltip for the studio button */
+"settings.layout.openStudioHelp" = "在整尺寸的实时预览旁边排布这个界面。";
+
 /* Caption over the live popover preview in the layout editor */
 "settings.layout.preview" = "预览";
 
 /* Shown when a layout page has no popover tab to draw */
 "settings.layout.previewUnavailable" = "该页面没有可预览的 popover 标签页。";
+
+/* Caption marking the studio preview as live */
+"settings.layout.studioLive" = "实时";
+
+/* Title of the layout studio window */
+"settings.layout.studioTitle" = "布局工作台";
 
 /* Toggle label */
 "settings.mcp.allowRefresh" = "允许 agent 刷新额度";

--- a/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/VibeBarCore/Resources/zh-Hans.lproj/Localizable.strings
@@ -2057,6 +2057,12 @@
 /* Settings row label for the in-app language override */
 "settings.language.title" = "语言";
 
+/* Caption over the live popover preview in the layout editor */
+"settings.layout.preview" = "预览";
+
+/* Shown when a layout page has no popover tab to draw */
+"settings.layout.previewUnavailable" = "该页面没有可预览的 popover 标签页。";
+
 /* Toggle label */
 "settings.mcp.allowRefresh" = "允许 agent 刷新额度";
 
@@ -2248,6 +2254,9 @@
 
 /* Ordinal badge showing a field's place in the order */
 "settings.miniWindow.position" = "%1$lld";
+
+/* Caption over the live mini-window preview in Settings */
+"settings.miniWindow.preview" = "预览";
 
 /* Tooltip on a row's remove control */
 "settings.miniWindow.removeFromWindow" = "从此窗口移除";

--- a/docs/handover-layout-studio.md
+++ b/docs/handover-layout-studio.md
@@ -75,6 +75,11 @@ Roughly in the order that would matter:
    be arrow-navigable.
 8. **Untested at small window sizes** and never looked at in Light Aqua — the
    gradient backdrop was tuned against Dark.
+9. **The mini-window stage measures the view, not the panel.**
+   `MiniQuotaWindowController.stableContentSize` adds a 20/24-point reserve for
+   the close button and can clamp to the screen; the stage measures
+   `MiniQuotaWindowView`'s intrinsic size alone, so a many-field window is
+   spaced slightly differently here than on screen. Reuse that sizing.
 
 ## Design intent, so a second pass does not undo the first
 

--- a/docs/handover-layout-studio.md
+++ b/docs/handover-layout-studio.md
@@ -1,0 +1,85 @@
+# Handover — Layout Studio
+
+Status: **shipped but unfinished.** It works and is reachable; the design is
+one pass in, not done. Written down rather than polished further because AQ
+called time on it — pick it up from here.
+
+## What it is
+
+Two settings panes arrange a surface you cannot see while arranging it:
+Mini Windows and Layout (the popover's module columns). The split we settled
+on:
+
+- **Inline stays a skeleton.** A settings pane's width belongs to its
+  controls, and a skeleton shows the thing those controls edit — how many
+  fields, how they fold, in what order. Layout already had one; Mini Windows
+  now does.
+- **The real surface moves to its own window.** `LayoutStudioWindowController`
+  opens a translucent window with the surface on a lit stage and the controls
+  beside it. The proportions invert on purpose: in Settings the controls own
+  the room, here the surface does.
+
+Both panes reach it through `LayoutStudioButton`; inside the studio that
+button hides itself via `EnvironmentValues.isInLayoutStudio`.
+
+## Where the code is
+
+| Piece | File |
+|---|---|
+| Window, translucency, `Subject` | `Sources/VibeBarApp/Controllers/LayoutStudioWindowController.swift` |
+| Stage, toolbar, inspector | `Sources/VibeBarApp/Views/LayoutStudioView.swift` |
+| Natural-size measure + scale, studio button, environment flag | `Sources/VibeBarApp/Views/ScaledPreview.swift` |
+| Mini Windows skeleton + door | `Sources/VibeBarApp/Views/MiniWindowsSettingsSection.swift` (`windowSkeleton`) |
+| Layout skeleton + door | `Sources/VibeBarApp/Views/LayoutEditorView.swift` (`previewColumnStack`) |
+
+Two constraints worth not rediscovering:
+
+- **Neither surface can be sized with `.frame(width:)`.** A mini window lays
+  out at its panel's width and a popover at a window's; a narrower frame does
+  not narrow them, it makes them spill over whatever is beside them. That is
+  what `ScaledPreview` exists for — measure at natural size, then scale.
+- **`PopoverRoot` applies `initialPage` once**, to state it owns. The stage
+  gives it `.id(tab)` so switching subjects rebuilds it; without that the
+  preview stays on the page it opened with.
+
+## What works
+
+Driven in the built app, both subjects: the window opens from either pane,
+the surface renders live on the stage, the subject chips switch between the
+five popover pages and every mini window, Fit/Actual size changes the scale,
+and the inspector hosts the same editors Settings shows — so a control's
+behaviour is still defined in one place.
+
+## What is left
+
+Roughly in the order that would matter:
+
+1. **The stage is only ever top-left.** A short surface floats in a large
+   empty stage. It should centre, and probably grow the shadow with the zoom.
+2. **`Actual size` is a magic 10 000.** `ScaledPreview` caps its scale at 1×,
+   so passing an absurd width means "never shrink". It works and it reads
+   badly; give `ScaledPreview` an explicit mode instead.
+3. **No zoom between fit and 1×.** A slider, or ⌘+/⌘−, and a percentage
+   readout.
+4. **Motion is only on the container.** The subject chip has a
+   `matchedGeometryEffect` and the panes cross-fade, but the surface itself
+   does not animate when the arrangement under it changes — which is the one
+   moment where motion would actually explain something.
+5. **The inspector is Settings' pane at a different width**, not a layout
+   designed for this room. In particular the Mini Windows editor still shows
+   its own skeleton inside the studio, next to the full-size stage showing the
+   same thing.
+6. **Nothing restores the last subject.** The window always opens on whatever
+   pane sent you, and the model resets per launch.
+7. **No keyboard.** Escape should close, ⌘W too, and the subject chips should
+   be arrow-navigable.
+8. **Untested at small window sizes** and never looked at in Light Aqua — the
+   gradient backdrop was tuned against Dark.
+
+## Design intent, so a second pass does not undo the first
+
+The window is translucent (`underWindowBackground`, `isOpaque = false`) and
+the chrome is `.ultraThinMaterial`, so the stage reads as lit and everything
+else recedes. The surface keeps its own corners and gets a shadow rather than
+a frame — it is the real thing on a stage, not a picture in a border. Colour
+belongs to the surface; the studio itself is greys and one accent.


### PR DESCRIPTION
AQ: the mini-window arrangement needs to be visual — and *"那原来的layout那一栏设置是不是也可以渲染出来，现在是示意图"*.

Both places arrange something you cannot see while you arrange it.

## Mini Windows had no preview at all

Pick a style, drag a row, then open the window to find out what you did. It now draws the real `MiniQuotaWindowView` for the selected window, directly under the style picker at the full width of the pane — updating live, because that view re-reads its config from settings on every render.

## The layout editor had one, but it was a schematic

A stack of grey rectangles standing in for the cards: the *shape* the segment boxes produce, which is true and is not what anyone arranges for. Its own comment already promised more than it delivered:

> The groups are drawn as boxes; the popover draws no boundary at all. That is the point of the picture — the boxes say what the ordering constraint is, and **the preview beside them says what it produces**.

It now draws the popover page itself, at the width the popover opens at, scaled down.

## `ScaledPreview`

Neither surface can be constrained with `.frame(width:)`. A mini window lays out at its panel's width and a popover at a window's; a narrower frame does not make either narrower, it makes them spill over whatever is beside them — which is exactly what the first attempt did. So the content is measured at its natural size and scaled to fit the room available.

Both previews are inert. A live second copy would let a double-click cycle the style out from under the picker that set it.

## Verification

`swift build`, `swift test` (2274 pass), `./Scripts/build_app.sh release`. Captured both panes from demo mode: the mini window preview renders the Regular style legibly at full width, and the layout editor shows the real Overview popover — tab strip, cost summary, provider cards — beside the segment boxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)