### PR TITLE
Bump the build number to 72 for a Dev release

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -26,7 +26,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.6.2</string>
 	<key>CFBundleVersion</key>
-	<string>71</string>
+	<string>72</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
CFBundleVersion 71 → 72 for `v1.6.2-dev.72`, which carries the popover density in Layout / the Studio / the menu (#344), the Layout Studio's menu bar subject (#345, #346) and the palette-to-stage drop that follows. Merge last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)