### PR TITLE
Draw a page whole on the stage, at actual size to begin with

### DIFF
--- a/Sources/VibeBarApp/Controllers/LayoutStudioWindowController.swift
+++ b/Sources/VibeBarApp/Controllers/LayoutStudioWindowController.swift
@@ -209,7 +209,10 @@ final class LayoutStudioModel: ObservableObject {
     }
 
     @Published var subject: LayoutStudioWindowController.Subject = .popoverPage(.overview)
-    @Published var zoom: Zoom = .fit
+    /// Actual size to begin with: the surface on the stage is the real one,
+    /// and it should look like it. A page taller than the window scrolls;
+    /// Fit (⌘0) is a step away for the overview of it.
+    @Published var zoom: Zoom = .scale(1)
     @Published var isInspectorShown = false
     /// What the last edits replaced, newest last. Per studio session: closing
     /// the window forgets it, which is also what makes each entry cheap.

--- a/Sources/VibeBarApp/Views/LayoutStudioView.swift
+++ b/Sources/VibeBarApp/Views/LayoutStudioView.swift
@@ -108,6 +108,10 @@ struct LayoutStudioView: View {
             hovered = nil
             drag = nil
             settling = nil
+            // A page is drawn whole now, so the stage may be scrolled deep
+            // into one when the subject changes; the next surface starts
+            // at its top, not partway down where the last one was left.
+            scrollPosition.scrollTo(x: 0, y: 0)
             showHint()
         }
         // Every write to the subject's saved state — a drop on the stage, a

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -6,6 +6,7 @@ import VibeBarCore
 struct PopoverRoot: View {
     let width: CGFloat
     let onContentHeightChange: (CGFloat) -> Void
+    @Environment(\.surfaceItemFrames) private var surfaceItemFrames
     let onToggleMiniWindow: () -> Void
     /// The tab the popover opens on. Production always starts on Overview;
     /// demo mode builds one popover per captured page.
@@ -43,18 +44,29 @@ struct PopoverRoot: View {
             Divider()
                 .opacity(0.3)
                 .padding(.bottom, shellDensity.interSectionSpacing)
-            ScrollView(.vertical, showsIndicators: false) {
+            if isOnStage {
+                // On the Studio's stage the page is a surface to be arranged,
+                // not a popover to be scrolled: it cannot be scrolled there
+                // (the stage owns the pointer), so a page taller than the
+                // popover's ceiling was simply cut off, cards and all. Drawn
+                // whole instead; the Studio's Fit and zoom do the rest.
                 content(density: contentDensity)
-                    // A vertical ScrollView does not always pass a finite
-                    // horizontal proposal through to intrinsically wide
-                    // HStacks. Provider detail pages then grow to the sum of
-                    // both columns' ideal widths and their right edge escapes
-                    // the shared popover shell. Give every tab the exact same
-                    // viewport width so only its height remains scrollable.
                     .frame(width: shellContentWidth, alignment: .topLeading)
                     .padding(.bottom, 4)
+            } else {
+                ScrollView(.vertical, showsIndicators: false) {
+                    content(density: contentDensity)
+                        // A vertical ScrollView does not always pass a finite
+                        // horizontal proposal through to intrinsically wide
+                        // HStacks. Provider detail pages then grow to the sum of
+                        // both columns' ideal widths and their right edge escapes
+                        // the shared popover shell. Give every tab the exact same
+                        // viewport width so only its height remains scrollable.
+                        .frame(width: shellContentWidth, alignment: .topLeading)
+                        .padding(.bottom, 4)
+                }
+                .frame(maxHeight: maxScrollHeight)
             }
-            .frame(maxHeight: maxScrollHeight)
         }
         // Provider pages have a narrower intrinsic HStack than Overview and
         // Misc. Pin the shared shell's inner width before adding padding so
@@ -116,6 +128,10 @@ struct PopoverRoot: View {
         let visible = NSScreen.vibeBarPresentationScreen?.visibleFrame.height ?? 900
         return max(360, visible - 150)
     }
+
+    /// Whether this page is the Studio's surface: the Studio hands every
+    /// surface it arranges the frames it reports into, and nothing else does.
+    private var isOnStage: Bool { surfaceItemFrames != nil }
 
     @ViewBuilder
     private func content(density: Theme.Density) -> some View {


### PR DESCRIPTION
AQ's screenshot: the Overview's last card on the left column cut in half on the stage, its hover frame reaching below the surface.

- `PopoverRoot` capped its content in a `ScrollView` at the screen height minus 150 — right for the popover, wrong on the stage, which cannot scroll the page and so simply cut it off. When the page is the Studio's surface (it is handed `surfaceItemFrames`, nothing else is), the content is drawn whole; the stage scrolls.
- The Studio opens at 100% instead of Fit: the surface is the real one and should look like it. Fit (⌘0) stays for the overview.

`swift build`, `swift test`, `lint_localization.py` clean; packaged and checked in demo mode (`studio:overview`): the whole page down to the heatmaps is drawn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)