### PR TITLE
Give Grok Bot its usage and its reset lane, and Claude its scratch tasks

### DIFF
--- a/Sources/VibeBarApp/Controllers/SessionManagerModel.swift
+++ b/Sources/VibeBarApp/Controllers/SessionManagerModel.swift
@@ -899,6 +899,9 @@ final class SessionManagerModel: ObservableObject {
         if summary.provider == .codex, isGeneratedProjectlessPath(summary.projectDir) {
             return .projectless
         }
+        if isClaudeScratchWorkspacePath(summary.projectDir) {
+            return .projectless
+        }
         return projectBucket(summary.projectDir)
     }
 
@@ -919,6 +922,22 @@ final class SessionManagerModel: ObservableObject {
         let date = components[codex + 1].split(separator: "-", omittingEmptySubsequences: false)
         return date.count == 3 && date[0].count == 4 && date[1].count == 2 && date[2].count == 2
             && date.allSatisfy { Int($0) != nil }
+    }
+
+    /// Claude Desktop and Cowork open a projectless task in a scratch
+    /// workspace under the app's own support directory —
+    /// `Claude/scratch-workspaces/<workspace>/<task>/scratch-<date>-<id>` —
+    /// the same idea as Codex's dated scratch cwd. The path is what the
+    /// session records as its cwd, and it is nobody's project.
+    nonisolated static func isClaudeScratchWorkspacePath(_ path: String?) -> Bool {
+        guard let path else { return false }
+        let components = URL(fileURLWithPath: path).standardizedFileURL.pathComponents
+        guard let support = components.firstIndex(of: "Application Support"),
+              components.count > support + 2,
+              components[support + 1] == "Claude",
+              components[support + 2] == "scratch-workspaces"
+        else { return false }
+        return true
     }
 
     /// The loaded page filtered in memory — instant, on every keystroke —

