### PR TITLE
Make the Studio's chrome take clicks, and the strip's drags run smooth

### DIFF
--- a/Sources/VibeBarApp/Views/LayoutStudioView.swift
+++ b/Sources/VibeBarApp/Views/LayoutStudioView.swift
@@ -1272,10 +1272,10 @@ struct LayoutStudioView: View {
         .menuStyle(.borderlessButton)
         .menuIndicator(.hidden)
         .fixedSize()
+        .help(L10n.Platform.Macos.MenuBar.displayDensity)
         .foregroundStyle(.primary)
         .padding(3)
         .glassEffect(.regular, in: .capsule)
-        .help(L10n.Platform.Macos.MenuBar.displayDensity)
     }
 
     private var zoomPill: some View {
@@ -1308,17 +1308,22 @@ struct LayoutStudioView: View {
         .glassEffect(.regular, in: .capsule)
     }
 
+    /// The glass is on a container around the button, as the zoom pill does
+    /// it — applied to the button itself it sat above the button in hit
+    /// testing, and the undo and inspector controls stopped taking clicks.
     private func glassIconButton(systemImage: String, help: String, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            Image(systemName: systemImage)
-                .font(.system(size: 12, weight: .semibold))
-                .frame(width: 30, height: 30)
-                .contentShape(Circle())
+        HStack(spacing: 0) {
+            Button(action: action) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 12, weight: .semibold))
+                    .frame(width: 30, height: 30)
+                    .contentShape(Circle())
+            }
+            .buttonStyle(.vibeBar(cornerRadius: 15))
+            .help(help)
         }
-        .buttonStyle(.vibeBar(cornerRadius: 15))
         .foregroundStyle(.primary)
         .glassEffect(.regular, in: .circle)
-        .help(help)
     }
 
     /// One choice in a glass pill. The selection is a single shape that

