### PR TITLE
Name every quota block by its SubProvider, and offer every mark as a logo

### DIFF
--- a/Sources/VibeBarApp/ProviderBrandIcon.swift
+++ b/Sources/VibeBarApp/ProviderBrandIcon.swift
@@ -724,6 +724,36 @@ struct CompanyBrandBadge: View {
     }
 }
 
+extension MenuBarBrandLogo {
+    /// The picture this build has for the block, if any. `nil` draws the
+    /// tool's own mark, which is what the block would have been before the
+    /// company or SubProvider got a mark of its own.
+    var brandMark: BrandMark? {
+        switch level {
+        case .company: return BrandMark.company(for: tool)
+        case .subProvider: return BrandMark.subProvider(tool: tool, bucketID: bucketId)
+        }
+    }
+
+    /// Whose accent a "brand" colour uses for this block.
+    var accentTool: ToolType { brandMark?.accentTool ?? tool }
+}
+
+/// Brand icon for a composed logo block that names a company or a
+/// SubProvider — the tool's own mark when this build has no separate one.
+struct BrandLogoIconView: View {
+    let logo: MenuBarBrandLogo
+    var size: CGFloat = 16
+
+    var body: some View {
+        if let mark = logo.brandMark {
+            BrandMarkIconView(mark: mark, size: size)
+        } else {
+            ToolBrandIconView(tool: logo.tool, size: size)
+        }
+    }
+}
+
 /// Brand icon for a quota section: its tool's mark, unless the bucket names a
 /// SubProvider with one of its own.
 struct QuotaBrandIconView: View {

--- a/Sources/VibeBarApp/StatusItemController.swift
+++ b/Sources/VibeBarApp/StatusItemController.swift
@@ -1630,6 +1630,17 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
             return brandAttachment(
                 for: tool, fontSize: fontSize, font: font, tint: tint, tintKey: tintKey
             )
+        case let .brand(logo):
+            guard let mark = logo.brandMark else {
+                return brandAttachment(
+                    for: logo.tool, fontSize: fontSize, font: font, tint: tint, tintKey: tintKey
+                )
+            }
+            let side = MenuBarStripMetrics.singleRowGlyphSide(fontSize: fontSize)
+            guard let image = brandMarkImage(mark, side: side, tint: tint, tintKey: tintKey) else {
+                return nil
+            }
+            return attachment(image: image, side: side, font: font)
         case .app:
             let side = MenuBarStripMetrics.singleRowGlyphSide(fontSize: fontSize)
             guard let image = appGlyphImage(side: side, tint: tint, tintKey: tintKey) else {
@@ -1649,9 +1660,35 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         switch glyph {
         case let .provider(tool):
             return brandLogoImage(for: tool, side: side, tint: tint, tintKey: tintKey)
+        case let .brand(logo):
+            guard let mark = logo.brandMark else {
+                return brandLogoImage(for: logo.tool, side: side, tint: tint, tintKey: tintKey)
+            }
+            return brandMarkImage(mark, side: side, tint: tint, tintKey: tintKey)
         case .app:
             return appGlyphImage(side: side, tint: tint, tintKey: tintKey)
         }
+    }
+
+    /// A company's or SubProvider's mark, cached beside the tool marks on a
+    /// key shape of its own so Grok Bot's and Cursor's can never collide.
+    private func brandMarkImage(
+        _ mark: BrandMark,
+        side: CGFloat,
+        tint: NSColor,
+        tintKey: String
+    ) -> NSImage? {
+        let appearance = compactStatusItem?.button?.effectiveAppearance ?? NSApp.effectiveAppearance
+        let key = "mark.\(mark.rawValue).\(side).\(appearance.name.rawValue).\(tintKey)"
+        if let cached = brandAttachmentImages[key] { return cached }
+        let image = ProviderBrandIcon.image(
+            for: mark,
+            size: NSSize(width: side, height: side),
+            tint: tint,
+            appearance: appearance
+        )
+        brandAttachmentImages[key] = image
+        return image
     }
 
     /// Vibe Bar's own mark, cached beside the provider marks on the same key

--- a/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
+++ b/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
@@ -79,6 +79,9 @@ struct MenuBarComposerEditor: View {
     @State private var optionsById: [String: MenuBarFieldOption] = [:]
     @State private var paletteQuotaSections: [PaletteQuotaSection] = []
     @State private var paletteLogoTools: [ToolType] = []
+    /// Company and SubProvider marks the quota sections wear that no tool
+    /// mark already is — Google AI, SpaceXAI, Grok Bot.
+    @State private var paletteBrandLogos: [MenuBarBrandLogo] = []
 
     private struct PaletteQuotaSection: Identifiable {
         let tool: ToolType
@@ -573,9 +576,23 @@ struct MenuBarComposerEditor: View {
             selection = isSelected && selection.count == 1 ? [] : [token.id]
         } label: {
             HStack(spacing: 4) {
-                if case let .logo(tool) = token.kind {
+                // A quota block wears its provider's mark, the way the
+                // palette entry it came from does — the fastest way to tell
+                // one "Weekly" from another.
+                switch token.kind {
+                case let .logo(tool):
                     ToolBrandIconView(tool: tool, size: 11)
-                } else {
+                case let .brandLogo(logo):
+                    BrandLogoIconView(logo: logo, size: 11)
+                case let .quota(fieldId, _):
+                    if let option = optionsById[fieldId] {
+                        QuotaBrandIconView(tool: option.tool, bucketID: option.bucketId, size: 11)
+                    } else {
+                        Image(systemName: symbol(for: token.kind))
+                            .font(.system(size: 9, weight: .semibold))
+                            .foregroundStyle(.secondary)
+                    }
+                default:
                     Image(systemName: symbol(for: token.kind))
                         .font(.system(size: 9, weight: .semibold))
                         .foregroundStyle(.secondary)
@@ -662,7 +679,7 @@ struct MenuBarComposerEditor: View {
 
     private func symbol(for kind: MenuBarToken.Kind) -> String {
         switch kind {
-        case .logo: return "app.badge"
+        case .logo, .brandLogo: return "app.badge"
         case .text: return "textformat"
         case .quota: return "percent"
         case .space: return "space"
@@ -676,12 +693,19 @@ struct MenuBarComposerEditor: View {
         switch token.kind {
         case let .logo(tool):
             return tool.menuTitle
+        case let .brandLogo(logo):
+            return logo.name
         case let .text(text):
             let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
             return trimmed.isEmpty ? L10n.MenuBar.composerBlockEmptyText : MenuBarToken.truncated(trimmed)
         case let .quota(fieldId, metric):
-            let name = optionsById[fieldId]?.displayDefaultLabel ?? fieldId
-            return "\(name) · \(metric.title)"
+            // SubProvider first: a strip holding three "Weekly" blocks has to
+            // say which is Codex's, which Claude's, which Grok Bot's. The
+            // metric is spelled only when it is not the plain percentage,
+            // which is what the "Shows" control says and what nearly every
+            // block shows.
+            let name = optionsById[fieldId].map(Self.fieldTitle) ?? fieldId
+            return metric == .displayPercent ? name : "\(name) · \(metric.title)"
         case let .space(width):
             let width = MenuBarToken.clampedSpaceWidth(width)
             return width == MenuBarToken.defaultSpaceWidth
@@ -695,6 +719,14 @@ struct MenuBarComposerEditor: View {
         case .unsupported:
             return L10n.MenuBar.composerBlockUnsupported
         }
+    }
+
+    /// "Grok Bot · Weekly", "ChatGPT · GPT-5.3 Codex Spark · 5 Hours": the L2
+    /// SubProvider the bucket bills against, then the field's own title.
+    /// Every list of fields in this editor spells them this way, because a
+    /// bare "Weekly" is exactly the ambiguity the naming axis exists to end.
+    static func fieldTitle(_ option: MenuBarFieldOption) -> String {
+        "\(option.tool.quotaSubProviderName(bucketID: option.bucketId)) · \(option.displayTitle)"
     }
 
     private func chipHelp(_ token: MenuBarToken, isSilent: Bool, isDegraded: Bool) -> String {
@@ -719,6 +751,11 @@ struct MenuBarComposerEditor: View {
                 ForEach(paletteLogoTools, id: \.self) { tool in
                     paletteButton(title: tool.menuTitle, icon: nil, tool: tool) {
                         MenuBarToken.newLogo(tool)
+                    }
+                }
+                ForEach(paletteBrandLogos, id: \.self) { logo in
+                    paletteButton(title: logo.name, icon: nil, brand: logo) {
+                        MenuBarToken.newBrandLogo(logo)
                     }
                 }
             }
@@ -834,9 +871,10 @@ struct MenuBarComposerEditor: View {
         title: String,
         icon: String?,
         tool: ToolType? = nil,
+        brand: MenuBarBrandLogo? = nil,
         make: @escaping () -> MenuBarToken
     ) -> some View {
-        paletteButton(title: title, icon: icon, tool: tool) { add(make()) }
+        paletteButton(title: title, icon: icon, tool: tool, brand: brand) { add(make()) }
             .onDrag {
                 // Same flush as a chip drag: the drop writes the whole
                 // snapshot back, so a queued edit missing from it would be
@@ -855,12 +893,15 @@ struct MenuBarComposerEditor: View {
         icon: String?,
         tool: ToolType? = nil,
         bucketID: String? = nil,
+        brand: MenuBarBrandLogo? = nil,
         isOpen: Bool = false,
         action: @escaping () -> Void
     ) -> some View {
         Button(action: action) {
             HStack(spacing: 4) {
-                if let tool {
+                if let brand {
+                    BrandLogoIconView(logo: brand, size: 11)
+                } else if let tool {
                     // Bucket-aware: a quota section riding another company's
                     // account draws its own mark, not the account holder's.
                     QuotaBrandIconView(tool: tool, bucketID: bucketID, size: 11)
@@ -924,6 +965,7 @@ struct MenuBarComposerEditor: View {
                     warning(L10n.MenuBar.composerWarningDegraded)
                 }
                 MenuBarTokenInspector(
+                    brandLogos: paletteBrandLogos,
                     token: token,
                     options: sortedOptions,
                     liveFieldIds: liveFieldIds,
@@ -1208,6 +1250,26 @@ struct MenuBarComposerEditor: View {
         }
         paletteQuotaSections = sections
         paletteLogoTools = ToolType.dedicatedCardProviders
+        // Every mark the Quota row can show that the Logo row could not: the
+        // companies with a mark of their own, then the SubProviders with one.
+        // Deduplicated by picture, so Gemini and AntiGravity offer Google AI
+        // once.
+        var brandLogos: [MenuBarBrandLogo] = []
+        var marks = Set<BrandMark>()
+        for tool in ToolType.dedicatedCardProviders {
+            let logo = MenuBarBrandLogo.company(tool)
+            if let mark = logo.brandMark, marks.insert(mark).inserted {
+                brandLogos.append(logo)
+            }
+        }
+        for section in sections {
+            guard let bucket = section.options.first?.bucketId else { continue }
+            let logo = MenuBarBrandLogo.subProvider(section.tool, bucketId: bucket)
+            if let mark = logo.brandMark, marks.insert(mark).inserted {
+                brandLogos.append(logo)
+            }
+        }
+        paletteBrandLogos = brandLogos
     }
 
     /// What the snapshots are resolved from: the order being drawn, plus the
@@ -1242,6 +1304,9 @@ struct MenuBarComposerEditor: View {
 /// Controls for one block. Split out so the editor's own body does not
 /// re-evaluate every palette section and every chip when a slider moves.
 private struct MenuBarTokenInspector: View {
+    /// The company and SubProvider marks the palette offers, so the logo
+    /// picker lists the same choices as the row the block came from.
+    let brandLogos: [MenuBarBrandLogo]
     let token: MenuBarToken
     let options: [MenuBarFieldOption]
     let liveFieldIds: Set<String>
@@ -1399,15 +1464,21 @@ private struct MenuBarTokenInspector: View {
                 }
                 .help(L10n.MenuBar.composerFieldResetFormatHelp)
             }
-        case let .logo(tool):
+        case .logo, .brandLogo:
             HStack(spacing: 8) {
                 Text(L10n.MenuBar.composerFieldProvider).frame(width: 62, alignment: .leading)
                 Picker("", selection: Binding(
-                    get: { tool },
-                    set: { value in update { $0.kind = .logo(value) } }
+                    get: { token.kind },
+                    set: { value in update { $0.kind = value } }
                 )) {
-                    ForEach(ToolType.dedicatedCardProviders, id: \.self) {
-                        Text($0.menuTitle).tag($0)
+                    // A mark the palette no longer offers (its quota went
+                    // away) still needs a row, or the picker would show a
+                    // neighbour and a click would silently change the block.
+                    if !logoChoices.contains(token.kind) {
+                        Text(logoTitle(token.kind)).tag(token.kind)
+                    }
+                    ForEach(logoChoices, id: \.self) { kind in
+                        Text(logoTitle(kind)).tag(kind)
                     }
                 }
                 .labelsHidden()
@@ -1657,6 +1728,21 @@ private struct MenuBarTokenInspector: View {
         }
     }
 
+    /// Every mark a logo block can be: the tools, then the company and
+    /// SubProvider marks — the Logo row of the palette, in its order.
+    private var logoChoices: [MenuBarToken.Kind] {
+        ToolType.dedicatedCardProviders.map { MenuBarToken.Kind.logo($0) }
+            + brandLogos.map { MenuBarToken.Kind.brandLogo($0) }
+    }
+
+    private func logoTitle(_ kind: MenuBarToken.Kind) -> String {
+        switch kind {
+        case let .logo(tool): return tool.menuTitle
+        case let .brandLogo(logo): return logo.name
+        default: return ""
+        }
+    }
+
     private func fieldPicker(
         selected: String,
         set: @escaping (String) -> Void
@@ -1668,9 +1754,10 @@ private struct MenuBarTokenInspector: View {
                 Text(selected).tag(selected)
             }
             ForEach(options) { option in
+                let title = MenuBarComposerEditor.fieldTitle(option)
                 Text(liveFieldIds.contains(option.id)
-                    ? option.displayTitle
-                    : L10n.MenuBar.composerFieldOfflineOption(title: option.displayTitle))
+                    ? title
+                    : L10n.MenuBar.composerFieldOfflineOption(title: title))
                     .tag(option.id)
             }
         }
@@ -1710,6 +1797,8 @@ private struct MenuBarTokenInspector: View {
                     case .brand:
                         if case let .logo(tool) = edited.kind {
                             edited.style.color = .brand(tool)
+                        } else if case let .brandLogo(logo) = edited.kind {
+                            edited.style.color = .brand(logo.accentTool)
                         } else {
                             edited.style.color = .brand(ToolType.dedicatedCardProviders.first ?? .claude)
                         }

--- a/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
+++ b/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
@@ -726,7 +726,16 @@ struct MenuBarComposerEditor: View {
     /// Every list of fields in this editor spells them this way, because a
     /// bare "Weekly" is exactly the ambiguity the naming axis exists to end.
     static func fieldTitle(_ option: MenuBarFieldOption) -> String {
-        "\(option.tool.quotaSubProviderName(bucketID: option.bucketId)) · \(option.displayTitle)"
+        let subProvider = option.tool.quotaSubProviderName(bucketID: option.bucketId)
+        let title = option.displayTitle
+        // A legacy catalog title can already lead with the SubProvider
+        // ("Grok Bot · Weekly"); saying it twice would be worse than the
+        // ambiguity this fixes.
+        let prefix = "\(subProvider) · "
+        if title.lowercased().hasPrefix(prefix.lowercased()) {
+            return "\(subProvider) · \(title.dropFirst(prefix.count))"
+        }
+        return "\(subProvider) · \(title)"
     }
 
     private func chipHelp(_ token: MenuBarToken, isSilent: Bool, isDegraded: Bool) -> String {

--- a/Sources/VibeBarApp/Views/MenuBarStripView.swift
+++ b/Sources/VibeBarApp/Views/MenuBarStripView.swift
@@ -576,6 +576,11 @@ private struct MenuBarStripGlyph: View {
         switch glyph {
         case let .provider(tool):
             return ProviderBrandIcon.image(for: tool, size: size, tint: tint, appearance: appearance)
+        case let .brand(logo):
+            if let mark = logo.brandMark {
+                return ProviderBrandIcon.image(for: mark, size: size, tint: tint, appearance: appearance)
+            }
+            return ProviderBrandIcon.image(for: logo.tool, size: size, tint: tint, appearance: appearance)
         case .app:
             return ProviderBrandIcon.image(
                 for: MenuBarItemKind.compact, size: size, tint: tint, appearance: appearance
@@ -586,6 +591,8 @@ private struct MenuBarStripGlyph: View {
     private var fallbackSymbol: String {
         switch glyph {
         case let .provider(tool): return ProviderBrandIcon.fallbackSystemImage(for: tool)
+        case let .brand(logo):
+            return logo.brandMark?.fallbackSystemImage ?? ProviderBrandIcon.fallbackSystemImage(for: logo.tool)
         case .app: return ProviderBrandIcon.fallbackSystemImage(for: MenuBarItemKind.compact)
         }
     }

--- a/Sources/VibeBarCore/Models/MenuBarComposition.swift
+++ b/Sources/VibeBarCore/Models/MenuBarComposition.swift
@@ -85,6 +85,50 @@ public enum MenuBarQuotaMetric: String, Codable, CaseIterable, Sendable {
 
 /// One block in a composed menu-bar strip.
 ///
+/// A brand mark on the quota axis that is not a tool's own — what
+/// `MenuBarToken.Kind.brandLogo` draws.
+///
+/// Keyed the way the naming seam is keyed: a company by its representative
+/// tool, a SubProvider by the bucket that names it
+/// (`ToolType.quotaSubProviderName(bucketID:)`). The app resolves the picture
+/// from the same pair, so the mark it draws and the name it speaks can never
+/// disagree — and a build that gains a new mark later draws it for a block
+/// saved before it existed.
+public struct MenuBarBrandLogo: Hashable, Sendable {
+    public enum Level: String, Codable, Sendable {
+        case company
+        case subProvider
+    }
+
+    public var tool: ToolType
+    public var level: Level
+    /// The bucket that names the SubProvider; nil for a company mark.
+    public var bucketId: String?
+
+    public init(tool: ToolType, level: Level, bucketId: String? = nil) {
+        self.tool = tool
+        self.level = level
+        self.bucketId = bucketId
+    }
+
+    public static func company(_ tool: ToolType) -> MenuBarBrandLogo {
+        MenuBarBrandLogo(tool: tool.coreProviderRepresentative ?? tool, level: .company)
+    }
+
+    public static func subProvider(_ tool: ToolType, bucketId: String) -> MenuBarBrandLogo {
+        MenuBarBrandLogo(tool: tool, level: .subProvider, bucketId: bucketId)
+    }
+
+    /// What the block is called. A company or a SubProvider is a name, and
+    /// stays as its owner spells it in every language.
+    public var name: String {
+        switch level {
+        case .company: return tool.vendorName
+        case .subProvider: return tool.quotaSubProviderName(bucketID: bucketId)
+        }
+    }
+}
+
 /// The identity is a `UUID` rather than the content so the stage-2 editor can
 /// drag, duplicate, and undo blocks that happen to render identically — two
 /// `.text("·")` separators are two blocks, not one.
@@ -95,6 +139,13 @@ public struct MenuBarToken: Identifiable, Codable, Hashable, Sendable {
         /// the style says otherwise. Any provider, not just the ones the user
         /// selected as quota fields.
         case logo(ToolType)
+        /// A brand mark that is not a tool's own: an L1 company's (Google AI
+        /// over Gemini and AntiGravity, SpaceXAI over Grok and Cursor) or an
+        /// L2 SubProvider's (Grok Bot, whose quota rides on Cursor's
+        /// account). Named by the tool and the level rather than by the
+        /// picture, so a build with no picture for it still knows what to
+        /// say — see `MenuBarBrandLogo`.
+        case brandLogo(MenuBarBrandLogo)
         /// Literal words the user typed.
         case text(String)
         /// One number (or name, or countdown) read off a live quota bucket.
@@ -401,6 +452,10 @@ public struct MenuBarToken: Identifiable, Codable, Hashable, Sendable {
 
     public static func newLogo(_ tool: ToolType) -> MenuBarToken {
         MenuBarToken(kind: .logo(tool), style: .label)
+    }
+
+    public static func newBrandLogo(_ logo: MenuBarBrandLogo) -> MenuBarToken {
+        MenuBarToken(kind: .brandLogo(logo), style: .label)
     }
 
     public static func newQuota(fieldId: String) -> MenuBarToken {
@@ -964,7 +1019,7 @@ public struct MenuBarComposition: Codable, Equatable, Sendable {
                 continue
             case let .quota(_, metric) where metric != .label:
                 sawValue = true
-            case .logo, .appIcon, .text, .quota, .unsupported:
+            case .logo, .brandLogo, .appIcon, .text, .quota, .unsupported:
                 if sawValue {
                     starts.append(index)
                     sawValue = false
@@ -2064,6 +2119,8 @@ public struct MenuBarRenderedToken: Equatable, Sendable, Identifiable {
     /// A mark rather than words: a provider's brand, or Vibe Bar's own icon.
     public enum Glyph: Equatable, Sendable {
         case provider(ToolType)
+        /// A company's or SubProvider's mark — see `MenuBarBrandLogo`.
+        case brand(MenuBarBrandLogo)
         case app
     }
 
@@ -2447,6 +2504,8 @@ public extension MenuBarComposition {
                 glyph: .provider(tool),
                 spoken: tool.quotaSubProviderName()
             )
+        case let .brandLogo(logo):
+            return TokenContent(text: nil, glyph: .brand(logo), spoken: logo.name)
         case .appIcon:
             return TokenContent(text: nil, glyph: .app, spoken: "Vibe Bar")
         case let .text(text):
@@ -2673,10 +2732,12 @@ extension MenuBarToken.Kind: Codable {
         case fieldId
         case metric
         case width
+        case level
+        case bucketId
     }
 
     private enum Discriminator: String, Codable {
-        case logo, text, quota, space, separator, appIcon
+        case logo, brandLogo, text, quota, space, separator, appIcon
     }
 
     public init(from decoder: Decoder) throws {
@@ -2696,6 +2757,14 @@ extension MenuBarToken.Kind: Codable {
         switch try c.decode(Discriminator.self, forKey: .type) {
         case .logo:
             return .logo(try c.decode(ToolType.self, forKey: .tool))
+        case .brandLogo:
+            // A level this build lacks throws, so the block is preserved
+            // whole rather than redrawn as some other mark.
+            return .brandLogo(MenuBarBrandLogo(
+                tool: try c.decode(ToolType.self, forKey: .tool),
+                level: try c.decode(MenuBarBrandLogo.Level.self, forKey: .level),
+                bucketId: try c.decodeIfPresent(String.self, forKey: .bucketId)
+            ))
         case .text:
             return .text(try c.decode(String.self, forKey: .text))
         case .quota:
@@ -2733,6 +2802,11 @@ extension MenuBarToken.Kind: Codable {
         case let .logo(tool):
             try c.encode(Discriminator.logo, forKey: .type)
             try c.encode(tool, forKey: .tool)
+        case let .brandLogo(logo):
+            try c.encode(Discriminator.brandLogo, forKey: .type)
+            try c.encode(logo.tool, forKey: .tool)
+            try c.encode(logo.level, forKey: .level)
+            try c.encodeIfPresent(logo.bucketId, forKey: .bucketId)
         case let .text(text):
             try c.encode(Discriminator.text, forKey: .type)
             try c.encode(text, forKey: .text)

--- a/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
+++ b/Tests/VibeBarCoreTests/MenuBarCompositionTests.swift
@@ -2406,6 +2406,55 @@ final class MenuBarCompositionTests: XCTestCase {
         XCTAssertEqual(restored.composition?.tokens.last?.kind, .text("tail"))
     }
 
+    // MARK: - Brand logos
+
+    func testABrandLogoRoundTripsAndDrawsItsOwnMark() throws {
+        let grokBot = MenuBarBrandLogo.subProvider(.cursor, bucketId: "grok_bot_weekly")
+        let googleAI = MenuBarBrandLogo.company(.antigravity)
+        let composition = MenuBarComposition(tokens: [
+            MenuBarToken.newBrandLogo(grokBot),
+            MenuBarToken.newBrandLogo(googleAI)
+        ])
+        let data = try JSONEncoder().encode(composition)
+        let json = String(decoding: data, as: UTF8.self)
+        XCTAssertTrue(json.contains("\"type\":\"brandLogo\""))
+        XCTAssertTrue(json.contains("\"level\":\"subProvider\""))
+
+        let decoded = try JSONDecoder().decode(MenuBarComposition.self, from: data)
+        XCTAssertEqual(decoded.tokens.map(\.kind), [.brandLogo(grokBot), .brandLogo(googleAI)])
+
+        // The company is keyed by its representative tool, so AntiGravity's
+        // company mark is Gemini's — one Google AI, however it was asked for.
+        XCTAssertEqual(googleAI.tool, .gemini)
+        XCTAssertEqual(googleAI.name, ToolType.gemini.vendorName)
+        XCTAssertEqual(grokBot.name, "Grok Bot")
+
+        let plan = decoded.plan(quotas: [], displayMode: .used, colorBasis: .actual, now: reference)
+        let glyphs = plan.rows.flatMap(\.tokens).compactMap(\.glyph)
+        XCTAssertEqual(glyphs, [.brand(grokBot), .brand(googleAI)])
+    }
+
+    func testABrandLogoOfALevelThisBuildLacksIsPreserved() throws {
+        let json = """
+        {"isEnabled":true,"template":"roomy","tokens":[
+          {"id":"11111111-1111-1111-1111-111111111111",
+           "kind":{"type":"brandLogo","tool":"cursor","level":"galaxy"},
+           "style":{"color":{"type":"primary"},"size":"regular","weight":"medium","monospacedDigits":false},
+           "visibility":{"type":"always"}}
+        ]}
+        """
+        let decoded = try JSONDecoder().decode(MenuBarComposition.self, from: Data(json.utf8))
+        guard case .unsupported = decoded.tokens[0].kind else {
+            return XCTFail("a brand logo this build cannot read should be preserved, not redrawn")
+        }
+        let again = try JSONDecoder().decode(
+            MenuBarComposition.self, from: try JSONEncoder().encode(decoded)
+        )
+        guard case .unsupported = again.tokens[0].kind else {
+            return XCTFail("and it should survive a save")
+        }
+    }
+
     func testAnUnreadableBlockIsKeptRatherThanDroppedFromTheStrip() throws {
         // This used to assert the block was dropped. Dropping is a silent,
         // permanent deletion the moment the settings file is saved again, so


### PR DESCRIPTION
AQ, on the composer: *"很多都是weekly 5hours 看不懂哪个是哪个"* and *"这里的logo似乎都选不全 … 比如没有grokbot 新加的那些都没有"*.

## Summary

**Quota blocks say whose they are.** A strip holding three "Weekly" blocks read "Weekly · Percent (follows setting)" three times, and the field picker listed "5 Hours", "Weekly", "All Models · Weekly" with nothing to say which SubProvider. Every field is now spelled on the quota axis — "Grok Bot · Weekly", "ChatGPT · GPT-5.3 Codex Spark · 5 Hours" — in the chip, the inspector's picker and the palette (`MenuBarComposerEditor.fieldTitle`, one spelling for all three), and a quota chip wears its provider's mark the way its palette entry already did. The metric is spelled only when it is not the plain percentage, which the "Shows" control names and nearly every block uses.

**Every mark can be a logo.** The Logo row offered only the tools, so Grok Bot — a SubProvider on Cursor's account — and the company marks (Google AI, SpaceXAI) could not be put on the bar although the Quota row wore them. A new block kind, `brandLogo`, names a company or a SubProvider the way the naming seam does: the representative tool, or the tool plus the bucket that names the SubProvider (`quotaSubProviderName(bucketID:)`). The app resolves the picture from the same pair (`BrandMark.company` / `BrandMark.subProvider`), so the mark drawn and the name spoken cannot disagree, and a build with no picture for it draws the tool's own. The palette lists these after the tool marks, deduplicated by picture (Gemini and AntiGravity offer Google AI once); the inspector's logo picker offers the same list.

**Compatibility.** `brandLogo` is a new discriminator; an older build preserves the block unread (`.unsupported`) and writes it back untouched, as it does for every kind it lacks — the same test shape that guards `sparkline` now guards a `brandLogo` with an unknown level.

## Test plan

- [x] `swift build`, `swift test` (targeted: composition, lint, catalog; full suite run on the branch)
- [x] `Scripts/lint_localization.py` clean — no new strings; company and SubProvider names are identifiers
- [x] New tests: round trip + plan glyph + spoken name; unknown-level preservation across a save
- [ ] In the built app (pending — the Mac was in use): the strip's chips read "SubProvider · field"; the Logo row shows Google AI, SpaceXAI and Grok Bot; a Grok Bot logo block draws the Grok Bot mark on the menu bar and in the preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)