### PR TITLE
Arrange the menu bar strip on the Layout Studio's stage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -739,7 +739,7 @@ gate reads. With it on:
 - `KeychainStore` reports every item missing and swallows writes at its
   three primitives, so no surface can raise the login-keychain prompt.
 - `DemoPresenter` (`Sources/VibeBarApp/Controllers/`) opens one surface
-  (`VIBEBAR_DEMO_SURFACE=popover:<page>|mini:<mode>|workbench:<page>|settings:<section>|onboarding:<step>`)
+  (`VIBEBAR_DEMO_SURFACE=popover:<page>|mini:<mode>|workbench:<page>|settings:<section>|onboarding:<step>|studio:<page|mini|menuBar>`)
   on the sharpest display, behind it a flat full-screen backdrop, pinned to
   `VIBEBAR_DEMO_APPEARANCE=light|dark`, and prints the window frames on
   stdout for the capture script. The popover is anchored to the backdrop

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
         // `bump-vibe-bar-i18n.yml` opens the pull request that moves the pin.
         // `Package.resolved` is not committed, so the exact pin is what makes
         // two machines build the same strings.
-        .package(url: "https://github.com/AstroQore/vibe-bar-i18n.git", exact: "0.3.0"),
+        .package(url: "https://github.com/AstroQore/vibe-bar-i18n.git", exact: "0.5.0"),
         // Sparkle is the standard update framework for independently
         // distributed macOS applications. Pin the exact reviewed release:
         // update verification and installation are security-sensitive.

--- a/Scripts/lint_localization.py
+++ b/Scripts/lint_localization.py
@@ -146,6 +146,8 @@ MIGRATED = [
     "Sources/VibeBarApp/Views/CodexBarProviderBridgeCard.swift",
     "Sources/VibeBarApp/Views/RemoteMachinesPage.swift",
     "Sources/VibeBarApp/Views/MenuBarComposerEditor.swift",
+    "Sources/VibeBarApp/Views/MenuBarStripStage.swift",
+    "Sources/VibeBarApp/Views/MenuBarStageView.swift",
     "Sources/VibeBarApp/Views/MenuBarStripView.swift",
 ]
 

--- a/Sources/VibeBarApp/Controllers/DemoPresenter.swift
+++ b/Sources/VibeBarApp/Controllers/DemoPresenter.swift
@@ -168,6 +168,25 @@ final class DemoPresenter {
             let resolved = step.isEmpty ? .welcome : OnboardingStep(rawValue: step)
             guard let resolved else { return warnUnknown(surface) }
             environment.showOnboarding(step: resolved)
+        case let .studio(subject):
+            guard let resolved = studioSubject(for: subject) else { return warnUnknown(surface) }
+            LayoutStudioWindowController.shared.open(subject: resolved, environment: environment)
+        }
+    }
+
+    /// Empty or a popover tab's raw value names a page; `mini` the first
+    /// mini window; `menuBar` the composed strip.
+    private func studioSubject(for identifier: String) -> LayoutStudioWindowController.Subject? {
+        switch identifier {
+        case "":
+            return .popoverPage(.overview)
+        case "mini":
+            return environment.settingsStore.settings.miniWindow.windows.first.map { .miniWindow($0.id) }
+        case "menuBar":
+            return .menuBar(.compact)
+        default:
+            guard let tab = OverviewPage(rawValue: identifier), let page = tab.layoutPageID else { return nil }
+            return .popoverPage(page)
         }
     }
 

--- a/Sources/VibeBarApp/Controllers/LayoutStudioWindowController.swift
+++ b/Sources/VibeBarApp/Controllers/LayoutStudioWindowController.swift
@@ -23,6 +23,8 @@ final class LayoutStudioWindowController: NSObject {
     enum Subject: Hashable {
         case popoverPage(PageLayoutPageID)
         case miniWindow(UUID)
+        /// The composed menu bar strip of one status item.
+        case menuBar(MenuBarItemKind)
     }
 
     private var window: NSWindow?
@@ -245,11 +247,13 @@ final class StudioPointer: ObservableObject {
 enum StudioUndo: Equatable {
     case page(PageLayoutPageID, StoredPageLayout?)
     case miniWindow(UUID, MiniWindowConfig?)
+    case menuBar(MenuBarItemKind, MenuBarItemSettings)
 
     var subject: LayoutStudioWindowController.Subject {
         switch self {
         case let .page(page, _): return .popoverPage(page)
         case let .miniWindow(id, _): return .miniWindow(id)
+        case let .menuBar(kind, _): return .menuBar(kind)
         }
     }
 }

--- a/Sources/VibeBarApp/Controllers/LayoutStudioWindowController.swift
+++ b/Sources/VibeBarApp/Controllers/LayoutStudioWindowController.swift
@@ -59,7 +59,11 @@ final class LayoutStudioWindowController: NSObject {
         )
         // As tall as the screen allows, so a page fits without shrinking
         // further than it has to; the width is the stage plus the inspector.
-        let visible = NSScreen.main?.visibleFrame.size ?? NSSize(width: 1440, height: 900)
+        // In demo mode that is the capture display, where the window is
+        // also placed — a capture clamps to that display, and a window on
+        // another one would be an empty picture.
+        let demoScreen = DemoMode.isEnabled ? DemoPresenter.targetScreen : nil
+        let visible = (demoScreen ?? NSScreen.main)?.visibleFrame.size ?? NSSize(width: 1440, height: 900)
         let initialSize = NSSize(
             width: min(1240, max(880, visible.width - 80)),
             height: min(1100, max(600, visible.height - 60))
@@ -98,7 +102,16 @@ final class LayoutStudioWindowController: NSObject {
         shell.addChild(hosting)
         win.contentViewController = shell
         win.setContentSize(initialSize)
-        win.center()
+        if let demoScreen {
+            let frame = demoScreen.visibleFrame
+            let size = win.frame.size
+            win.setFrameOrigin(NSPoint(
+                x: frame.midX - size.width / 2,
+                y: frame.midY - size.height / 2
+            ))
+        } else {
+            win.center()
+        }
         win.minSize = NSSize(width: 880, height: 600)
         if !DemoMode.isEnabled {
             win.setFrameAutosaveName(Self.frameAutosaveName)

--- a/Sources/VibeBarApp/Views/LayoutStudioView.swift
+++ b/Sources/VibeBarApp/Views/LayoutStudioView.swift
@@ -51,6 +51,11 @@ struct LayoutStudioView: View {
     /// An undo writes the saved state too; that write is not a new step.
     @State private var isUndoing = false
     @State private var isHintShown = false
+    /// The menu bar subject's selection — shared with the composer in the
+    /// inspector, so the block picked on the stage is the block it edits.
+    @State private var stripSelection: Set<UUID> = []
+    /// The menu bar the strip is previewed on; the window's own until picked.
+    @State private var stripScheme: ColorScheme?
     @State private var hintGeneration = 0
     /// The merged field catalog, rebuilt when the registry changes rather
     /// than per render — the same reason Settings caches it.
@@ -186,6 +191,27 @@ struct LayoutStudioView: View {
                     .frame(width: size?.width, height: size?.height)
             }
             .id(id)
+        case let .menuBar(kind):
+            // Not through `surfaceShell`: the strip is not a picture scaled
+            // from outside but a live surface that draws itself at the
+            // stage's zoom and owns its own gesture — see `MenuBarStageView`.
+            if settingsStore.settings.menuBarItem(kind).usesComposedStrip {
+                MenuBarStageView(
+                    kind: kind,
+                    selection: $stripSelection,
+                    scheme: stripScheme ?? scheme,
+                    scale: scale,
+                    onNaturalSize: { naturalSize = $0 }
+                )
+                .id(kind)
+            } else {
+                Text(L10n.Platform.Macos.MenuBar.composerStudioDefault)
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 360)
+                    .padding(24)
+            }
         }
     }
 
@@ -363,7 +389,8 @@ struct LayoutStudioView: View {
             .map(LayoutStudioWindowController.Subject.popoverPage)
         let windows = settingsStore.settings.miniWindow.windows
             .map { LayoutStudioWindowController.Subject.miniWindow($0.id) }
-        return pages + windows
+        let strips = MenuBarItemKind.allCases.map(LayoutStudioWindowController.Subject.menuBar)
+        return pages + windows + strips
     }
 
     private func stepSubject(by offset: Int) {
@@ -381,6 +408,8 @@ struct LayoutStudioView: View {
                 ?? L10n.Popover.Tab.overview
         case let .miniWindow(id):
             return settingsStore.settings.miniWindow.config(id: id)?.name ?? L10n.Popover.Header.mini
+        case .menuBar:
+            return L10n.Settings.Section.menuBar
         }
     }
 
@@ -388,6 +417,7 @@ struct LayoutStudioView: View {
         switch subject {
         case .popoverPage: return "rectangle.portrait.on.rectangle.portrait"
         case .miniWindow:  return "macwindow"
+        case .menuBar:     return "menubar.rectangle"
         }
     }
 
@@ -642,6 +672,9 @@ struct LayoutStudioView: View {
             started.baseOrder = config.fieldIds
             started.axis = config.displayMode.stageAxis
             return started
+        case .menuBar:
+            // The strip owns its own gesture — see `MenuBarStageView`.
+            return nil
         }
     }
 
@@ -734,6 +767,8 @@ struct LayoutStudioView: View {
             } else {
                 drag = current
             }
+        case .menuBar:
+            drag = current
         }
 
         autoscroll(for: location)
@@ -789,6 +824,8 @@ struct LayoutStudioView: View {
                 commitMini(current, id: id, order: order)
             }
             settle(current, to: target)
+        case .menuBar:
+            withAnimation(Self.reflow) { drag = nil }
         }
     }
 
