### PR TITLE
Give the popover's density a home in Layout, the Studio and the menu

### DIFF
--- a/Sources/VibeBarApp/Controllers/LayoutStudioWindowController.swift
+++ b/Sources/VibeBarApp/Controllers/LayoutStudioWindowController.swift
@@ -55,7 +55,13 @@ final class LayoutStudioWindowController: NSObject {
                 .environmentObject(environment.pageLayout)
                 .environmentObject(environment.workbenchServices)
         )
-        let initialSize = NSSize(width: 1240, height: 860)
+        // As tall as the screen allows, so a page fits without shrinking
+        // further than it has to; the width is the stage plus the inspector.
+        let visible = NSScreen.main?.visibleFrame.size ?? NSSize(width: 1440, height: 900)
+        let initialSize = NSSize(
+            width: min(1240, max(880, visible.width - 80)),
+            height: min(1100, max(600, visible.height - 60))
+        )
         let win = NSWindow(
             contentRect: NSRect(origin: .zero, size: initialSize),
             styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],

--- a/Sources/VibeBarApp/StatusItemController.swift
+++ b/Sources/VibeBarApp/StatusItemController.swift
@@ -657,6 +657,7 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         menu.addItem(actionMenuItem("Refresh", action: #selector(refreshFromContextMenu(_:)), keyEquivalent: "r"))
         addMiniWindowMenuItems(to: menu)
         menu.addItem(actionMenuItem("Open Workbench", action: #selector(openWorkbenchFromContextMenu(_:))))
+        menu.addItem(densityMenuItem())
         menu.addItem(actionMenuItem("Open Settings", action: #selector(openSettingsFromContextMenu(_:)), keyEquivalent: ","))
         let updateItem = actionMenuItem(
             "Check for Updates…",
@@ -738,6 +739,32 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
         item.isEnabled = false
         return item
+    }
+
+    /// The popover's density, from the bar itself: the one layout choice a
+    /// user makes often enough — a big display at the desk, the laptop's own
+    /// on the train — to deserve a place that is not two windows away.
+    private func densityMenuItem() -> NSMenuItem {
+        let item = NSMenuItem(title: L10n.Platform.Macos.MenuBar.displayDensity, action: nil, keyEquivalent: "")
+        let submenu = NSMenu(title: L10n.Platform.Macos.MenuBar.displayDensity)
+        submenu.autoenablesItems = false
+        let current = environment.settingsStore.settings.popoverDensity
+        for density in PopoverDensity.allCases {
+            let choice = actionMenuItem(density.label, action: #selector(setDensityFromContextMenu(_:)))
+            choice.representedObject = density.rawValue
+            choice.state = density == current ? .on : .off
+            submenu.addItem(choice)
+        }
+        item.submenu = submenu
+        return item
+    }
+
+    @objc private func setDensityFromContextMenu(_ sender: NSMenuItem) {
+        guard let raw = sender.representedObject as? String,
+              let density = PopoverDensity(rawValue: raw),
+              density != environment.settingsStore.settings.popoverDensity
+        else { return }
+        environment.settingsStore.settings.popoverDensity = density
     }
 
     private func actionMenuItem(_ title: String, action: Selector, keyEquivalent: String = "") -> NSMenuItem {

--- a/Sources/VibeBarApp/Views/LayoutEditorView.swift
+++ b/Sources/VibeBarApp/Views/LayoutEditorView.swift
@@ -123,6 +123,7 @@ struct LayoutEditorView: View {
         )
 
         VStack(alignment: .leading, spacing: 12) {
+            densityRow
             pagePicker(pages: pages, selected: page)
             modeRow(page: page, mode: mode, arrangement: arrangement, descriptors: descriptors)
             controlRow(page: page, config: config, descriptors: descriptors)
@@ -184,6 +185,30 @@ struct LayoutEditorView: View {
         guard let initialPage, !hasAppliedInitialPage else { return }
         hasAppliedInitialPage = true
         selectedPage = initialPage
+    }
+
+    // MARK: - Density
+
+    /// How much room every popover page gives its cards. It lives with the
+    /// layout rather than with the menu bar because it is a property of the
+    /// surfaces being arranged here — the Studio's inspector is this same
+    /// view, so the control is in both places without being two controls.
+    private var densityRow: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Picker(
+                L10n.Platform.Macos.MenuBar.displayDensity,
+                selection: Binding(
+                    get: { settingsStore.settings.popoverDensity },
+                    set: { settingsStore.settings.popoverDensity = $0 }
+                )
+            ) {
+                ForEach(PopoverDensity.allCases) { Text($0.label).tag($0) }
+            }
+            .pickerStyle(.segmented)
+            Text(settingsStore.settings.popoverDensity.detail)
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
     }
 
     // MARK: - Page picker

--- a/Sources/VibeBarApp/Views/LayoutStudioView.swift
+++ b/Sources/VibeBarApp/Views/LayoutStudioView.swift
@@ -1000,7 +1000,12 @@ struct LayoutStudioView: View {
                     }
                     .transition(.scale(scale: 0.8).combined(with: .opacity))
                 }
-                densityPill
+                // Only where it changes the surface on the stage: a mini
+                // window has a strip density of its own and never reads the
+                // popover's.
+                if case .popoverPage = model.subject {
+                    densityPill
+                }
                 zoomPill
                 glassIconButton(
                     systemImage: model.isInspectorShown ? "sidebar.trailing" : "sidebar.leading",

--- a/Sources/VibeBarApp/Views/LayoutStudioView.swift
+++ b/Sources/VibeBarApp/Views/LayoutStudioView.swift
@@ -60,6 +60,9 @@ struct LayoutStudioView: View {
     /// Every frame the studio reasons in: the root of this view.
     static let space = "vibebar.studio"
     private static let stagePadding: CGFloat = 44
+    /// What the top and bottom bars float over: a fitted surface should sit
+    /// between them, not under them.
+    private static let fitBarReserve: CGFloat = 72
     private static let dragThreshold: CGFloat = 4
     private static let zoomSteps: [CGFloat] = [0.5, 0.67, 0.8, 1, 1.25, 1.5, 2]
     private static let inspectorWidth: CGFloat = 520
@@ -315,9 +318,19 @@ struct LayoutStudioView: View {
     private var scale: CGFloat {
         switch model.zoom {
         case .fit:
-            guard naturalSize.width > 0, stageFrame.width > 0 else { return 1 }
-            let room = stageFrame.width - Self.stagePadding * 2
-            return min(1, max(0.35, room / naturalSize.width))
+            // Both axes: a page is far taller than it is wide, and fitting
+            // the width alone left the bottom half of it to be scrolled to —
+            // which read as cut off, not as "there is more". Whole page in
+            // view first; zoom in to work on a part of it.
+            guard naturalSize.width > 0, naturalSize.height > 0,
+                  stageFrame.width > 0, stageFrame.height > 0
+            else { return 1 }
+            let room = CGSize(
+                width: stageFrame.width - Self.stagePadding * 2,
+                height: stageFrame.height - Self.stagePadding * 2 - Self.fitBarReserve
+            )
+            let fit = min(room.width / naturalSize.width, room.height / naturalSize.height)
+            return min(1, max(0.35, fit))
         case let .scale(value):
             return value
         }
@@ -987,6 +1000,7 @@ struct LayoutStudioView: View {
                     }
                     .transition(.scale(scale: 0.8).combined(with: .opacity))
                 }
+                densityPill
                 zoomPill
                 glassIconButton(
                     systemImage: model.isInspectorShown ? "sidebar.trailing" : "sidebar.leading",
@@ -1122,6 +1136,46 @@ struct LayoutStudioView: View {
                 .glassEffect(.regular, in: .capsule)
             }
         }
+    }
+
+    /// The popover's density, changeable from the stage: the surface being
+    /// arranged re-lays itself out at the new spacing as soon as it is picked.
+    private var densityPill: some View {
+        Menu {
+            ForEach(PopoverDensity.allCases) { candidate in
+                Button {
+                    guard candidate != settingsStore.settings.popoverDensity else { return }
+                    withAnimation(Self.reflow) { settingsStore.settings.popoverDensity = candidate }
+                } label: {
+                    if candidate == settingsStore.settings.popoverDensity {
+                        Label(candidate.label, systemImage: "checkmark")
+                    } else {
+                        Text(candidate.label)
+                    }
+                }
+            }
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: "textformat.size")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                Text(settingsStore.settings.popoverDensity.label)
+                    .font(.system(size: 11, weight: .semibold))
+                    .lineLimit(1)
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 8, weight: .bold))
+                    .foregroundStyle(.tertiary)
+            }
+            .padding(.horizontal, 10)
+            .frame(height: 22)
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .foregroundStyle(.primary)
+        .padding(3)
+        .glassEffect(.regular, in: .capsule)
+        .help(L10n.Platform.Macos.MenuBar.displayDensity)
     }
 
     private var zoomPill: some View {

--- a/Sources/VibeBarApp/Views/SettingsView.swift
+++ b/Sources/VibeBarApp/Views/SettingsView.swift
@@ -874,13 +874,6 @@ struct SettingsView: View {
                     .foregroundStyle(.tertiary)
             }
 
-            Picker(L10n.Platform.Macos.MenuBar.displayDensity, selection: popoverDensityBinding()) {
-                ForEach(PopoverDensity.allCases) { Text($0.label).tag($0) }
-            }
-            .pickerStyle(.segmented)
-            Text(settingsStore.settings.popoverDensity.detail)
-                .font(.caption2)
-                .foregroundStyle(.tertiary)
             Picker(L10n.Platform.Macos.MenuBar.percentColor, selection: menuBarColorBasisBinding()) {
                 ForEach(MenuBarColorBasis.allCases) { Text($0.label).tag($0) }
             }
@@ -1073,13 +1066,6 @@ struct SettingsView: View {
         Binding(
             get: { settingsStore.settings.menuBarColorBasis },
             set: { settingsStore.settings.menuBarColorBasis = $0 }
-        )
-    }
-
-    private func popoverDensityBinding() -> Binding<PopoverDensity> {
-        Binding(
-            get: { settingsStore.settings.popoverDensity },
-            set: { settingsStore.settings.popoverDensity = $0 }
         )
     }
 


### PR DESCRIPTION
## What

- **Display density moves from the Menu Bar pane to the Layout pane.** It is a property of the popover pages being arranged there. The Layout editor is also the Studio's inspector, so the same control shows up in the Studio without being a second one.
- **The Studio's top bar gets a density pill** (icon + current density, menu of the three). The surface on the stage re-lays itself out as soon as one is picked.
- **The status item's context menu gets a Display density submenu** with the current one checked — the switch people make most often (big display at the desk, the laptop's own on the train) without opening two windows.
- **Studio Fit fits both axes, and the window opens as tall as the screen allows.** Fit used to fit the width alone; a page is far taller than wide, so its bottom half had to be scrolled to and read as cut off. The whole page is seen first, zoomed into to work on.

## Verification

- `swift build`, `swift test`, `build_app.sh release`, entitlements empty; `lint_localization.py` clean.
- Demo (`settings:layout`): the density row heads the Layout pane, switching to Compact updates the caption and the pages; Open Studio now opens a full-height window at 76% Fit with the whole Overview page in view and the density pill in the top bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)