### PR TITLE
Fall back to the Grok web session when the bearer is refused

### DIFF
--- a/Sources/VibeBarCore/Adapters/GrokQuotaAdapter.swift
+++ b/Sources/VibeBarCore/Adapters/GrokQuotaAdapter.swift
@@ -39,11 +39,22 @@ public struct GrokQuotaAdapter: QuotaAdapter {
             creds.isExpired ? nil : creds
         }
 
+        let header = try? GrokWebCookieStore.readCookieHeader()
+
         if let credentials {
-            return try await fetchWithBearer(credentials: credentials, account: account)
+            do {
+                return try await fetchWithBearer(credentials: credentials, account: account)
+            } catch let error as QuotaError where error == .needsLogin || error == .noCredential {
+                // The bearer was refused. A web session, when there is
+                // one, reads the same billing — the fallback AccountStore
+                // promises for this account — so it is tried before the
+                // refusal is reported.
+                guard let header else { throw error }
+                return try await fetchWithCookies(header: header, account: account)
+            }
         }
 
-        if let header = try? GrokWebCookieStore.readCookieHeader() {
+        if let header {
             return try await fetchWithCookies(header: header, account: account)
         }
 


### PR DESCRIPTION
From the auth-method audit: `GrokQuotaAdapter` went bearer-only whenever `~/.grok/auth.json` was present and unexpired, and a 401 was the final answer even with an imported web session on hand — while `AccountStore` registers the account on the promise that the adapter falls back internally. A bearer refused with `needsLogin` / `noCredential` now tries the cookie path before reporting; a rate limit still surfaces as one.

`swift build`; Grok suites pass; `lint_localization.py` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)