### PR TITLE
Read ChatGPT Chat allowances with the Codex login

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -989,9 +989,14 @@ upstream labels — canonicalize the display, never the stored value.
 
 `ToolType.chatgptChat` is an independent, quota-only member of OpenAI, shown
 before ChatGPT Agentic. It reads Image Generation and Deep Research remainders
-through the existing Cookie/WebView login. It does not read conversation history
-or count model messages. Plan identity comes from the same `/wham/usage`
-`plan_type` parser used by Agentic, through the Chat account's own transport.
+through the Codex CLI's OAuth bearer first (`ChatGPTChatOAuthTransport`: the
+same `~/.codex/auth.json` / Keychain credential and headers the Codex quota
+uses — chatgpt.com accepts it for `/backend-api/conversation/init`, verified
+live 2026-09-06), then the existing Cookie/WebView login. A Codex login is
+therefore a Chat login; the web session is only needed when there is no Codex
+credential. It does not read conversation history or count model messages.
+Plan identity comes from the same `/wham/usage` `plan_type` parser used by
+Agentic, through the Chat account's own transport.
 
 `ChatGPTChatAllowanceStore` learns a total only after three consistent observed
 reset boundaries. Initial reads, mismatches, missed boundaries, and account/plan

--- a/Sources/VibeBarCore/Adapters/ChatGPTChatClient.swift
+++ b/Sources/VibeBarCore/Adapters/ChatGPTChatClient.swift
@@ -2,7 +2,64 @@ import Foundation
 
 public protocol ChatGPTChatTransport: Sendable {
     var name: String { get }
+    /// Whether the transport authenticates every request itself, so the
+    /// client neither fetches a web session token nor passes one. The
+    /// OAuth transport does; the cookie and WebView ones need the token
+    /// the chatgpt.com session hands out.
+    var ownsBearer: Bool { get }
     func request(path: String, method: String, bearer: String?, body: Data?) async throws -> Data
+}
+
+public extension ChatGPTChatTransport {
+    var ownsBearer: Bool { false }
+}
+
+/// The Codex CLI's OAuth bearer, sent the way the Codex quota adapter sends
+/// it. chatgpt.com's backend accepts it for the same read-only endpoints the
+/// web session token reaches — the plan, and the feature allowances — so a
+/// Codex login is a Chat login too, with no web cookie or WebView needed.
+public final class ChatGPTChatOAuthTransport: NSObject, ChatGPTChatTransport, URLSessionTaskDelegate, @unchecked Sendable {
+    public let name = "oauth"
+    public var ownsBearer: Bool { true }
+    private let credential: CodexCredential
+    private var session: URLSession!
+
+    public init(credential: CodexCredential, configuration: URLSessionConfiguration = .ephemeral) {
+        self.credential = credential
+        super.init()
+        configuration.httpCookieStorage = nil
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        session = URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
+    }
+
+    public func close() { session.invalidateAndCancel() }
+
+    public func request(path: String, method: String = "GET", bearer: String? = nil, body: Data? = nil) async throws -> Data {
+        guard ChatGPTChatRequestPolicy.allows(path: path, method: method),
+              path != "/api/auth/session",
+              let url = URL(string: "https://chatgpt.com" + path) else { throw QuotaError.parseFailure("Invalid ChatGPT Chat request.") }
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.httpBody = body
+        request.timeoutInterval = 15
+        request.setValue("Bearer " + credential.accessToken, forHTTPHeaderField: "Authorization")
+        request.setValue("codex-cli", forHTTPHeaderField: "User-Agent")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        if let id = credential.accountId, !id.isEmpty {
+            request.setValue(id, forHTTPHeaderField: "ChatGPT-Account-Id")
+        }
+        if body != nil { request.setValue("application/json", forHTTPHeaderField: "Content-Type") }
+        let (data, response) = try await session.data(for: request)
+        try ChatGPTChatCookieTransport.validate(status: (response as? HTTPURLResponse)?.statusCode ?? 0, size: data.count)
+        return data
+    }
+
+    public func urlSession(_ session: URLSession, task: URLSessionTask,
+                           willPerformHTTPRedirection response: HTTPURLResponse, newRequest request: URLRequest,
+                           completionHandler: @escaping (URLRequest?) -> Void) {
+        // The bearer must never leave its origin.
+        completionHandler(nil)
+    }
 }
 
 /// Only first-party, read-like Chat endpoints are reachable through either transport.