@@ -852,6 +889,11 @@ struct LayoutStudioView: View {
                 subject: model.subject,
                 state: .miniWindow(id, miniConfig(id))
             )
+        case let .menuBar(kind):
+            return SavedState(
+                subject: model.subject,
+                state: .menuBar(kind, settingsStore.settings.menuBarItem(kind))
+            )
         }
     }
 
@@ -895,6 +937,8 @@ struct LayoutStudioView: View {
         case let .miniWindow(id):
             guard let config = miniConfig(id) else { return }
             updateMini(id) { $0.fieldIds.removeAll { $0 == current.item } }
+        case .menuBar:
+            break
         }
     }
 
@@ -917,6 +961,8 @@ struct LayoutStudioView: View {
                     settings.miniWindow.windows.removeAll { $0.id == id }
                 }
                 settingsStore.settings = settings
+            case let .menuBar(_, item):
+                settingsStore.settings.setMenuBarItem(item)
             }
         }
     }
@@ -925,7 +971,7 @@ struct LayoutStudioView: View {
 
     /// The pills whose selection slides as one shape.
     private enum PillGroup: Hashable {
-        case mode, ratio, style
+        case mode, ratio, style, appearance
     }
 
     private struct TrayItem: Identifiable {
@@ -948,13 +994,16 @@ struct LayoutStudioView: View {
             return notShownFields(config).map {
                 TrayItem(id: $0.id, label: $0.displayTitle, accent: Theme.providerAccent(for: $0.tool))
             }
+        case .menuBar:
+            // The palette in the inspector is the strip's tray.
+            return []
         }
     }
 
     private var trayCaption: String {
         switch model.subject {
         case .popoverPage: return L10n.Settings.Layout.studioTrayHidden
-        case .miniWindow:  return L10n.Settings.Layout.studioTrayNotShown
+        case .miniWindow, .menuBar: return L10n.Settings.Layout.studioTrayNotShown
         }
     }
 
@@ -968,6 +1017,8 @@ struct LayoutStudioView: View {
                 updateMini(id) { config in
                     if !config.fieldIds.contains(item.id) { config.fieldIds.append(item.id) }
                 }
+            case .menuBar:
+                break
             }
         }
     }
@@ -1017,6 +1068,15 @@ struct LayoutStudioView: View {
             }
             Section(L10n.Settings.Section.miniWindows) {
                 ForEach(subjects.filter { if case .miniWindow = $0 { return true } else { return false } }, id: \.self) { subject in
+                    Button {
+                        withAnimation(.smooth(duration: 0.28)) { model.subject = subject }
+                    } label: {
+                        Label(title(for: subject), systemImage: icon(for: subject))
+                    }
+                }
+            }
+            Section(L10n.Settings.Section.menuBar) {
+                ForEach(subjects.filter { if case .menuBar = $0 { return true } else { return false } }, id: \.self) { subject in
                     Button {
                         withAnimation(.smooth(duration: 0.28)) { model.subject = subject }
                     } label: {
@@ -1121,6 +1181,29 @@ struct LayoutStudioView: View {
                 .padding(3)
                 .glassEffect(.regular, in: .capsule)
             }
+        case .menuBar:
+            // The one thing a strip has to be checked against that a page
+            // does not: both menu bars. A fixed colour can read on one and
+            // vanish on the other.
+            let current = stripScheme ?? scheme
+            HStack(spacing: 2) {
+                ForEach([ColorScheme.light, ColorScheme.dark], id: \.self) { candidate in
+                    let label = candidate == .dark
+                        ? L10n.MenuBar.Composer.Canvas.dark
+                        : L10n.MenuBar.Composer.Canvas.light
+                    pillButton(
+                        isSelected: candidate == current,
+                        systemImage: candidate == .dark ? "moon" : "sun.max",
+                        title: candidate == current ? label : nil,
+                        group: .appearance,
+                        help: label
+                    ) {
+                        withAnimation(.smooth(duration: 0.22)) { stripScheme = candidate }
+                    }
+                }
+            }
+            .padding(3)
+            .glassEffect(.regular, in: .capsule)
         }
     }
 
@@ -1289,7 +1372,7 @@ struct LayoutStudioView: View {
     private var trayHelp: String {
         switch model.subject {
         case .popoverPage: return L10n.Settings.Layout.studioTrayShowHelp
-        case .miniWindow:  return L10n.Settings.Layout.studioTrayAddHelp
+        case .miniWindow, .menuBar: return L10n.Settings.Layout.studioTrayAddHelp
         }
     }
 
@@ -1325,6 +1408,9 @@ struct LayoutStudioView: View {
             return config.displayMode.supportsStageArranging
                 ? L10n.Settings.Layout.studioHintMini
                 : L10n.Settings.Layout.studioHintFixedStyle
+        case let .menuBar(kind):
+            guard settingsStore.settings.menuBarItem(kind).usesComposedStrip else { return nil }
+            return L10n.Platform.Macos.MenuBar.composerCanvasHint
         }
     }
 
@@ -1421,6 +1507,9 @@ struct LayoutStudioView: View {
                 case let .miniWindow(id):
                     MiniWindowsSettingsSection(initialWindowID: id)
                         .id(id)
+                case let .menuBar(kind):
+                    menuBarInspector(kind)
+                        .id(kind)
                 }
             }
             .padding(16)
@@ -1434,12 +1523,52 @@ struct LayoutStudioView: View {
         }
     }
 