--- a/Sources/VibeBarApp/Views/MenuBarStageView.swift
+++ b/Sources/VibeBarApp/Views/MenuBarStageView.swift
@@ -51,6 +51,10 @@ struct MenuBarStageView: View {
 
     @State private var frames = MenuBarStageFrames()
     @State private var drag: StageDrag?
+    /// The pointer while a drag is in flight. Its own object so the picture
+    /// under the pointer is the only view that redraws per mouse move — the
+    /// strip itself redraws only when the slot changes.
+    @StateObject private var pointer = MenuBarStagePointer()
     /// Set by Escape mid-drag: the gesture keeps reporting until the button
     /// is released, and every report after the cancel must be ignored.
     @State private var isDragCancelled = false
@@ -88,6 +92,9 @@ struct MenuBarStageView: View {
         /// does not jump to centre itself on the cursor.
         var grabOffset: CGSize = .zero
         var target: MenuBarStageTarget?
+        /// The strip's frames with the run lifted out, taken once when the
+        /// drag engaged — what every slot decision is judged against.
+        var collapsedFrames: [UUID: CGRect] = [:]
     }
 
     private var zoom: CGFloat { Self.baseZoom * scale }
@@ -251,7 +258,9 @@ struct MenuBarStageView: View {
             onNaturalSize?(CGSize(width: frame.width / scale, height: frame.height / scale))
         }
         .contentShape(Rectangle())
-        .gesture(dragGesture)
+        // High priority: the stage sits in the Studio's scrolling stage, and
+        // a drag along the strip must not be read as a pan.
+        .highPriorityGesture(dragGesture)
         .onDrop(
             of: [.text],
             delegate: MenuBarStageDropDelegate(
@@ -263,7 +272,12 @@ struct MenuBarStageView: View {
         )
         .overlay(alignment: .topLeading) {
             if let drag, drag.engaged, !drag.run.isEmpty {
-                ghost(drag, composition: composition, plan: plan)
+                MenuBarStageGhostLayer(
+                    pointer: pointer,
+                    grabOffset: drag.grabOffset,
+                    stageOrigin: stageFrame.origin,
+                    ghost: ghost(drag, composition: composition, plan: plan)
+                )
             }
         }
         .focusable()
@@ -279,7 +293,7 @@ struct MenuBarStageView: View {
         _ drag: StageDrag,
         composition: MenuBarComposition,
         plan: MenuBarRenderPlan
-    ) -> some View {
+    ) -> MenuBarStageRunGhost {
         let tokens = drag.run.compactMap { composition.token($0) }
         var rendered: [UUID: MenuBarRenderedToken] = [:]
         for column in plan.columns {
@@ -296,11 +310,6 @@ struct MenuBarStageView: View {
             scheme: scheme,
             zoom: zoom,
             naming: naming
-        )
-        .scaleEffect(1.04)
-        .offset(
-            x: drag.location.x - drag.grabOffset.width - stageFrame.minX,
-            y: drag.location.y - drag.grabOffset.height - stageFrame.minY
         )
     }
 
@@ -369,31 +378,27 @@ struct MenuBarStageView: View {
 
     private func advance(to location: CGPoint) {
         guard var current = drag else { return }
-        current.location = location
+        pointer.location = location
         if !current.engaged {
             let fromStart = hypot(location.x - current.start.x, location.y - current.start.y)
-            guard let anchor = current.anchor, fromStart >= Self.dragThreshold else {
-                drag = current
-                return
-            }
-            _ = anchor
+            guard current.anchor != nil, fromStart >= Self.dragThreshold else { return }
             current.engaged = true
+            current.location = location
             let box = current.run
                 .compactMap { frames.tokens[$0] }
                 .reduce(CGRect.null) { $0.union($1) }
             if !box.isNull {
                 current.grabOffset = CGSize(width: current.start.x - box.minX, height: current.start.y - box.minY)
             }
+            current.collapsedFrames = frames.framesCollapsing(current.run, in: composition)
             isFocused = true
             // Snapshot the committed order; every crossing rearranges this
             // copy, and only the drop writes.
             dragComposition = composition
             NSCursor.closedHand.set()
-        }
-        guard let anchor = current.anchor else {
             drag = current
-            return
         }
+        guard let anchor = current.anchor else { return }
         let target: MenuBarStageTarget?
         if frames.well.contains(location) {
             target = .removed
@@ -402,26 +407,29 @@ struct MenuBarStageView: View {
                 at: location,
                 in: dragComposition ?? composition,
                 moving: Set(current.run),
-                reach: Self.reach
+                reach: Self.reach,
+                tokenFrames: current.collapsedFrames
             ) ?? current.target
         }
-        if let target, target != current.target {
-            current.target = target
-            // From the committed order every time, so a drag that crosses
-            // the strip twice ends where the pointer is, not where the
-            // crossings accumulated to.
-            var next = composition
-            switch target {
-            case let .before(id):
-                next.move(anchor, before: id)
-            case let .endOf(address):
-                next.move(anchor, toEndOf: address)
-            case .removed:
-                for id in current.run { next.remove(id) }
-            }
-            if next != dragComposition {
-                withAnimation(Self.reflow) { dragComposition = next }
-            }
+        // The strip is touched only when the slot changes: the pointer's
+        // every move goes to the picture alone.
+        guard let target, target != current.target else { return }
+        current.target = target
+        current.location = location
+        // From the committed order every time, so a drag that crosses the
+        // strip twice ends where the pointer is, not where the crossings
+        // accumulated to.
+        var next = composition
+        switch target {
+        case let .before(id):
+            next.move(anchor, before: id)
+        case let .endOf(address):
+            next.move(anchor, toEndOf: address)
+        case .removed:
+            for id in current.run { next.remove(id) }
+        }
+        if next != dragComposition {
+            withAnimation(Self.reflow) { dragComposition = next }
         }
         drag = current
     }
@@ -694,5 +702,29 @@ struct MenuBarStageView: View {
         .menuStyle(.borderlessButton)
         .menuIndicator(.hidden)
         .fixedSize()
+    }
+}
+
+/// The pointer, published on its own — see `MenuBarStageView.pointer`.
+@MainActor
+final class MenuBarStagePointer: ObservableObject {
+    @Published var location: CGPoint = .zero
+}
+
+/// The picture under the pointer, placed by the pointer alone: this is the
+/// one view that redraws per mouse move.
+private struct MenuBarStageGhostLayer: View {
+    @ObservedObject var pointer: MenuBarStagePointer
+    let grabOffset: CGSize
+    let stageOrigin: CGPoint
+    let ghost: MenuBarStageRunGhost
+
+    var body: some View {
+        ghost
+            .scaleEffect(1.04)
+            .offset(
+                x: pointer.location.x - grabOffset.width - stageOrigin.x,
+                y: pointer.location.y - grabOffset.height - stageOrigin.y
+            )
     }
 }

--- a/Sources/VibeBarApp/Views/MenuBarStripStage.swift
+++ b/Sources/VibeBarApp/Views/MenuBarStripStage.swift
@@ -64,20 +64,55 @@ extension MenuBarStageFrames {
     /// front of the first block whose middle the pointer has not passed, else
     /// at the end of the row. `moving` are the blocks being carried, which
     /// cannot be their own target.
+    ///
+    /// `tokenFrames` are the frames to judge by — the live ones by default.
+    /// A drag passes the frames of the strip *without* the carried run
+    /// instead: the live ones move every time the placeholder is re-slotted,
+    /// so judging by them made the slot flip back and forth under a pointer
+    /// that had not moved.
     func target(
         at point: CGPoint,
         in composition: MenuBarComposition,
         moving: Set<UUID>,
-        reach: CGFloat
+        reach: CGFloat,
+        tokenFrames: [UUID: CGRect]? = nil
     ) -> MenuBarStageTarget? {
         guard let address = row(near: point, reach: reach),
               let segment = composition.segmentIndex(of: address.segment)
         else { return nil }
+        let judged = tokenFrames ?? tokens
         for token in composition.segments[segment][address.row] where !moving.contains(token.id) {
-            guard let frame = tokens[token.id] else { continue }
+            guard let frame = judged[token.id] else { continue }
             if point.x < frame.midX { return .before(token.id) }
         }
         return .endOf(address)
+    }
+
+    /// The strip's frames as they would be with `run` lifted out of its row:
+    /// everything after it in that row slides left by the room it took.
+    /// Rows the run is not in are untouched. Judged against these, a slot
+    /// depends only on where the pointer is.
+    func framesCollapsing(_ run: [UUID], in composition: MenuBarComposition) -> [UUID: CGRect] {
+        var collapsed = tokens
+        guard let first = run.first, let at = composition.location(of: first),
+              let box = run.compactMap({ tokens[$0] }).reduce(nil, { (acc: CGRect?, frame) in
+                  acc.map { $0.union(frame) } ?? frame
+              })
+        else { return collapsed }
+        let row = composition.segments[at.segment][at.row]
+        let moving = Set(run)
+        // The gap the run took with it: from its box to the next block.
+        var vacated = box.width
+        if let next = row.first(where: { !moving.contains($0.id) && (tokens[$0.id]?.minX ?? -1) > box.maxX }),
+           let nextFrame = tokens[next.id] {
+            vacated += max(0, nextFrame.minX - box.maxX)
+        }
+        for token in row where !moving.contains(token.id) {
+            guard var frame = collapsed[token.id], frame.minX > box.maxX else { continue }
+            frame.origin.x -= vacated
+            collapsed[token.id] = frame
+        }
+        return collapsed
     }
 }
 
@@ -356,7 +391,8 @@ struct MenuBarStripStage<TokenMenu: View, SegmentMenu: View>: View {
                     baseFontSize: base,
                     rowCount: rowCount,
                     quotas: quotas,
-                    displayMode: displayMode
+                    displayMode: displayMode,
+                    zoom: zoom
                 )
                 // A space draws nothing, and nothing cannot be picked up:
                 // the canvas shows it as the width it takes.
@@ -470,7 +506,8 @@ struct MenuBarStageRunGhost: View {
                             baseFontSize: base,
                             rowCount: rowCount,
                             quotas: quotas,
-                            displayMode: displayMode
+                            displayMode: displayMode,
+                            zoom: zoom
                         )
                     } else {
                         Text(naming.title(token))

--- a/Sources/VibeBarApp/Views/MenuBarStripView.swift
+++ b/Sources/VibeBarApp/Views/MenuBarStripView.swift
@@ -526,6 +526,10 @@ struct MenuBarStripTokenView: View {
     let rowCount: Int
     let quotas: [MenuBarQuotaSnapshot]
     let displayMode: DisplayMode
+    /// How much larger than the bar this is drawn. The glyph box is capped
+    /// at the bar's own ceiling, so the cap has to scale with the drawing
+    /// or a strip drawn large keeps menu-bar-sized marks beside big text.
+    var zoom: CGFloat = 1
 
     var body: some View {
         let size = max(4, baseFontSize * token.fontScale)
@@ -539,11 +543,11 @@ struct MenuBarStripTokenView: View {
                 MenuBarStripGlyph(
                     glyph: glyph,
                     // Whatever the bar will use for this many rows, not a
-                    // preview-only cap.
+                    // preview-only cap — at the bar's size, then scaled.
                     side: MenuBarStripMetrics.glyphSide(
-                        fontSize: size,
+                        fontSize: size / max(1, zoom),
                         rowCount: rowCount
-                    ),
+                    ) * max(1, zoom),
                     paint: paint
                 )
             } else if let text = token.text {


### PR DESCRIPTION
AQ: the Studio's top bar cannot be clicked; grouped blocks drag oddly; drags feel rough and drop out; the strip on the stage does not look like the menu bar.

- **Clickable chrome.** `glassIconButton` (undo, inspector toggle) applied `.glassEffect` to the `Button` itself, and the glass sat above the button in hit testing. The glass now wraps a container, as the zoom pill does; the density pill follows. Verified in demo mode: the inspector opens on the first click.
- **Smooth strip drags.** The pointer is published on its own object (`MenuBarStagePointer`), so only the carried picture redraws per mouse move; the strip re-renders only when the drop slot changes. The slot is judged against the strip's frames with the carried run lifted out (`MenuBarStageFrames.framesCollapsing`), taken once at engage — the live frames moved every time the placeholder was re-slotted, which is what made the slot flip under a still pointer, worst for groups. The gesture is `highPriorityGesture` so the Studio's scrolling stage cannot take it.
- **Faithful marks.** `MenuBarStripTokenView` takes a `zoom`; the glyph cap (`maximumTwoRowGlyphSide`) scales with it instead of leaving 12 pt marks beside 22 pt text.

`swift build`, `swift test`, `build_app.sh release`, `lint_localization.py` clean. The click fix and the mark scaling were checked live in `studio:menuBar`; the drag rework was not driven in this session (the Mac was in use), it is the Studio's own pointer/slot pattern applied to the strip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)