### PR TITLE
Bump the build number to 71 for a Dev release

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -26,7 +26,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.6.2</string>
 	<key>CFBundleVersion</key>
-	<string>70</string>
+	<string>71</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
CFBundleVersion 70 → 71 for `v1.6.2-dev.71`, which carries the Layout Studio (#337), the composer segments and brand marks (#334, #338, #340), the shared i18n catalogue (#339, vibe-bar-i18n 0.3.0) and the Workbench filter pickers (#341). Merge after #341.

🤖 Generated with [Claude Code](https://claude.com/claude-code)