--- a/Sources/VibeBarApp/Views/Workbench/SessionListView.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SessionListView.swift
@@ -293,7 +293,9 @@ private struct SessionRow: View {
             Text(summary.effectiveHarness.displayName)
                 .fontWeight(.medium)
                 .lineLimit(1)
-            if let model = summary.model, !model.isEmpty {
+            // An unlearned AntiGravity model enum says nothing a reader can
+            // use; the row is better off without the chip.
+            if let model = summary.model, !model.isEmpty, !UsageModelNaming.isUnlabelledModelEnum(model) {
                 Text(UsageModelNaming.canonicalDisplayName(model))
                     .lineLimit(1)
                     .padding(.horizontal, 5)

--- a/Sources/VibeBarCore/Adapters/CursorQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/CursorQuotaAdapter.swift
@@ -329,7 +329,6 @@ enum CursorResponseParser {
         if let bot = grokBotUsage,
            let percent = bot.usagePercent,
            bot.hasNonZeroIncludedLimit != false {
-            let periodStart = parseBillingCycleEnd(bot.currentPeriodStart)
             let resetAt = parseBillingCycleEnd(bot.nextResetTimestampUtc)
             buckets.append(QuotaBucket(
                 id: "grok_bot_weekly",
@@ -337,7 +336,12 @@ enum CursorResponseParser {
                 shortLabel: "Grok Bot",
                 usedPercent: clampPercent(percent),
                 resetAt: resetAt,
-                rawWindowSeconds: windowSeconds(start: periodStart, end: resetAt),
+                // A week, by definition of the bucket. `currentPeriodStart`
+                // is not the window's start — it moved with the last refresh,
+                // so the span to the reset came out as three or four days,
+                // and a lane shorter than a week is exactly what the reset
+                // history leaves out. Grok Bot vanished from it as a result.
+                rawWindowSeconds: 604_800,
                 groupTitle: "Grok Bot"
             ))
         }

--- a/Sources/VibeBarCore/Services/CursorCostUsageFetcher.swift
+++ b/Sources/VibeBarCore/Services/CursorCostUsageFetcher.swift
@@ -115,6 +115,13 @@ struct CursorCostUsageFetcher: Sendable {
         ))
     }
 
+    /// Whether a Cursor ledger event is Grok Bot's: by the client type the
+    /// bot reports, or by the model it is named for.
+    static func isGrokBot(clientType: String?, model: String) -> Bool {
+        if clientType?.lowercased() == "grok-bot" { return true }
+        return model.lowercased().hasPrefix("grok-bot")
+    }
+
     func prepareSnapshot(
         cookieHeader: String,
         since: Date?,
@@ -136,11 +143,17 @@ struct CursorCostUsageFetcher: Sendable {
         var latestEventDate: Date?
         for event in events {
             guard let date = event.date,
-                  event.clientType?.lowercased() != "grok-bot",
                   let usage = event.tokenUsage,
                   usage.totalTokens > 0
             else { continue }
             let model = event.model.flatMap { $0.isEmpty ? nil : $0 } ?? "cursor-unknown"
+            // Cursor's account ledger carries Grok Bot's requests too: the
+            // bot reports as its own client type, and its models are named
+            // after it. Those are Grok Bot's usage, not the editor's — the
+            // same split the quota side makes with the Grok Bot bucket.
+            let harness: Harness = Self.isGrokBot(clientType: event.clientType, model: model)
+                ? .grokBot
+                : .cursor
             let costUSD = max(0, (usage.totalCents ?? 0) / 100)
             accumulator.add(
                 at: date,
@@ -167,7 +180,7 @@ struct CursorCostUsageFetcher: Sendable {
                         cache: usage.cacheWriteTokens + usage.cacheReadTokens,
                         cacheCreation: usage.cacheWriteTokens,
                         sourceKey: sourceKey,
-                        harness: .cursor
+                        harness: harness
                     ),
                     costUSD: costUSD
                 ))

--- a/Sources/VibeBarCore/Utilities/UsageModelNaming.swift
+++ b/Sources/VibeBarCore/Utilities/UsageModelNaming.swift
@@ -5,9 +5,20 @@ import Foundation
 /// thinking level separately; AntiGravity labels that level in parentheses,
 /// so Vibe Bar appends it as a stable local variant suffix.
 public enum UsageModelNaming {
+    /// AntiGravity records some turns under an internal model enum —
+    /// `MODEL_PLACEHOLDER_M318` and the like — for which no human label has
+    /// been learned. It is an identifier for the pricing side to key on,
+    /// not a name anyone should read.
+    public static func isUnlabelledModelEnum(_ raw: String) -> Bool {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix("MODEL_"), trimmed.count > 6 else { return false }
+        return trimmed.allSatisfy { $0.isUppercase || $0.isNumber || $0 == "_" }
+    }
+
     public static func canonicalDisplayName(_ raw: String) -> String {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return "Unknown model" }
+        if isUnlabelledModelEnum(trimmed) { return "Unlabelled model" }
         guard trimmed.lowercased().hasPrefix("gemini ") else {
             return trimmed
         }

--- a/Tests/VibeBarCoreTests/CursorCostUsageFetcherTests.swift
+++ b/Tests/VibeBarCoreTests/CursorCostUsageFetcherTests.swift
@@ -32,7 +32,7 @@ final class CursorCostUsageFetcherTests: XCTestCase {
         return prepared.snapshot
     }
 
-    func testBuildsSnapshotFromCursorEventsAndExcludesGrokBotRows() async throws {
+    func testBuildsSnapshotFromCursorEventsAndAttributesGrokBotRows() async throws {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [CursorCostStubURLProtocol.self]
         let session = URLSession(configuration: configuration)
@@ -118,14 +118,14 @@ final class CursorCostUsageFetcherTests: XCTestCase {
             sourceID: "fixture-account"
         )
 
+        // The grok-bot row counts too — as Grok Bot's, not the editor's.
         XCTAssertEqual(snapshot.tool, .cursor)
-        XCTAssertEqual(snapshot.allTimeRequests, 2)
-        XCTAssertEqual(snapshot.allTimeTokens, 180)
-        XCTAssertEqual(snapshot.allTimeCostUSD, 1.50, accuracy: 0.000_001)
+        XCTAssertEqual(snapshot.allTimeRequests, 3)
+        XCTAssertEqual(snapshot.allTimeTokens, 2_178)
+        XCTAssertEqual(snapshot.allTimeCostUSD, 11.49, accuracy: 0.000_001)
         XCTAssertEqual(Set(snapshot.modelBreakdowns.map(\.modelName)), [
-            "cursor-grok-4.6-high-fast", "composer-2.5"
+            "cursor-grok-4.6-high-fast", "composer-2.5", "cloud-model"
         ])
-        XCTAssertFalse(snapshot.modelBreakdowns.contains { $0.modelName == "cloud-model" })
 
         let filter = UsageQueryFilter(range: DateInterval(
             start: now.addingTimeInterval(-300),
@@ -134,13 +134,16 @@ final class CursorCostUsageFetcherTests: XCTestCase {
         let ledgerSummary = try await ledger.summary(filter)
         XCTAssertEqual(ledgerSummary.requests, snapshot.allTimeRequests)
         XCTAssertEqual(ledgerSummary.realTotalTokens, Int64(snapshot.allTimeTokens))
-        XCTAssertEqual(ledgerSummary.costMicros, 1_500_000)
-        XCTAssertEqual(ledgerSummary.freshInput, 110)
-        XCTAssertEqual(ledgerSummary.output, 55)
+        XCTAssertEqual(ledgerSummary.costMicros, 11_490_000)
+        XCTAssertEqual(ledgerSummary.freshInput, 1_109)
+        XCTAssertEqual(ledgerSummary.output, 1_054)
         XCTAssertEqual(ledgerSummary.cacheCreation, 5)
         XCTAssertEqual(ledgerSummary.cacheRead, 10)
         let ledgerTools = try await ledger.providerStats(filter).map(\.tool)
         XCTAssertEqual(ledgerTools, [.cursor])
+        let harnesses = try await ledger.harnessStats(filter)
+        XCTAssertEqual(Set(harnesses.map(\.harness)), [.cursor, .grokBot])
+        XCTAssertEqual(harnesses.first { $0.harness == .grokBot }?.requests, 1)
         _ = try await ledger.prepareForPricingRevision("cursor-authoritative-v1")
         let repricedSummary = try await ledger.summary(filter)
         XCTAssertEqual(repricedSummary.costMicros, ledgerSummary.costMicros)
@@ -173,12 +176,12 @@ final class CursorCostUsageFetcherTests: XCTestCase {
             sourceID: "fixture-account"
         )
         let correctedLedgerSummary = try await ledger.summary(filter)
-        XCTAssertEqual(correctedSnapshot.allTimeRequests, 2)
-        XCTAssertEqual(correctedSnapshot.allTimeTokens, 200)
-        XCTAssertEqual(correctedSnapshot.allTimeCostUSD, 1.75, accuracy: 0.000_001)
-        XCTAssertEqual(correctedLedgerSummary.requests, 2)
-        XCTAssertEqual(correctedLedgerSummary.realTotalTokens, 200)
-        XCTAssertEqual(correctedLedgerSummary.costMicros, 1_750_000)
+        XCTAssertEqual(correctedSnapshot.allTimeRequests, 3)
+        XCTAssertEqual(correctedSnapshot.allTimeTokens, 2_198)
+        XCTAssertEqual(correctedSnapshot.allTimeCostUSD, 11.74, accuracy: 0.000_001)
+        XCTAssertEqual(correctedLedgerSummary.requests, 3)
+        XCTAssertEqual(correctedLedgerSummary.realTotalTokens, 2_198)
+        XCTAssertEqual(correctedLedgerSummary.costMicros, 11_740_000)
     }
 
     func testRejectedCursorAppSessionFallsBackWithoutDoubleCounting() async throws {
@@ -457,4 +460,13 @@ private final class CursorCostStubURLProtocol: URLProtocol {
     }
 
     override func stopLoading() {}
+
+    func testGrokBotRequestsAreGrokBotsByClientTypeOrModel() {
+        XCTAssertTrue(CursorCostUsageFetcher.isGrokBot(clientType: "grok-bot", model: "gpt-5.6-luna-high"))
+        XCTAssertTrue(CursorCostUsageFetcher.isGrokBot(clientType: "Grok-Bot", model: "anything"))
+        XCTAssertTrue(CursorCostUsageFetcher.isGrokBot(clientType: nil, model: "grok-bot-default"))
+        XCTAssertTrue(CursorCostUsageFetcher.isGrokBot(clientType: "cursor", model: "Grok-Bot-cua"))
+        XCTAssertFalse(CursorCostUsageFetcher.isGrokBot(clientType: "cursor", model: "cursor-grok-4.6-xhigh-fast"))
+        XCTAssertFalse(CursorCostUsageFetcher.isGrokBot(clientType: nil, model: "gpt-5.6-luna-high"))
+    }
 }

--- a/Tests/VibeBarCoreTests/UsageModelNamingTests.swift
+++ b/Tests/VibeBarCoreTests/UsageModelNamingTests.swift
@@ -47,4 +47,13 @@ final class UsageModelNamingTests: XCTestCase {
         // Surrounding whitespace is the one thing it does normalize.
         XCTAssertEqual(UsageModelNaming.canonicalDisplayName(" gemini-2.5-pro "), "gemini-2.5-pro")
     }
+
+    func testUnlearnedAntiGravityEnumsAreNotNames() {
+        XCTAssertTrue(UsageModelNaming.isUnlabelledModelEnum("MODEL_PLACEHOLDER_M318"))
+        XCTAssertTrue(UsageModelNaming.isUnlabelledModelEnum(" MODEL_GEMINI_2_5_PRO "))
+        XCTAssertFalse(UsageModelNaming.isUnlabelledModelEnum("gemini-default"))
+        XCTAssertFalse(UsageModelNaming.isUnlabelledModelEnum("MODEL_"))
+        XCTAssertFalse(UsageModelNaming.isUnlabelledModelEnum("model_placeholder"))
+        XCTAssertEqual(UsageModelNaming.canonicalDisplayName("MODEL_PLACEHOLDER_M318"), "Unlabelled model")
+    }
 }


### PR DESCRIPTION
Four of AQ's reports, all attribution:

- **Grok Bot usage.** `CursorCostUsageFetcher` skipped every event whose client type was `grok-bot` and attributed the rest to Cursor, so `grok-bot-*` models showed under the Cursor harness. Events are Grok Bot's by client type or by model prefix (`isGrokBot(clientType:model:)`) and are ingested with `harness: .grokBot`; the fixture test now asserts the split.
- **Grok Bot in Reset History.** The weekly bucket's `rawWindowSeconds` came from `currentPeriodStart`, which moves with the last refresh — 3–4 days to the reset — and `ResetHistoryComparison` drops lanes shorter than a week (the history file already held its cycles). The window is 604 800 s by definition, as Grok's weekly is.
- **Claude scratch workspaces are projectless.** `…/Application Support/Claude/scratch-workspaces/<workspace>/<task>/scratch-<date>-<id>` buckets like Codex's dated cwd.
- **AntiGravity `MODEL_PLACEHOLDER_M318`.** The session kit surfaces an unlearned internal model enum as the model; `UsageModelNaming.isUnlabelledModelEnum` recognises the shape, the Sessions row drops the chip, tables say "Unlabelled model".

`swift build`, `swift test`, `build_app.sh release`, `lint_localization.py` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)