+    /// The composer, as Settings shows it, editing the block picked on the
+    /// stage; above it the switch that makes the strip a composed one at all.
+    private func menuBarInspector(_ kind: MenuBarItemKind) -> some View {
+        let item = settingsStore.settings.menuBarItem(kind)
+        return VStack(alignment: .leading, spacing: 12) {
+            Picker(
+                L10n.MenuBar.Composer.Mode.label,
+                selection: Binding(
+                    get: { item.usesComposedStrip },
+                    set: { enabled in
+                        var updated = settingsStore.settings.menuBarItem(kind)
+                        updated.setComposedStripEnabled(
+                            enabled,
+                            template: .matching(updated.layout),
+                            registry: quotaService.fieldRegistry,
+                            groupCatalogLabel: MiniWindowGroupLabelCatalog.defaultLabel(for:)
+                        )
+                        settingsStore.settings.setMenuBarItem(updated)
+                    }
+                )
+            ) {
+                Text(L10n.MenuBar.Composer.Mode.default).tag(false)
+                Text(L10n.MenuBar.Composer.Mode.custom).tag(true)
+            }
+            .pickerStyle(.segmented)
+            if item.usesComposedStrip {
+                MenuBarComposerEditor(kind: kind, density: density, externalSelection: $stripSelection)
+            } else {
+                Text(L10n.MenuBar.Composer.Mode.defaultCaption)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
     // MARK: - Keys
 
     private func installKeys() {
         model.keyHandler = { key in
             switch key {
             case .escape:
+                // The strip answers Escape itself — a drag to cancel, a
+                // selection to clear — through the key press the window
+                // passes on when this returns false.
+                if case .menuBar = model.subject { return false }
                 if drag != nil {
                     cancelDrag()
                 } else {

--- a/Sources/VibeBarApp/Views/LayoutStudioView.swift
+++ b/Sources/VibeBarApp/Views/LayoutStudioView.swift
@@ -56,6 +56,9 @@ struct LayoutStudioView: View {
     @State private var stripSelection: Set<UUID> = []
     /// The menu bar the strip is previewed on; the window's own until picked.
     @State private var stripScheme: ColorScheme?
+    /// Whether the strip has a block in hand — what decides who answers
+    /// Escape.
+    @State private var stripIsDragging = false
     @State private var hintGeneration = 0
     /// The merged field catalog, rebuilt when the registry changes rather
     /// than per render — the same reason Settings caches it.
@@ -204,7 +207,8 @@ struct LayoutStudioView: View {
                     selection: $stripSelection,
                     scheme: stripScheme ?? scheme,
                     scale: scale,
-                    onNaturalSize: { naturalSize = $0 }
+                    onNaturalSize: { naturalSize = $0 },
+                    onDragChange: { stripIsDragging = $0 }
                 )
                 .id(kind)
             } else {
@@ -1626,8 +1630,11 @@ struct LayoutStudioView: View {
             case .escape:
                 // The strip answers Escape itself — a drag to cancel, a
                 // selection to clear — through the key press the window
-                // passes on when this returns false.
-                if case .menuBar = model.subject { return false }
+                // passes on when this returns false. With neither, Escape
+                // closes the Studio as it does for every other subject.
+                if case .menuBar = model.subject, stripIsDragging || !stripSelection.isEmpty {
+                    return false
+                }
                 if drag != nil {
                     cancelDrag()
                 } else {

--- a/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
+++ b/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
@@ -17,6 +17,11 @@ import VibeBarCore
 struct MenuBarComposerEditor: View {
     let kind: MenuBarItemKind
     let density: Theme.Density
+    /// The Studio's selection, when this editor is its inspector: a block
+    /// picked on the stage is the block the inspector edits, and the other
+    /// way round. Kept in step with the editor's own selection rather than
+    /// replacing it, so the editor in Settings needs no owner.
+    var externalSelection: Binding<Set<UUID>>? = nil
 
     @EnvironmentObject private var environment: AppEnvironment
     @EnvironmentObject private var settingsStore: SettingsStore
@@ -199,7 +204,18 @@ struct MenuBarComposerEditor: View {
         // Selecting another block retires the inspector that queued the write,
         // so spend it first. Deterministic, unlike waiting for that view's
         // teardown to be delivered.
-        .onChange(of: selection) { _, _ in pendingCommit.flush() }
+        .onChange(of: selection) { _, new in
+            pendingCommit.flush()
+            if let external = externalSelection, external.wrappedValue != new {
+                external.wrappedValue = new
+            }
+        }
+        .onChange(of: externalSelection?.wrappedValue) { _, new in
+            if let new, new != selection { selection = new }
+        }
+        .onAppear {
+            if let external = externalSelection?.wrappedValue { selection = external }
+        }
         .onDisappear { pendingCommit.flush() }
         // A forecast percentage, a verdict rule, or a forecast colour goes
         // stale on `QuotaService`'s five-minute grid, and none of the input
@@ -678,64 +694,17 @@ struct MenuBarComposerEditor: View {
     }
 
     private func symbol(for kind: MenuBarToken.Kind) -> String {
-        switch kind {
-        case .logo, .brandLogo: return "app.badge"
-        case .text: return "textformat"
-        case .quota: return "percent"
-        case .space: return "space"
-        case .separator: return "line.diagonal"
-        case .appIcon: return "menubar.rectangle"
-        case .unsupported: return "questionmark.square.dashed"
-        }
+        MenuBarTokenNaming.symbol(for: kind)
     }
 
     private func chipTitle(_ token: MenuBarToken) -> String {
-        switch token.kind {
-        case let .logo(tool):
-            return tool.menuTitle
-        case let .brandLogo(logo):
-            return logo.name
-        case let .text(text):
-            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-            return trimmed.isEmpty ? L10n.MenuBar.Composer.Block.emptyText : MenuBarToken.truncated(trimmed)
-        case let .quota(fieldId, metric):
-            // SubProvider first: a strip holding three "Weekly" blocks has to
-            // say which is Codex's, which Claude's, which Grok Bot's. The
-            // metric is spelled only when it is not the plain percentage,
-            // which is what the "Shows" control says and what nearly every
-            // block shows.
-            let name = optionsById[fieldId].map(Self.fieldTitle) ?? fieldId
-            return metric == .displayPercent ? name : "\(name) · \(metric.title)"
-        case let .space(width):
-            let width = MenuBarToken.clampedSpaceWidth(width)
-            return width == MenuBarToken.defaultSpaceWidth
-                ? L10n.MenuBar.Composer.Block.space
-                : L10n.MenuBar.Composer.Space.widthValue(count: width)
-        case let .separator(separator):
-            let trimmed = separator.trimmingCharacters(in: .whitespacesAndNewlines)
-            return trimmed.isEmpty ? L10n.MenuBar.Composer.Block.gap : trimmed
-        case .appIcon:
-            return L10n.MenuBar.Composer.Block.appIcon
-        case .unsupported:
-            return L10n.MenuBar.Composer.Block.unsupported
-        }
+        MenuBarTokenNaming(optionsById: optionsById).title(token)
     }
 
-    /// "Grok Bot · Weekly", "ChatGPT · GPT-5.3 Codex Spark · 5 Hours": the L2
-    /// SubProvider the bucket bills against, then the field's own title.
-    /// Every list of fields in this editor spells them this way, because a
-    /// bare "Weekly" is exactly the ambiguity the naming axis exists to end.
+    /// "Grok Bot · Weekly", "ChatGPT · GPT-5.3 Codex Spark · 5 Hours" — see
+    /// `MenuBarTokenNaming.fieldTitle`.
     static func fieldTitle(_ option: MenuBarFieldOption) -> String {
-        let subProvider = option.tool.quotaSubProviderName(bucketID: option.bucketId)
-        let title = option.displayTitle
-        // A legacy catalog title can already lead with the SubProvider
-        // ("Grok Bot · Weekly"); saying it twice would be worse than the
-        // ambiguity this fixes.
-        let prefix = "\(subProvider) · "
-        if title.lowercased().hasPrefix(prefix.lowercased()) {
-            return "\(subProvider) · \(title.dropFirst(prefix.count))"
-        }
-        return "\(subProvider) · \(title)"
+        MenuBarTokenNaming.fieldTitle(option)
     }
 
     private func chipHelp(_ token: MenuBarToken, isSilent: Bool, isDegraded: Bool) -> String {

--- a/Sources/VibeBarApp/Views/MenuBarStageView.swift
+++ b/Sources/VibeBarApp/Views/MenuBarStageView.swift
@@ -25,6 +25,9 @@ struct MenuBarStageView: View {
     /// The stage's size at the Studio's 100 %, whenever it changes — what
     /// Fit measures against.
     var onNaturalSize: ((CGSize) -> Void)? = nil
+    /// Whether a block is being carried, whenever that changes — so the
+    /// Studio can tell an Escape the strip will answer from one it should.
+    var onDragChange: ((Bool) -> Void)? = nil
 
     /// How much larger than the bar the strip is at the Studio's 100 %.
     static let baseZoom: CGFloat = 2.5
@@ -140,6 +143,7 @@ struct MenuBarStageView: View {
         }
         .fixedSize(horizontal: true, vertical: false)
         .coordinateSpace(.named(MenuBarStageSpace.name))
+        .onChange(of: drag?.engaged == true) { _, isDragging in onDragChange?(isDragging) }
         .onAppear {
             inputs.start(environment: environment)
             rebuild()

--- a/Sources/VibeBarApp/Views/MenuBarStageView.swift
+++ b/Sources/VibeBarApp/Views/MenuBarStageView.swift
@@ -1,0 +1,588 @@
+import AppKit
+import SwiftUI
+import VibeBarCore
+
+/// The menu bar strip on the Studio's stage: the strip drawn large, and the
+/// gesture that arranges it.
+///
+/// Everything the Settings composer does with chips this does on the strip
+/// itself — pick a block up and it moves, its whole group with it, the rest
+/// making room live; drop it on the well below to remove it; click to select,
+/// shift-click to build a run, ⌘G to bind it. The composer's inspector sits
+/// beside this in the Studio and edits the block that is selected here.
+///
+/// Self-contained on purpose: it owns the gesture, the selection's meaning,
+/// and the provisional order, and writes settings exactly once per drop. The
+/// Studio hosts it, scales it, and lends it the light and dark grounds.
+struct MenuBarStageView: View {
+    let kind: MenuBarItemKind
+    @Binding var selection: Set<UUID>
+    /// The menu bar the strip is previewed on.
+    let scheme: ColorScheme
+    /// The Studio's scale. The strip is drawn at `baseZoom` times it, so
+    /// "100 %" on the stage is a strip large enough to take hold of.
+    let scale: CGFloat
+    /// The stage's size at the Studio's 100 %, whenever it changes — what
+    /// Fit measures against.
+    var onNaturalSize: ((CGSize) -> Void)? = nil
+
+    /// How much larger than the bar the strip is at the Studio's 100 %.
+    static let baseZoom: CGFloat = 2.5
+
+    @EnvironmentObject private var environment: AppEnvironment
+    @EnvironmentObject private var settingsStore: SettingsStore
+    @EnvironmentObject private var quotaService: QuotaService
+
+    /// Holds the subscription to the one list of things a composed strip
+    /// depends on — the same list the status item re-renders on.
+    @StateObject private var inputs = MenuBarStripInputObserver()
+
+    // Everything expensive is cached and rebuilt on a data change, never on
+    // a pointer move: resolving a quota can compute a personal forecast.
+    @State private var snapshots: [MenuBarQuotaSnapshot] = []
+    @State private var liveFieldIds: Set<String> = []
+    @State private var optionsById: [String: MenuBarFieldOption] = [:]
+
+    @State private var frames = MenuBarStageFrames()
+    @State private var drag: StageDrag?
+    /// Set by Escape mid-drag: the gesture keeps reporting until the button
+    /// is released, and every report after the cancel must be ignored.
+    @State private var isDragCancelled = false
+    /// The order the strip *would* have if the drag ended here. Local state,
+    /// not settings: writing every crossing through `settingsStore` would
+    /// re-render the menu bar mid-gesture.
+    @State private var dragComposition: MenuBarComposition?
+    /// The stage's frame in the shared space, to place the picture carried
+    /// under the pointer.
+    @State private var stageFrame: CGRect = .zero
+    @FocusState private var isFocused: Bool
+
+    private static let dragThreshold: CGFloat = 4
+    /// How far above or below a row a drag may hover and still mean it.
+    private static let reach: CGFloat = 40
+    private static let reflow = Animation.snappy(duration: 0.26, extraBounce: 0.03)
+
+    private struct StageDrag {
+        /// The block pressed, nil for a press on the ground.
+        let anchor: UUID?
+        /// The blocks that move with it — its whole group.
+        let run: [UUID]
+        /// Where the press began; the threshold is measured from here.
+        let start: CGPoint
+        var location: CGPoint
+        var engaged = false
+        /// Where inside the run's box the pointer took hold, so the picture
+        /// does not jump to centre itself on the cursor.
+        var grabOffset: CGSize = .zero
+        var target: MenuBarStageTarget?
+    }
+
+    private var zoom: CGFloat { Self.baseZoom * scale }
+    private var item: MenuBarItemSettings { settingsStore.settings.menuBarItem(kind) }
+    private var composition: MenuBarComposition { item.composition ?? MenuBarComposition() }
+    private var naming: MenuBarTokenNaming { MenuBarTokenNaming(optionsById: optionsById) }
+
+    /// What the stage draws: the provisional order while a drag is in
+    /// flight, the committed one otherwise.
+    private var displayedComposition: MenuBarComposition {
+        guard drag?.engaged == true, let dragComposition else { return composition }
+        return dragComposition
+    }
+
+    /// Everything the cached snapshots are derived from — see the composer's
+    /// `SnapshotKey` for why the display mode and colour basis are in here.
+    private struct SnapshotKey: Equatable {
+        var requirements: [MenuBarQuotaRequirement]
+        var displayMode: DisplayMode
+        var colorBasis: MenuBarColorBasis
+        var customLabels: [String: String]
+    }
+
+    private var snapshotKey: SnapshotKey {
+        SnapshotKey(
+            requirements: composition.quotaRequirements,
+            displayMode: settingsStore.settings.displayMode,
+            colorBasis: settingsStore.settings.menuBarColorBasis,
+            customLabels: item.customLabels
+        )
+    }
+
+    private var needsForecastClock: Bool {
+        composition.needsForecastClock(colorBasis: settingsStore.settings.menuBarColorBasis)
+    }
+
+    var body: some View {
+        let composition = displayedComposition
+        let availability = composition.availability(liveFieldIds: liveFieldIds)
+        let bound = composition.boundGroupIDs
+        // Hugs the strip: the well below stretches to the strip's width
+        // rather than the stage's, so the pair reads as one object.
+        VStack(alignment: .center, spacing: 14) {
+            // A countdown block is wrong a minute later with no new data
+            // behind it. Gated on the strip actually printing one — see the
+            // composer's preview for the reasoning.
+            TimelineView(
+                QuotaClockSchedule(
+                    isActive: composition.hasTimeBasedBlock,
+                    interval: MenuBarCountdownClock.interval
+                )
+            ) { context in
+                let plan = composition.plan(
+                    quotas: snapshots,
+                    displayMode: settingsStore.settings.displayMode,
+                    colorBasis: settingsStore.settings.menuBarColorBasis,
+                    now: context.date,
+                    canvas: MenuBarStripMetrics.twoRowCanvas()
+                )
+                stage(composition, plan: plan, availability: availability, bound: bound)
+            }
+            well
+        }
+        .fixedSize(horizontal: true, vertical: false)
+        .coordinateSpace(.named(MenuBarStageSpace.name))
+        .onAppear {
+            inputs.start(environment: environment)
+            rebuild()
+        }
+        .onReceive(inputs.$generation) { _ in rebuild() }
+        .onChange(of: snapshotKey) { _, _ in rebuild() }
+        // A forecast percentage, a verdict rule, or a forecast colour goes
+        // stale on `QuotaService`'s five-minute grid, and none of the input
+        // publishers fires in between — same pacing as the composer's.
+        .task(id: needsForecastClock) {
+            guard needsForecastClock else { return }
+            while !Task.isCancelled {
+                let next = MenuBarCountdownClock.nextTick(
+                    after: Date(),
+                    anchor: QuotaClockSchedule.anchor,
+                    interval: MenuBarCountdownClock.forecastInterval
+                )
+                try? await Task.sleep(for: .seconds(max(0, next.timeIntervalSinceNow)))
+                guard !Task.isCancelled else { return }
+                rebuild()
+            }
+        }
+    }
+
+    private func rebuild() {
+        let merged = MenuBarFieldCatalog.mergedFields(registry: quotaService.fieldRegistry)
+        optionsById = Dictionary(merged.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+        snapshots = MenuBarStripResolver.snapshots(
+            for: composition,
+            itemSettings: item,
+            settings: settingsStore.settings,
+            environment: environment
+        )
+        liveFieldIds = MenuBarStripResolver.liveFieldIds(environment: environment)
+    }
+
+    // MARK: - Stage
+
+    private func stage(
+        _ composition: MenuBarComposition,
+        plan: MenuBarRenderPlan,
+        availability: MenuBarComposition.Availability,
+        bound: Set<UUID>
+    ) -> some View {
+        let lifted: Set<UUID> = drag?.engaged == true ? Set(drag?.run ?? []) : []
+        return ZStack(alignment: .topLeading) {
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                // A stand-in for a menu bar, not a card: a light or a dark
+                // ground to read the strip against.
+                .fill(scheme == .dark ? Color.black.opacity(0.84) : Color.white.opacity(0.94))
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .strokeBorder(Color.primary.opacity(isFocused ? 0.26 : 0.12), lineWidth: 0.5)
+            if composition.segments.isEmpty {
+                Text(L10n.MenuBar.Composer.Blocks.empty)
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                    .padding(18)
+            } else {
+                MenuBarStripStage(
+                    composition: composition,
+                    plan: plan,
+                    template: composition.template,
+                    quotas: snapshots,
+                    displayMode: settingsStore.settings.displayMode,
+                    availability: availability,
+                    bound: bound,
+                    selection: selection,
+                    lifted: lifted,
+                    scheme: scheme,
+                    zoom: zoom,
+                    frames: frames,
+                    naming: naming,
+                    tokenMenu: { token in tokenMenu(token, in: composition) },
+                    segmentMenu: { segment, index in segmentMenu(segment, index: index, of: composition) }
+                )
+                .padding(.horizontal, 18)
+                .padding(.vertical, 14)
+            }
+        }
+        .fixedSize()
+        .onGeometryChange(for: CGRect.self) { $0.frame(in: .named(MenuBarStageSpace.name)) } action: { frame in
+            stageFrame = frame
+            onNaturalSize?(CGSize(width: frame.width / scale, height: frame.height / scale))
+        }
+        .contentShape(Rectangle())
+        .gesture(dragGesture)
+        .overlay(alignment: .topLeading) {
+            if let drag, drag.engaged, !drag.run.isEmpty {
+                ghost(drag, composition: composition, plan: plan)
+            }
+        }
+        .focusable()
+        .focused($isFocused)
+        .focusEffectDisabled()
+        .onKeyPress(phases: .down) { press in handleKey(press, composition: composition) }
+        .shadow(color: .black.opacity(scheme == .dark ? 0.5 : 0.16), radius: 22, y: 10)
+    }
+
+    /// The picture carried under the pointer: the run being moved, drawn as
+    /// the stage draws it, over the placeholder that is making room.
+    private func ghost(
+        _ drag: StageDrag,
+        composition: MenuBarComposition,
+        plan: MenuBarRenderPlan
+    ) -> some View {
+        let tokens = drag.run.compactMap { composition.token($0) }
+        var rendered: [UUID: MenuBarRenderedToken] = [:]
+        for column in plan.columns {
+            for token in column.top.tokens { rendered[token.id] = token }
+            for token in column.bottom?.tokens ?? [] { rendered[token.id] = token }
+        }
+        return MenuBarStageRunGhost(
+            tokens: tokens,
+            rendered: rendered,
+            template: composition.template,
+            plan: plan,
+            quotas: snapshots,
+            displayMode: settingsStore.settings.displayMode,
+            scheme: scheme,
+            zoom: zoom,
+            naming: naming
+        )
+        .scaleEffect(1.04)
+        .offset(
+            x: drag.location.x - drag.grabOffset.width - stageFrame.minX,
+            y: drag.location.y - drag.grabOffset.height - stageFrame.minY
+        )
+    }
+
+    /// The bar a block is dropped on to remove it. Lit while the pointer is
+    /// over it with a block in hand.
+    private var well: some View {
+        let isTargeted = drag?.target == .removed
+        return HStack(spacing: 6) {
+            Image(systemName: "trash")
+                .font(.system(size: 11, weight: .semibold))
+            Text(L10n.MenuBar.Composer.removeTarget)
+                .font(.system(size: 11.5, weight: .medium))
+        }
+        .foregroundStyle(isTargeted ? Color.red : Color.secondary)
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 9)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color.red.opacity(isTargeted ? 0.16 : 0.05))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .strokeBorder(
+                    Color.red.opacity(isTargeted ? 0.55 : 0.2),
+                    style: StrokeStyle(lineWidth: 0.5, dash: [3, 3])
+                )
+        )
+        .onGeometryChange(for: CGRect.self) { $0.frame(in: .named(MenuBarStageSpace.name)) } action: { frame in
+            frames.well = frame
+        }
+        .animation(.smooth(duration: 0.18), value: isTargeted)
+    }
+
+    // MARK: - Gesture
+
+    private var dragGesture: some Gesture {
+        // `minimumDistance: 0` so the press is captured immediately — the
+        // gesture then owns the pointer until release — but nothing lifts
+        // until the threshold below is crossed, so a click never moves a
+        // block.
+        DragGesture(minimumDistance: 0, coordinateSpace: .named(MenuBarStageSpace.name))
+            .onChanged { value in
+                if drag == nil {
+                    guard !isDragCancelled else { return }
+                    let anchor = frames.token(at: value.startLocation)
+                    drag = StageDrag(
+                        anchor: anchor,
+                        run: anchor.map { composition.groupedRun(of: $0) } ?? [],
+                        start: value.startLocation,
+                        location: value.location
+                    )
+                }
+                advance(to: value.location)
+            }
+            .onEnded { _ in
+                isDragCancelled = false
+                guard let current = drag else { return }
+                drag = nil
+                if current.engaged {
+                    finish(current)
+                } else {
+                    click(current.anchor)
+                }
+            }
+    }
+
+    private func advance(to location: CGPoint) {
+        guard var current = drag else { return }
+        current.location = location
+        if !current.engaged {
+            let fromStart = hypot(location.x - current.start.x, location.y - current.start.y)
+            guard let anchor = current.anchor, fromStart >= Self.dragThreshold else {
+                drag = current
+                return
+            }
+            _ = anchor
+            current.engaged = true
+            let box = current.run
+                .compactMap { frames.tokens[$0] }
+                .reduce(CGRect.null) { $0.union($1) }
+            if !box.isNull {
+                current.grabOffset = CGSize(width: current.start.x - box.minX, height: current.start.y - box.minY)
+            }
+            isFocused = true
+            // Snapshot the committed order; every crossing rearranges this
+            // copy, and only the drop writes.
+            dragComposition = composition
+            NSCursor.closedHand.set()
+        }
+        guard let anchor = current.anchor else {
+            drag = current
+            return
+        }
+        let target: MenuBarStageTarget?
+        if frames.well.contains(location) {
+            target = .removed
+        } else {
+            target = frames.target(
+                at: location,
+                in: dragComposition ?? composition,
+                moving: Set(current.run),
+                reach: Self.reach
+            ) ?? current.target
+        }
+        if let target, target != current.target {
+            current.target = target
+            // From the committed order every time, so a drag that crosses
+            // the strip twice ends where the pointer is, not where the
+            // crossings accumulated to.
+            var next = composition
+            switch target {
+            case let .before(id):
+                next.move(anchor, before: id)
+            case let .endOf(address):
+                next.move(anchor, toEndOf: address)
+            case .removed:
+                for id in current.run { next.remove(id) }
+            }
+            if next != dragComposition {
+                withAnimation(Self.reflow) { dragComposition = next }
+            }
+        }
+        drag = current
+    }
+
+    private func finish(_ current: StageDrag) {
+        NSCursor.arrow.set()
+        if current.target == .removed {
+            selection.subtract(current.run)
+        }
+        let reordered = dragComposition
+        withAnimation(Self.reflow) { dragComposition = nil }
+        if let reordered, reordered != composition {
+            let segments = reordered.segments
+            mutate { $0.segments = segments }
+        }
+    }
+
+    private func cancel() {
+        guard let current = drag, current.engaged else { return }
+        isDragCancelled = true
+        drag = nil
+        withAnimation(Self.reflow) { dragComposition = nil }
+        NSCursor.arrow.set()
+    }
+
+    /// A press that never became a drag. Shift or command extends the
+    /// selection — that is how a run to group is picked — and a press on the
+    /// ground clears it.
+    private func click(_ anchor: UUID?) {
+        isFocused = true
+        guard let anchor else {
+            selection = []
+            return
+        }
+        let flags = NSEvent.modifierFlags
+        if flags.contains(.shift) || flags.contains(.command) {
+            if selection.contains(anchor) {
+                selection.remove(anchor)
+            } else {
+                selection.insert(anchor)
+            }
+        } else {
+            selection = [anchor]
+        }
+    }
+
+    private func handleKey(_ press: KeyPress, composition: MenuBarComposition) -> KeyPress.Result {
+        switch press.key {
+        case .escape:
+            if drag?.engaged == true {
+                cancel()
+            } else if !selection.isEmpty {
+                selection = []
+            } else {
+                return .ignored
+            }
+            return .handled
+        case .delete, .deleteForward:
+            guard !selection.isEmpty else { return .ignored }
+            remove(Array(selection))
+            return .handled
+        default:
+            break
+        }
+        guard press.modifiers.contains(.command) else { return .ignored }
+        switch press.characters.lowercased() {
+        case "g":
+            if press.modifiers.contains(.shift) {
+                ungroupSelection(composition)
+            } else {
+                groupSelection(composition)
+            }
+            return .handled
+        case "d":
+            guard selection.count == 1 else { return .ignored }
+            duplicateSelected()
+            return .handled
+        default:
+            return .ignored
+        }
+    }
+
+    // MARK: - Edits
+
+    /// The one settings write an edit performs. An edit that changes nothing
+    /// must not publish: every write fans out to every subscriber and
+    /// re-renders the menu bar.
+    private func mutate(_ change: (inout MenuBarComposition) -> Void) {
+        var updated = item
+        let before = updated.composition
+        var composed = before ?? MenuBarComposition(isEnabled: true)
+        change(&composed)
+        guard composed != before else { return }
+        updated.composition = composed
+        settingsStore.settings.setMenuBarItem(updated)
+    }
+
+    func groupSelection(_ composition: MenuBarComposition) {
+        let ids = Array(selection)
+        guard composition.canGroup(ids) else { return }
+        mutate { $0.group(ids) }
+    }
+
+    func ungroupSelection(_ composition: MenuBarComposition) {
+        let grouped = selection.filter { composition.isGrouped($0) }
+        guard !grouped.isEmpty else { return }
+        mutate { composed in
+            var done: Set<UUID> = []
+            for id in grouped where !done.contains(id) {
+                done.formUnion(composed.groupedRun(of: id))
+                composed.ungroup(id)
+            }
+        }
+    }
+
+    private func duplicateSelected() {
+        guard selection.count == 1, let id = selection.first else { return }
+        var copy: UUID?
+        mutate { copy = $0.duplicate(id) }
+        if let copy { selection = [copy] }
+    }
+
+    private func remove(_ ids: [UUID]) {
+        guard !ids.isEmpty else { return }
+        selection.subtract(ids)
+        mutate { composed in
+            for id in ids { composed.remove(id) }
+        }
+    }
+
+    // MARK: - Menus
+
+    @ViewBuilder
+    private func tokenMenu(_ token: MenuBarToken, in composition: MenuBarComposition) -> some View {
+        let ids = selection.contains(token.id) ? Array(selection) : [token.id]
+        Button(L10n.MenuBar.Composer.Group.bind) {
+            selection = Set(ids)
+            groupSelection(composition)
+        }
+        .disabled(!composition.canGroup(ids))
+        if composition.isGrouped(token.id) {
+            Button(L10n.MenuBar.Composer.Group.unbind) { mutate { $0.ungroup(token.id) } }
+        }
+        Divider()
+        if composition.canSplitSegment(before: token.id) {
+            Button(L10n.MenuBar.Composer.Segment.splitHere) { mutate { $0.splitSegment(before: token.id) } }
+        }
+        Button(L10n.MenuBar.Composer.Action.duplicate) {
+            var copy: UUID?
+            mutate { copy = $0.duplicate(token.id) }
+            if let copy { selection = [copy] }
+        }
+        Divider()
+        Button(L10n.Common.remove, role: .destructive) { remove(ids) }
+    }
+
+    /// One segment's own actions: move it, merge it, open or close its
+    /// second row, remove it. Saving it as a preset stays in the inspector,
+    /// which has the name field.
+    private func segmentMenu(_ segment: MenuBarSegment, index: Int, of composition: MenuBarComposition) -> some View {
+        Menu {
+            Button(L10n.MenuBar.Composer.Segment.moveLeft) {
+                mutate { $0.moveSegment(segment.id, by: -1) }
+            }
+            .disabled(index == 0)
+            Button(L10n.MenuBar.Composer.Segment.moveRight) {
+                mutate { $0.moveSegment(segment.id, by: 1) }
+            }
+            .disabled(index == composition.segments.count - 1)
+            Button(L10n.MenuBar.Composer.Segment.mergeLeft) {
+                mutate { $0.mergeSegmentIntoPrevious(segment.id) }
+            }
+            .disabled(index == 0)
+            Divider()
+            if segment.isStacked {
+                Button(L10n.MenuBar.Composer.Segment.removeRow) {
+                    mutate { $0.removeRow(fromSegment: segment.id) }
+                }
+            } else {
+                Button(L10n.MenuBar.Composer.Segment.addRow) {
+                    mutate { $0.addRow(toSegment: segment.id) }
+                }
+            }
+            Divider()
+            Button(L10n.MenuBar.Composer.Segment.remove, role: .destructive) {
+                selection.subtract(segment.tokens.map(\.id))
+                mutate { $0.removeSegment(segment.id) }
+            }
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .frame(width: 18, height: 14)
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+    }
+}

--- a/Sources/VibeBarApp/Views/MenuBarStripStage.swift
+++ b/Sources/VibeBarApp/Views/MenuBarStripStage.swift
@@ -1,0 +1,528 @@
+import AppKit
+import SwiftUI
+import VibeBarCore
+
+// The composer arranges the strip on the strip itself. This file is the
+// strip drawn large enough to take hold of: every block the composition
+// holds — drawn the way the bar draws it, or as a ghost when the bar is not
+// drawing it right now — laid out in its segments and rows, reporting where
+// it is so the editor can ask what is under the pointer. The editor owns the
+// gesture, the selection and the provisional order; this only draws.
+
+// MARK: - Frames
+
+/// Where the blocks and rows of the live strip are, as it last drew them, in
+/// the canvas's own coordinate space.
+///
+/// A plain class, like `SurfaceItemFrames`: frames move on every pass of a
+/// reflow animation, and nothing should re-render because of that. The editor
+/// reads them when the pointer asks a question.
+@MainActor
+final class MenuBarStageFrames {
+    private(set) var tokens: [UUID: CGRect] = [:]
+    private(set) var rows: [MenuBarComposition.RowAddress: CGRect] = [:]
+    /// The bar under the strip that a block is dropped on to remove it.
+    var well: CGRect = .null
+
+    func report(_ frame: CGRect, token id: UUID) { tokens[id] = frame }
+    func forget(token id: UUID) { tokens.removeValue(forKey: id) }
+    func report(_ frame: CGRect, row: MenuBarComposition.RowAddress) { rows[row] = frame }
+    func forget(row: MenuBarComposition.RowAddress) { rows.removeValue(forKey: row) }
+
+    /// The block under `point`. A little slack around each: a glyph is small,
+    /// and the gap beside it is not something anyone means to press.
+    func token(at point: CGPoint) -> UUID? {
+        tokens.first { $0.value.insetBy(dx: -2, dy: -3).contains(point) }?.key
+    }
+
+    /// The row under `point`, or the nearest one within `reach` of it — a
+    /// drag hovering just above a row still means that row.
+    func row(near point: CGPoint, reach: CGFloat) -> MenuBarComposition.RowAddress? {
+        if let hit = rows.first(where: { $0.value.contains(point) }) { return hit.key }
+        guard let nearest = rows.min(by: { Self.distance($0.value, point) < Self.distance($1.value, point) }),
+              Self.distance(nearest.value, point) <= reach
+        else { return nil }
+        return nearest.key
+    }
+
+    private static func distance(_ rect: CGRect, _ point: CGPoint) -> CGFloat {
+        let dx = max(rect.minX - point.x, 0, point.x - rect.maxX)
+        let dy = max(rect.minY - point.y, 0, point.y - rect.maxY)
+        return hypot(dx, dy)
+    }
+}
+
+/// Where a block in flight would land if it were dropped now.
+enum MenuBarStageTarget: Equatable {
+    case before(UUID)
+    case endOf(MenuBarComposition.RowAddress)
+    case removed
+}
+
+extension MenuBarStageFrames {
+    /// The slot under `point`, by the same midpoint rule the Studio uses: in
+    /// front of the first block whose middle the pointer has not passed, else
+    /// at the end of the row. `moving` are the blocks being carried, which
+    /// cannot be their own target.
+    func target(
+        at point: CGPoint,
+        in composition: MenuBarComposition,
+        moving: Set<UUID>,
+        reach: CGFloat
+    ) -> MenuBarStageTarget? {
+        guard let address = row(near: point, reach: reach),
+              let segment = composition.segmentIndex(of: address.segment)
+        else { return nil }
+        for token in composition.segments[segment][address.row] where !moving.contains(token.id) {
+            guard let frame = tokens[token.id] else { continue }
+            if point.x < frame.midX { return .before(token.id) }
+        }
+        return .endOf(address)
+    }
+}
+
+// MARK: - Naming
+
+/// What a block is called when the strip cannot say — the ghost of one the
+/// bar is not drawing, a tooltip, the inspector's title.
+struct MenuBarTokenNaming {
+    var optionsById: [String: MenuBarFieldOption] = [:]
+
+    func title(_ token: MenuBarToken) -> String {
+        switch token.kind {
+        case let .logo(tool):
+            return tool.menuTitle
+        case let .brandLogo(logo):
+            return logo.name
+        case let .text(text):
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? L10n.MenuBar.Composer.Block.emptyText : MenuBarToken.truncated(trimmed)
+        case let .quota(fieldId, metric):
+            // SubProvider first: a strip holding three "Weekly" blocks has to
+            // say which is Codex's, which Claude's, which Grok Bot's. The
+            // metric is spelled only when it is not the plain percentage,
+            // which is what the "Shows" control says and what nearly every
+            // block shows.
+            let name = optionsById[fieldId].map(Self.fieldTitle) ?? fieldId
+            return metric == .displayPercent ? name : "\(name) · \(metric.title)"
+        case let .space(width):
+            let width = MenuBarToken.clampedSpaceWidth(width)
+            return width == MenuBarToken.defaultSpaceWidth
+                ? L10n.MenuBar.Composer.Block.space
+                : L10n.MenuBar.Composer.Space.widthValue(count: width)
+        case let .separator(separator):
+            let trimmed = separator.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? L10n.MenuBar.Composer.Block.gap : trimmed
+        case .appIcon:
+            return L10n.MenuBar.Composer.Block.appIcon
+        case .unsupported:
+            return L10n.MenuBar.Composer.Block.unsupported
+        }
+    }
+
+    /// "Grok Bot · Weekly", "ChatGPT · GPT-5.3 Codex Spark · 5 Hours": the L2
+    /// SubProvider the bucket bills against, then the field's own title.
+    /// Every list of fields in the composer spells them this way, because a
+    /// bare "Weekly" is exactly the ambiguity the naming axis exists to end.
+    static func fieldTitle(_ option: MenuBarFieldOption) -> String {
+        let subProvider = option.tool.quotaSubProviderName(bucketID: option.bucketId)
+        let title = option.displayTitle
+        // A legacy catalog title can already lead with the SubProvider
+        // ("Grok Bot · Weekly"); saying it twice would be worse than the
+        // ambiguity this fixes.
+        let prefix = "\(subProvider) · "
+        if title.lowercased().hasPrefix(prefix.lowercased()) {
+            return "\(subProvider) · \(title.dropFirst(prefix.count))"
+        }
+        return "\(subProvider) · \(title)"
+    }
+
+    static func symbol(for kind: MenuBarToken.Kind) -> String {
+        switch kind {
+        case .logo, .brandLogo: return "app.badge"
+        case .text: return "textformat"
+        case .quota: return "percent"
+        case .space: return "space"
+        case .separator: return "line.diagonal"
+        case .appIcon: return "menubar.rectangle"
+        case .unsupported: return "questionmark.square.dashed"
+        }
+    }
+}
+
+// MARK: - Canvas
+
+/// The coordinate space the canvas, its well and the editor's gesture share.
+enum MenuBarStageSpace {
+    static let name = "vibebar.menubar.canvas"
+}
+
+/// The strip, drawn large on a menu-bar ground, every block in its place.
+///
+/// Laid out from the composition rather than from the render plan, so a
+/// block the bar is not drawing right now — a quota that is not answering, a
+/// rule that is not met — still has a place to be picked up from. Blocks the
+/// plan did render are drawn exactly as the bar draws them; the rest are
+/// ghosts that say their name.
+struct MenuBarStripStage<TokenMenu: View, SegmentMenu: View>: View {
+    /// The order being drawn — provisional while a drag is in flight.
+    let composition: MenuBarComposition
+    let plan: MenuBarRenderPlan
+    let template: MenuBarComposition.Template
+    let quotas: [MenuBarQuotaSnapshot]
+    let displayMode: DisplayMode
+    let availability: MenuBarComposition.Availability
+    /// Group ids that bind more than one block — see `boundGroupIDs`.
+    let bound: Set<UUID>
+    let selection: Set<UUID>
+    /// Blocks being carried: drawn in place as a dimmed placeholder.
+    let lifted: Set<UUID>
+    let scheme: ColorScheme
+    /// How much larger than the bar the strip is drawn.
+    let zoom: CGFloat
+    let frames: MenuBarStageFrames
+    let naming: MenuBarTokenNaming
+    @ViewBuilder let tokenMenu: (MenuBarToken) -> TokenMenu
+    @ViewBuilder let segmentMenu: (MenuBarSegment, Int) -> SegmentMenu
+
+    /// Rows the bar draws for this template, which sets its face and its
+    /// glyph box — the same count the preview and the status item use.
+    private var rowCount: Int { plan.isTwoRow || template == .twoColumn ? 2 : 1 }
+
+    /// The face the bar would draw this strip at, times the zoom.
+    private var base: CGFloat {
+        let face = MenuBarStripMetrics.baseFontSize(template: template, rowCount: rowCount)
+        let fit = MenuBarStripMetrics.estimatedFitScale(plan: plan, baseFontSize: face)
+        return face * fit * zoom
+    }
+
+    private var gap: CGFloat { base * plan.tokenSpacing * 0.28 }
+
+    var body: some View {
+        let rendered = renderedByID
+        HStack(alignment: .center, spacing: 0) {
+            ForEach(Array(composition.segments.enumerated()), id: \.element.id) { index, segment in
+                if index > 0 { boundary }
+                segmentBox(segment, index: index, rendered: rendered)
+            }
+        }
+        .environment(\.colorScheme, scheme)
+    }
+
+    private var renderedByID: [UUID: MenuBarRenderedToken] {
+        var out: [UUID: MenuBarRenderedToken] = [:]
+        for column in plan.columns {
+            for token in column.top.tokens { out[token.id] = token }
+            for token in column.bottom?.tokens ?? [] { out[token.id] = token }
+        }
+        return out
+    }
+
+    /// What the bar puts between two segments: the template's divider with a
+    /// gap each side, or the two-row column gap.
+    @ViewBuilder
+    private var boundary: some View {
+        if let separator = plan.columnSeparator, rowCount == 1 {
+            Text(separator)
+                .font(.system(size: base, weight: .regular))
+                .foregroundStyle(Color.primary.opacity(0.45))
+                .fixedSize()
+                .padding(.horizontal, gap + 6)
+        } else {
+            Color.clear.frame(width: MenuBarStripMetrics.twoRowColumnSpacing * zoom + 8, height: 0)
+        }
+    }
+
+    private func segmentBox(
+        _ segment: MenuBarSegment,
+        index: Int,
+        rendered: [UUID: MenuBarRenderedToken]
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            rowView(segment, row: .top, rendered: rendered)
+            if segment.isStacked {
+                Rectangle()
+                    .fill(Color.primary.opacity(0.10))
+                    .frame(height: 0.5)
+                rowView(segment, row: .bottom, rendered: rendered)
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.top, 14)
+        .padding(.bottom, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color.primary.opacity(0.045))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .strokeBorder(Color.primary.opacity(0.12), lineWidth: 0.5)
+        )
+        // The segment's number and its menu ride the box's top edge, small,
+        // so the strip itself stays the thing being looked at.
+        .overlay(alignment: .topLeading) {
+            Text(L10n.MenuBar.Composer.Segment.title(index: index + 1))
+                .font(.system(size: 8, weight: .semibold))
+                .foregroundStyle(.tertiary)
+                .textCase(.uppercase)
+                .padding(.leading, 8)
+                .padding(.top, 3)
+        }
+        .overlay(alignment: .topTrailing) {
+            segmentMenu(segment, index)
+                .padding(.trailing, 4)
+        }
+    }
+
+    private func rowView(
+        _ segment: MenuBarSegment,
+        row: MenuBarSegment.Row,
+        rendered: [UUID: MenuBarRenderedToken]
+    ) -> some View {
+        let address = MenuBarComposition.RowAddress(segment: segment.id, row: row)
+        let tokens = segment[row]
+        return Group {
+            if tokens.isEmpty {
+                Text(L10n.MenuBar.Composer.Row.empty)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .padding(.horizontal, 4)
+            } else {
+                HStack(spacing: gap) {
+                    ForEach(chunks(tokens), id: \.first!.id) { chunk in
+                        chunkView(chunk, rendered: rendered)
+                    }
+                }
+            }
+        }
+        .frame(minWidth: 48, minHeight: base * MenuBarStripMetrics.lineHeightRatio + 8, alignment: .leading)
+        .onGeometryChange(for: CGRect.self) { $0.frame(in: .named(MenuBarStageSpace.name)) } action: { frame in
+            frames.report(frame, row: address)
+        }
+        .onDisappear { frames.forget(row: address) }
+    }
+
+    /// A row as runs: blocks bound together become one chunk, everything
+    /// else a chunk of one — so a group can be drawn around, and carried, as
+    /// the single thing it is.
+    private func chunks(_ tokens: [MenuBarToken]) -> [[MenuBarToken]] {
+        var out: [[MenuBarToken]] = []
+        for token in tokens {
+            if let group = token.groupID, bound.contains(group),
+               let last = out.last?.last, last.groupID == group {
+                out[out.count - 1].append(token)
+            } else {
+                out.append([token])
+            }
+        }
+        return out
+    }
+
+    @ViewBuilder
+    private func chunkView(_ chunk: [MenuBarToken], rendered: [UUID: MenuBarRenderedToken]) -> some View {
+        let isGroup = chunk.count > 1
+        HStack(spacing: gap) {
+            ForEach(chunk) { token in
+                cell(token, rendered: rendered[token.id])
+            }
+        }
+        .padding(.horizontal, isGroup ? 5 : 0)
+        .padding(.vertical, isGroup ? 3 : 0)
+        .background {
+            if isGroup {
+                Capsule(style: .continuous)
+                    .fill(Color.accentColor.opacity(0.12))
+            }
+        }
+        .overlay {
+            if isGroup {
+                Capsule(style: .continuous)
+                    .strokeBorder(Color.accentColor.opacity(0.42), lineWidth: 0.7)
+            }
+        }
+    }
+
+    private func cell(_ token: MenuBarToken, rendered: MenuBarRenderedToken?) -> some View {
+        let isSelected = selection.contains(token.id)
+        let isSilent = availability.silentTokenIds.contains(token.id)
+        let isDegraded = availability.degradedTokenIds.contains(token.id)
+        let isSpace: Bool = { if case .space = token.kind { return true }; return false }()
+        return Group {
+            if let rendered {
+                MenuBarStripTokenView(
+                    token: rendered,
+                    baseFontSize: base,
+                    rowCount: rowCount,
+                    quotas: quotas,
+                    displayMode: displayMode
+                )
+                // A space draws nothing, and nothing cannot be picked up:
+                // the canvas shows it as the width it takes.
+                .background {
+                    if isSpace {
+                        RoundedRectangle(cornerRadius: 2, style: .continuous)
+                            .fill(Color.primary.opacity(0.10))
+                    }
+                }
+            } else {
+                ghost(token)
+            }
+        }
+        .padding(.horizontal, 3)
+        .padding(.vertical, 2)
+        .background(
+            RoundedRectangle(cornerRadius: 4, style: .continuous)
+                .fill(Color.accentColor.opacity(isSelected ? 0.22 : 0))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 4, style: .continuous)
+                .strokeBorder(Color.accentColor.opacity(isSelected ? 0.9 : 0), lineWidth: 1)
+        )
+        .overlay(alignment: .topTrailing) {
+            if isSilent || isDegraded {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 7, weight: .semibold))
+                    .foregroundStyle(isSilent ? Color.orange : Color.secondary)
+                    .offset(x: 4, y: -5)
+            }
+        }
+        .opacity(lifted.contains(token.id) ? 0.28 : 1)
+        .contentShape(Rectangle())
+        .contextMenu { tokenMenu(token) }
+        .help(help(token, rendered: rendered != nil, isSilent: isSilent, isDegraded: isDegraded))
+        .onGeometryChange(for: CGRect.self) { $0.frame(in: .named(MenuBarStageSpace.name)) } action: { frame in
+            frames.report(frame, token: token.id)
+        }
+        .onDisappear { frames.forget(token: token.id) }
+    }
+
+    /// A block the bar is not drawing right now, by name, so it can still be
+    /// picked up, grouped or removed.
+    private func ghost(_ token: MenuBarToken) -> some View {
+        let size = max(9, min(12, base * 0.82))
+        return HStack(spacing: 4) {
+            Image(systemName: MenuBarTokenNaming.symbol(for: token.kind))
+                .font(.system(size: size * 0.85, weight: .semibold))
+            Text(naming.title(token))
+                .font(.system(size: size, weight: .medium))
+                .lineLimit(1)
+        }
+        .foregroundStyle(.tertiary)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .overlay(
+            Capsule(style: .continuous)
+                .strokeBorder(
+                    Color.primary.opacity(0.32),
+                    style: StrokeStyle(lineWidth: 0.7, dash: [3, 2])
+                )
+        )
+    }
+
+    private func help(_ token: MenuBarToken, rendered: Bool, isSilent: Bool, isDegraded: Bool) -> String {
+        if isSilent { return L10n.MenuBar.Composer.Warning.silent }
+        if isDegraded { return L10n.MenuBar.Composer.Warning.degraded }
+        if !rendered {
+            if case let .text(text) = token.kind,
+               text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return L10n.MenuBar.Composer.Text.empty
+            }
+            return L10n.MenuBar.Composer.Canvas.hiddenByRule
+        }
+        return naming.title(token)
+    }
+}
+
+// MARK: - The run in flight
+
+/// The picture carried under the pointer: the blocks being moved, drawn the
+/// way the canvas draws them, lifted off the strip with a shadow.
+struct MenuBarStageRunGhost: View {
+    let tokens: [MenuBarToken]
+    let rendered: [UUID: MenuBarRenderedToken]
+    let template: MenuBarComposition.Template
+    let plan: MenuBarRenderPlan
+    let quotas: [MenuBarQuotaSnapshot]
+    let displayMode: DisplayMode
+    let scheme: ColorScheme
+    let zoom: CGFloat
+    let naming: MenuBarTokenNaming
+
+    private var rowCount: Int { plan.isTwoRow || template == .twoColumn ? 2 : 1 }
+
+    private var base: CGFloat {
+        let face = MenuBarStripMetrics.baseFontSize(template: template, rowCount: rowCount)
+        let fit = MenuBarStripMetrics.estimatedFitScale(plan: plan, baseFontSize: face)
+        return face * fit * zoom
+    }
+
+    var body: some View {
+        let gap = base * plan.tokenSpacing * 0.28
+        let isGroup = tokens.count > 1
+        HStack(spacing: gap) {
+            ForEach(tokens) { token in
+                Group {
+                    if let drawn = rendered[token.id] {
+                        MenuBarStripTokenView(
+                            token: drawn,
+                            baseFontSize: base,
+                            rowCount: rowCount,
+                            quotas: quotas,
+                            displayMode: displayMode
+                        )
+                    } else {
+                        Text(naming.title(token))
+                            .font(.system(size: max(9, min(12, base * 0.82)), weight: .medium))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+                .padding(.horizontal, 3)
+                .padding(.vertical, 2)
+            }
+        }
+        .padding(.horizontal, isGroup ? 5 : 2)
+        .padding(.vertical, isGroup ? 3 : 1)
+        .background(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(scheme == .dark ? Color.black.opacity(0.86) : Color.white.opacity(0.96))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .strokeBorder(Color.accentColor.opacity(isGroup ? 0.6 : 0.35), lineWidth: 0.8)
+        )
+        .shadow(color: .black.opacity(0.32), radius: 12, y: 6)
+        .environment(\.colorScheme, scheme)
+        .allowsHitTesting(false)
+    }
+}
+
+// MARK: - Palette drops
+
+/// A block dragged out of the palette, landing wherever the pointer is over
+/// the canvas. `stage` is asked on every movement with the pointer in canvas
+/// coordinates and decides what, if anything, changes; the delegate decides
+/// nothing about *where*.
+struct MenuBarStageDropDelegate: DropDelegate {
+    let stage: (CGPoint) -> Void
+    let entered: () -> Void
+    let exited: () -> Void
+    let commit: () -> Void
+
+    func dropEntered(info: DropInfo) {
+        entered()
+        stage(info.location)
+    }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        stage(info.location)
+        return DropProposal(operation: .move)
+    }
+
+    func dropExited(info: DropInfo) { exited() }
+
+    func performDrop(info: DropInfo) -> Bool {
+        commit()
+        return true
+    }
+}

--- a/Sources/VibeBarApp/Views/MenuBarStripView.swift
+++ b/Sources/VibeBarApp/Views/MenuBarStripView.swift
@@ -496,8 +496,36 @@ struct MenuBarStripView: View {
     /// that the preview and the bar agree at a glance.
     private static let spacingToPoints: CGFloat = 0.28
 
-    @ViewBuilder
     private func tokenView(_ token: MenuBarRenderedToken) -> some View {
+        MenuBarStripTokenView(
+            token: token,
+            baseFontSize: baseFontSize,
+            rowCount: drawnRowCount,
+            quotas: quotas,
+            displayMode: displayMode
+        )
+        .padding(.horizontal, highlighted == token.id ? 2 : 0)
+        .background {
+            if highlighted == token.id {
+                RoundedRectangle(cornerRadius: 3, style: .continuous)
+                    .fill(Color.accentColor.opacity(0.28))
+            }
+        }
+    }
+}
+
+/// One rendered block, drawn the way the strip draws it: the composer's live
+/// canvas lays these out itself, so it needs the block on its own.
+struct MenuBarStripTokenView: View {
+    let token: MenuBarRenderedToken
+    /// The face the strip is being drawn at.
+    let baseFontSize: CGFloat
+    /// Rows the strip draws — the glyph box depends on it.
+    let rowCount: Int
+    let quotas: [MenuBarQuotaSnapshot]
+    let displayMode: DisplayMode
+
+    var body: some View {
         let size = max(4, baseFontSize * token.fontScale)
         let paint = MenuBarStripPalette.paint(
             for: token.color,
@@ -512,27 +540,20 @@ struct MenuBarStripView: View {
                     // preview-only cap.
                     side: MenuBarStripMetrics.glyphSide(
                         fontSize: size,
-                        rowCount: drawnRowCount
+                        rowCount: rowCount
                     ),
                     paint: paint
                 )
             } else if let text = token.text {
                 Text(text)
-                    .font(font(for: token, size: size))
+                    .font(font(size: size))
                     .foregroundStyle(MenuBarStripPalette.color(paint))
                     .fixedSize()
             }
         }
-        .padding(.horizontal, highlighted == token.id ? 2 : 0)
-        .background {
-            if highlighted == token.id {
-                RoundedRectangle(cornerRadius: 3, style: .continuous)
-                    .fill(Color.accentColor.opacity(0.28))
-            }
-        }
     }
 
-    private func font(for token: MenuBarRenderedToken, size: CGFloat) -> Font {
+    private func font(size: CGFloat) -> Font {
         let weight: Font.Weight
         switch token.weight {
         case .regular: weight = .regular

--- a/Sources/VibeBarCore/Utilities/DemoMode.swift
+++ b/Sources/VibeBarCore/Utilities/DemoMode.swift
@@ -43,6 +43,10 @@ public enum DemoMode {
         case settings(section: String)
         /// The first-run setup assistant, opened on the named step.
         case onboarding(step: String)
+        /// The Layout Studio, opened on a popover page (`overview`, `openAI`,
+        /// …), the first mini window (`mini`) or the menu bar strip
+        /// (`menuBar`).
+        case studio(subject: String)
 
         /// `kind:identifier`. An unknown kind is `nil`; an empty identifier
         /// is allowed and means "the surface's default".
@@ -55,6 +59,7 @@ public enum DemoMode {
                 case "workbench": self = .workbench(page: "")
                 case "settings": self = .settings(section: "")
                 case "onboarding": self = .onboarding(step: "")
+                case "studio": self = .studio(subject: "")
                 default: return nil
                 }
                 return
@@ -67,6 +72,7 @@ public enum DemoMode {
             case "workbench": self = .workbench(page: identifier)
             case "settings": self = .settings(section: identifier)
             case "onboarding": self = .onboarding(step: identifier)
+            case "studio": self = .studio(subject: identifier)
             default: return nil
             }
         }

--- a/Tests/VibeBarCoreTests/DemoModeTests.swift
+++ b/Tests/VibeBarCoreTests/DemoModeTests.swift
@@ -139,6 +139,8 @@ final class DemoModeTests: XCTestCase {
         XCTAssertEqual(DemoMode.Surface(parsing: "settings:layout"), .settings(section: "layout"))
         XCTAssertEqual(DemoMode.Surface(parsing: "onboarding"), .onboarding(step: ""))
         XCTAssertEqual(DemoMode.Surface(parsing: "onboarding:subscriptions"), .onboarding(step: "subscriptions"))
+        XCTAssertEqual(DemoMode.Surface(parsing: "studio"), .studio(subject: ""))
+        XCTAssertEqual(DemoMode.Surface(parsing: "studio:menuBar"), .studio(subject: "menuBar"))
         XCTAssertNil(DemoMode.Surface(parsing: "window:main"))
         XCTAssertNil(DemoMode.Surface(parsing: ""))
     }


### PR DESCRIPTION
## What

The Layout Studio gets a third kind of subject: **the menu bar strip**. Settings keeps the composer exactly as it was; the Studio is where the strip is arranged directly.

- **The stage is the strip, drawn large.** `MenuBarStripStage` lays the composition out in its segments and rows at 2.5× the bar (times the Studio's zoom), every block drawn the way the bar draws it — and a block the bar is *not* drawing right now (a quota that is silent, a rule that is not met) as a ghost that says its name, so it can still be picked up, grouped or removed. Blocks bound together are drawn inside one capsule.
- **Pick a block up and it moves**, its whole group with it, the rest making room live (the same midpoint rule the Studio uses for cards); drop it on the well under the strip to remove it; Escape puts it back. Nothing is written until the drop.
- **Click selects, ⇧-click extends**, and the composer in the inspector edits the block picked on the stage (and the other way round) — `MenuBarComposerEditor` gains an optional `externalSelection` binding for that. Right-click a block for Group / Ungroup / Start a segment here / Duplicate / Remove; each segment box has its own ⋯ menu (move, merge, second row, remove). Keys on the stage: ⌘G groups, ⇧⌘G ungroups, ⌘D duplicates, Delete removes, Escape clears.
- **Light and dark** menu bars, as a pill in the Studio's top bar: a fixed colour can read on one and vanish on the other.
- Undo covers the strip like it covers pages and mini windows; the subject menu gets a "Menu Bar" section; a strip still on the Default layout shows a notice pointing at the Strip switch in the inspector.
- The segment presets were called "saved groups" — the word the composer uses for blocks bound together. They are saved segments now (catalogue 0.5.0, also carrying the stage's strings; ⌘-key hints live under `platform.macos`).
- Demo mode learns `VIBEBAR_DEMO_SURFACE=studio:<page|mini|menuBar>` so a Studio subject can be opened directly for captures.

## Verification

- `swift build`, `swift test`, `./Scripts/build_app.sh release`, entitlements empty; `lint_localization.py` clean (two new files registered).
- Demo (`studio:menuBar`, driven in the packaged build): the subject opens centred on its ground with the well below; click selects; dragging "Spark" to the front reflows live under the carried picture and commits on release; shift-click two adjacent blocks, right-click → Group draws the capsule; dragging the group carries both and lands them after 88%; dragging it onto the well removes it; Undo brings it back; the inspector opens with the composer's chips showing the same selection. Zoom in and out re-lays the strip cleanly (the glyphs mis-placed after a scale change until the stage stopped animating on `scale`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