@@ -92,16 +149,37 @@ public struct ChatGPTChatClient: Sendable {
     }
 
     public func fetch(account: AccountIdentity, settings: ChatGPTChatSettings, now: Date = Date()) async throws -> AccountQuota {
-        let sessionData = try await transport.request(path: "/api/auth/session", method: "GET", bearer: nil, body: nil)
-        let session = try ChatGPTChatParser.object(sessionData)
-        guard let token = session["accessToken"] as? String, !token.isEmpty,
-              let user = session["user"] as? [String: Any], let userID = user["id"] as? String else {
-            throw QuotaError.needsLogin
+        let token: String?
+        let userID: String
+        let email: String?
+        let plan: String?
+        if transport.ownsBearer {
+            // No web session to ask: the account and its plan come from
+            // the usage endpoint every ChatGPT bearer can read.
+            let usageData = try await transport.request(path: "/backend-api/wham/usage", method: "GET", bearer: nil, body: nil)
+            let usage = try ChatGPTChatParser.object(usageData)
+            guard let id = (usage["user_id"] as? String) ?? (usage["account_id"] as? String), !id.isEmpty else {
+                throw QuotaError.needsLogin
+            }
+            token = nil
+            userID = id
+            email = usage["email"] as? String
+            plan = CodexResponseParser.planType(data: usageData)
+        } else {
+            let sessionData = try await transport.request(path: "/api/auth/session", method: "GET", bearer: nil, body: nil)
+            let session = try ChatGPTChatParser.object(sessionData)
+            guard let webToken = session["accessToken"] as? String, !webToken.isEmpty,
+                  let user = session["user"] as? [String: Any], let id = user["id"] as? String else {
+                throw QuotaError.needsLogin
+            }
+            token = webToken
+            userID = id
+            email = user["email"] as? String
+            // Reuse Agentic's existing account-plan endpoint and parser, through
+            // this Chat account's transport so a different CLI account cannot leak in.
+            let planData = try? await transport.request(path: "/backend-api/wham/usage", method: "GET", bearer: webToken, body: nil)
+            plan = planData.flatMap { CodexResponseParser.planType(data: $0) }
         }
-        // Reuse Agentic's existing account-plan endpoint and parser, through
-        // this Chat account's transport so a different CLI account cannot leak in.
-        let planData = try? await transport.request(path: "/backend-api/wham/usage", method: "GET", bearer: token, body: nil)
-        let plan = planData.flatMap { CodexResponseParser.planType(data: $0) }
         let body = try JSONSerialization.data(withJSONObject: [
             "conversation_id": NSNull(), "gizmo_id": NSNull(), "requested_default_model": NSNull(),
             "system_hints": [], "timezone": TimeZone.current.identifier,
@@ -121,7 +199,7 @@ public struct ChatGPTChatClient: Sendable {
                                quantity: quantities[sample.id]?.quantity)
         }
         return AccountQuota(accountId: account.id, tool: .chatgptChat, buckets: buckets,
-                            plan: plan, email: user["email"] as? String, queriedAt: now,
+                            plan: plan, email: email, queriedAt: now,
                             chatGPTChat: ChatGPTChatSummary(transport: transport.name, planVerified: plan != nil, accountIdentity: identity))
     }
 }

--- a/Sources/VibeBarCore/Adapters/ChatGPTChatQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/ChatGPTChatQuotaAdapter.swift
@@ -6,6 +6,7 @@ public struct ChatGPTChatQuotaAdapter: QuotaAdapter {
     private let fallback: WebFallback?
     private let settings: @Sendable () -> ChatGPTChatSettings
     private let cookies: @Sendable () throws -> String
+    private let codexCredential: @Sendable () throws -> CodexCredential
 
     public init(webFallback: WebFallback? = nil,
                 settings: @escaping @Sendable () -> ChatGPTChatSettings = {
@@ -13,15 +14,35 @@ public struct ChatGPTChatQuotaAdapter: QuotaAdapter {
                 }, cookies: @escaping @Sendable () throws -> String = {
                     guard let value = OpenAIWebCookieStore.cachedCookieHeader() else { throw QuotaError.noCredential }
                     return value
+                },
+                // The Codex CLI's OAuth material first, the Keychain mirror
+                // second — the same order the Codex quota reads it in.
+                codexCredential: @escaping @Sendable () throws -> CodexCredential = {
+                    if let oauth = try? CodexCredentialReader.loadFromOAuth() { return oauth }
+                    return try CodexCredentialReader.loadFromCLI()
                 }) {
         fallback = webFallback
         self.settings = settings
         self.cookies = cookies
+        self.codexCredential = codexCredential
     }
 
     public func fetch(for account: AccountIdentity) async throws -> AccountQuota {
         let settings = settings().sanitized
         guard settings.enabled else { throw QuotaError.noCredential }
+        // A Codex login is a Chat login: its bearer reads the same
+        // allowances, so someone who never opened the web login window is
+        // not sent to it. Anything but a rate limit falls through to the
+        // cookie and WebView paths, which read the same account.
+        if let credential = try? codexCredential() {
+            let transport = ChatGPTChatOAuthTransport(credential: credential)
+            defer { transport.close() }
+            do { return try await ChatGPTChatClient(transport: transport).fetch(account: account, settings: settings) }
+            catch {
+                try Task.checkCancellation()
+                if let error = error as? QuotaError, error == .rateLimited { throw error }
+            }
+        }
         let cookie = try? cookies()
         if let cookie {
             let transport = ChatGPTChatCookieTransport(cookieHeader: cookie)

--- a/docs/chatgpt-chat.md
+++ b/docs/chatgpt-chat.md
@@ -6,9 +6,12 @@ existing browser import or built-in login. No browser extension is required.
 
 ## Learning totals
 
-The adapter reads the service remainder and reset time. It reuses Agentic's
-`/wham/usage` plan parser through the same authenticated Chat transport. There
-are no fixed feature totals and no cloud-history or model-message collector.
+The adapter reads the service remainder and reset time. It tries the Codex
+CLI's OAuth bearer first — the credential the Codex quota already reads — and
+only then the web cookie and the WebView session, so a Codex login needs no
+separate web login for Chat. It reuses Agentic's `/wham/usage` plan parser
+through whichever Chat transport answered. There are no fixed feature totals
+and no cloud-history or model-message collector.
 
 A first observation is not a reset. Three independent reset observations with
 the same remainder establish a learned total. Reads must bracket the reported


### PR DESCRIPTION
AQ's OpenAI card: "ChatGPT Chat · Refresh failed · no cached data · Needs re-login" while Agentic works.

**Cause.** The Chat adapter only knew the chatgpt.com web session (in-app WebView login or browser cookie import) and never read the Codex CLI's OAuth credential; a Codex user who never opened the web login window had no Chat credential at all.

**Fix.** `ChatGPTChatOAuthTransport` sends the Codex bearer the way `CodexQuotaAdapter` does (`User-Agent: codex-cli`, `ChatGPT-Account-Id`); it owns its bearer, so the client skips `/api/auth/session` and takes the account, plan and email from `/backend-api/wham/usage`, then reads `/backend-api/conversation/init` for the allowances. The adapter tries OAuth first (`auth.json`, then the Keychain mirror), then cookie, then WebView; a rate limit still surfaces.

**Verified.** Read-only probe with this Mac's Codex credential: `conversation/init` → 200 with `limits_progress` (Deep Research 250, Image Generation 1000). Packaged build, `--chatgpt-chat-probe`: `transport: "oauth"`, both buckets, plan pro. AGENTS.md and docs/chatgpt-chat.md describe the order.

`swift build`, `swift test`, `build_app.sh release`, `lint_localization.py` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)