### PR TITLE
Drop a palette block onto the Studio's strip

### DIFF
--- a/Sources/VibeBarApp/Views/LayoutStudioView.swift
+++ b/Sources/VibeBarApp/Views/LayoutStudioView.swift
@@ -59,6 +59,9 @@ struct LayoutStudioView: View {
     /// Whether the strip has a block in hand — what decides who answers
     /// Escape.
     @State private var stripIsDragging = false
+    /// The block the inspector's palette has in flight, shared with the
+    /// stage so it can be dropped there.
+    @State private var stripPendingBlock: PendingPaletteBlock?
     @State private var hintGeneration = 0
     /// The merged field catalog, rebuilt when the registry changes rather
     /// than per render — the same reason Settings caches it.
@@ -205,6 +208,7 @@ struct LayoutStudioView: View {
                 MenuBarStageView(
                     kind: kind,
                     selection: $stripSelection,
+                    pendingBlock: $stripPendingBlock,
                     scheme: stripScheme ?? scheme,
                     scale: scale,
                     onNaturalSize: { naturalSize = $0 },
@@ -1612,7 +1616,12 @@ struct LayoutStudioView: View {
             }
             .pickerStyle(.segmented)
             if item.usesComposedStrip {
-                MenuBarComposerEditor(kind: kind, density: density, externalSelection: $stripSelection)
+                MenuBarComposerEditor(
+                    kind: kind,
+                    density: density,
+                    externalSelection: $stripSelection,
+                    externalPendingBlock: $stripPendingBlock
+                )
             } else {
                 Text(L10n.MenuBar.Composer.Mode.defaultCaption)
                     .font(.caption2)

--- a/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
+++ b/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
@@ -22,6 +22,10 @@ struct MenuBarComposerEditor: View {
     /// way round. Kept in step with the editor's own selection rather than
     /// replacing it, so the editor in Settings needs no owner.
     var externalSelection: Binding<Set<UUID>>? = nil
+    /// The block in flight from the palette, when this editor is the
+    /// Studio's inspector: the stage beside it is a drop target too, and it
+    /// needs to know what is being carried. Kept in step the same way.
+    var externalPendingBlock: Binding<PendingPaletteBlock?>? = nil
 
     @EnvironmentObject private var environment: AppEnvironment
     @EnvironmentObject private var settingsStore: SettingsStore
@@ -212,6 +216,14 @@ struct MenuBarComposerEditor: View {
         }
         .onChange(of: externalSelection?.wrappedValue) { _, new in
             if let new, new != selection { selection = new }
+        }
+        .onChange(of: draggedNewToken) { _, new in
+            if let external = externalPendingBlock, external.wrappedValue != new {
+                external.wrappedValue = new
+            }
+        }
+        .onChange(of: externalPendingBlock?.wrappedValue) { _, new in
+            if let new, new != draggedNewToken { draggedNewToken = new }
         }
         .onAppear {
             if let external = externalSelection?.wrappedValue { selection = external }
@@ -1918,7 +1930,7 @@ private struct DebouncedPercentStepper: View {
 ///
 /// See `MenuBarComposerEditor.draggedNewToken` for why the deadline is here
 /// rather than a payload type.
-struct PendingPaletteBlock {
+struct PendingPaletteBlock: Equatable {
     let token: MenuBarToken
     var startedAt: Date = .now
 

--- a/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
+++ b/Sources/VibeBarApp/Views/MenuBarComposerEditor.swift
@@ -223,7 +223,12 @@ struct MenuBarComposerEditor: View {
             }
         }
         .onChange(of: externalPendingBlock?.wrappedValue) { _, new in
-            if let new, new != draggedNewToken { draggedNewToken = new }
+            // Chaining flattens the binding's optional, so `nil` here can
+            // mean "no binding" or "the stage cleared it". Only the second
+            // is an update — and it must land, or the block the stage just
+            // placed would stay in flight here for its whole deadline.
+            guard externalPendingBlock != nil, new != draggedNewToken else { return }
+            draggedNewToken = new
         }
         .onAppear {
             if let external = externalSelection?.wrappedValue { selection = external }

--- a/Sources/VibeBarApp/Views/MenuBarStageView.swift
+++ b/Sources/VibeBarApp/Views/MenuBarStageView.swift
@@ -17,6 +17,9 @@ import VibeBarCore
 struct MenuBarStageView: View {
     let kind: MenuBarItemKind
     @Binding var selection: Set<UUID>
+    /// The block the inspector's palette has in flight, if any: the stage
+    /// stages it where the pointer is and commits it on the drop.
+    @Binding var pendingBlock: PendingPaletteBlock?
     /// The menu bar the strip is previewed on.
     let scheme: ColorScheme
     /// The Studio's scale. The strip is drawn at `baseZoom` times it, so
@@ -55,6 +58,13 @@ struct MenuBarStageView: View {
     /// not settings: writing every crossing through `settingsStore` would
     /// re-render the menu bar mid-gesture.
     @State private var dragComposition: MenuBarComposition?
+    /// A palette block is staged in `dragComposition`: it is drawn there
+    /// until the drop lands or the pointer stays away long enough.
+    @State private var isPaletteDragActive = false
+    /// Fires shortly after a palette drag leaves the stage. There is no
+    /// "drag cancelled" callback, so a release elsewhere is inferred from
+    /// the pointer leaving and not coming back.
+    @State private var paletteCancelTask: Task<Void, Never>?
     /// The stage's frame in the shared space, to place the picture carried
     /// under the pointer.
     @State private var stageFrame: CGRect = .zero
@@ -88,8 +98,19 @@ struct MenuBarStageView: View {
     /// What the stage draws: the provisional order while a drag is in
     /// flight, the committed one otherwise.
     private var displayedComposition: MenuBarComposition {
-        guard drag?.engaged == true, let dragComposition else { return composition }
+        guard drag?.engaged == true || isPaletteDragActive, let dragComposition else { return composition }
         return dragComposition
+    }
+
+    /// What the snapshots are resolved from: the committed order, plus the
+    /// block still in flight from the palette — its quota needs a snapshot
+    /// before it has a place, or it draws nothing the moment it lands.
+    private var resolvableComposition: MenuBarComposition {
+        var order = composition
+        if let pending = pendingBlock, order.location(of: pending.token.id) == nil {
+            order.append(pending.token, to: nil)
+        }
+        return order
     }
 
     /// Everything the cached snapshots are derived from — see the composer's
@@ -144,6 +165,7 @@ struct MenuBarStageView: View {
         .fixedSize(horizontal: true, vertical: false)
         .coordinateSpace(.named(MenuBarStageSpace.name))
         .onChange(of: drag?.engaged == true) { _, isDragging in onDragChange?(isDragging) }
+        .onChange(of: pendingBlock) { _, _ in rebuild() }
         .onAppear {
             inputs.start(environment: environment)
             rebuild()
@@ -172,7 +194,7 @@ struct MenuBarStageView: View {
         let merged = MenuBarFieldCatalog.mergedFields(registry: quotaService.fieldRegistry)
         optionsById = Dictionary(merged.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
         snapshots = MenuBarStripResolver.snapshots(
-            for: composition,
+            for: resolvableComposition,
             itemSettings: item,
             settings: settingsStore.settings,
             environment: environment
@@ -230,6 +252,15 @@ struct MenuBarStageView: View {
         }
         .contentShape(Rectangle())
         .gesture(dragGesture)
+        .onDrop(
+            of: [.text],
+            delegate: MenuBarStageDropDelegate(
+                stage: { stagePalette(at: $0) },
+                entered: { paletteEntered() },
+                exited: { paletteExited() },
+                commit: { commitPalette() }
+            )
+        )
         .overlay(alignment: .topLeading) {
             if let drag, drag.engaged, !drag.run.isEmpty {
                 ghost(drag, composition: composition, plan: plan)
@@ -471,6 +502,81 @@ struct MenuBarStageView: View {
         default:
             return .ignored
         }
+    }
+
+    // MARK: - Palette drops
+
+    /// A block from the palette, staged where the pointer is. Nothing is
+    /// inserted until the drag reaches the stage, and a drag that leaves it
+    /// long enough rolls back, so a release over nothing adds nothing.
+    private func stagePalette(at local: CGPoint) {
+        guard drag == nil, let pending = pendingBlock, pending.isLive else { return }
+        let new = pending.token
+        let point = CGPoint(x: local.x + stageFrame.minX, y: local.y + stageFrame.minY)
+        let target = frames.target(
+            at: point,
+            in: displayedComposition,
+            moving: [new.id],
+            reach: Self.reach
+        )
+        var next = composition
+        switch target {
+        case let .before(id)?:
+            guard let at = next.location(of: id) else { return }
+            // Into the target's own row first, so the move that follows is
+            // a same-row reorder and cannot leave an empty segment behind
+            // the way appending to a new one would.
+            next.append(new, to: MenuBarComposition.RowAddress(
+                segment: next.segments[at.segment].id,
+                row: at.row
+            ))
+            next.move(new.id, before: id)
+        case let .endOf(address)?:
+            next.append(new, to: address)
+        case .removed?, nil:
+            // Over the ground rather than a row: the end of the strip, in
+            // the order it is read — not a segment of its own, which the
+            // pointer wandering over the margin would keep opening.
+            next.append(new)
+        }
+        isPaletteDragActive = true
+        if next != dragComposition {
+            withAnimation(Self.reflow) { dragComposition = next }
+        }
+    }
+
+    private func paletteEntered() {
+        paletteCancelTask?.cancel()
+        paletteCancelTask = nil
+    }
+
+    private func paletteExited() {
+        paletteCancelTask?.cancel()
+        paletteCancelTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(200))
+            guard !Task.isCancelled else { return }
+            withAnimation(Self.reflow) {
+                isPaletteDragActive = false
+                dragComposition = nil
+            }
+            paletteCancelTask = nil
+        }
+    }
+
+    /// The one settings write a palette drop performs; the new block is the
+    /// selection afterwards, so the inspector opens on it.
+    private func commitPalette() {
+        paletteCancelTask?.cancel()
+        paletteCancelTask = nil
+        let staged = isPaletteDragActive ? dragComposition : nil
+        let newID = pendingBlock?.token.id
+        isPaletteDragActive = false
+        dragComposition = nil
+        pendingBlock = nil
+        guard let staged, staged != composition else { return }
+        let segments = staged.segments
+        mutate { $0.segments = segments }
+        if let newID { selection = [newID] }
     }
 
     // MARK: - Edits

--- a/Sources/VibeBarApp/Views/MenuBarStripStage.swift
+++ b/Sources/VibeBarApp/Views/MenuBarStripStage.swift
@@ -498,3 +498,33 @@ struct MenuBarStageRunGhost: View {
         .allowsHitTesting(false)
     }
 }
+
+// MARK: - Palette drops
+
+/// A block dragged out of the inspector's palette, landing wherever the
+/// pointer is over the stage. `stage` is asked on every movement with the
+/// pointer in the stage's coordinates and decides what, if anything,
+/// changes; the delegate decides nothing about *where*.
+struct MenuBarStageDropDelegate: DropDelegate {
+    let stage: (CGPoint) -> Void
+    let entered: () -> Void
+    let exited: () -> Void
+    let commit: () -> Void
+
+    func dropEntered(info: DropInfo) {
+        entered()
+        stage(info.location)
+    }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        stage(info.location)
+        return DropProposal(operation: .move)
+    }
+
+    func dropExited(info: DropInfo) { exited() }
+
+    func performDrop(info: DropInfo) -> Bool {
+        commit()
+        return true
+    }
+}


### PR DESCRIPTION
## What

The composer's palette could only add a block by click; a block dragged out of it had nowhere to land on the Studio's stage.

- `MenuBarComposerEditor` gains `externalPendingBlock`, kept in step with its `draggedNewToken` the way `externalSelection` is with its selection, so the Studio knows what the palette has in flight.
- `MenuBarStageView` takes that block as a binding and accepts it as a drop (`MenuBarStageDropDelegate`, back and attached this time): on every crossing it stages the block where the pointer is — in front of a block, at the end of a row, or at the end of the strip when over the ground — in the same provisional order the stage's own drags use; a pointer that stays away for 200 ms rolls it back; the drop commits once and selects the new block, so the inspector opens on it. The staged block's quota is resolved before it has a place, so it draws the moment it lands.

## Verification

- `swift build`, `swift test`, `./Scripts/build_app.sh release`, entitlements empty; `lint_localization.py` clean.
- Not driven live: the inspector toggle would not take synthetic clicks in this session's demo runs. The delegate is the composer's proven pattern and the landing rule is the one the stage's own drags were driven with in #345.

🤖 Generated with [Claude Code](https://claude.com/claude-code)