### PR TITLE
Count ChatGPT Chat's Pro model messages against the published allowances

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -888,7 +888,7 @@ SubProvider → L3 quota / model group. Source of truth:
 | L1 company | L2 SubProvider        | L3 quota / model groups                  |
 | ---------- | --------------------- | ---------------------------------------- |
 | OpenAI     | ChatGPT Agentic       | All Models, Codex Spark …                 |
-| OpenAI     | ChatGPT Chat          | Image Generation, Deep Research |
+| OpenAI     | ChatGPT Chat          | Image Generation, Deep Research, GPT-6 Pro · Weekly, GPT-5.6 Sol Pro · Daily, Pro Models · Daily/Weekly |
 | Anthropic  | Claude                | All Models, Sonnet, Opus, Fable …         |
 | Google AI  | Gemini Web            | 5 Hours, Weekly                           |
 | Google AI  | AntiGravity           | Gemini Models, Claude & GPT Models        |
@@ -994,9 +994,30 @@ same `~/.codex/auth.json` / Keychain credential and headers the Codex quota
 uses — chatgpt.com accepts it for `/backend-api/conversation/init`, verified
 live 2026-09-06), then the existing Cookie/WebView login. A Codex login is
 therefore a Chat login; the web session is only needed when there is no Codex
-credential. It does not read conversation history or count model messages.
-Plan identity comes from the same `/wham/usage` `plan_type` parser used by
-Agentic, through the Chat account's own transport.
+credential. Plan identity comes from the same `/wham/usage` `plan_type` parser
+used by Agentic, through the Chat account's own transport. Every transport
+sends a browser user agent (`ChatGPTChatRequestPolicy.userAgent`): chatgpt.com's
+edge serves the saved-history endpoints only to one, and accepts it everywhere
+else (verified live 2026-09-07).
+
+The GPT-6 Pro and GPT-5.6 Sol Pro allowances have no service count.
+`conversation/init` names a model in `model_limits` only once it is exhausted
+(`model_slug`, `resets_after`, `using_default_model_slug` — the ChatGPT
+client's own schema), and `/backend-api/models` carries no allowance field.
+With `ChatGPTChatSettings.trackProModels` on (off by default), the client
+counts the account's saved conversations instead: `ChatGPTChatHistoryReader`
+walks `/backend-api/conversations` newest first inside a one-week window,
+skips Work rows and temporary chats, fetches only changed revisions (24 per
+refresh, 25 s), and `ChatGPTChatParser.conversation` charges each user turn
+to the model of its final answer, once. `ChatGPTChatProAllowances` holds the
+published totals per `plan_type` (`pro`: 200/week GPT-6 Pro, 170/day Sol Pro,
+200/day both; `prolite`: 50/week shared — help article 20001354, read
+2026-09-07); other plans get no Pro buckets. Counts are trailing-window
+estimates with no claimed reset; a throttled model overrides its bucket with
+the service's exhausted state and reset. Partial coverage shows the count
+without a percentage. Only hashed ids, times and model slugs are cached, in
+`~/.vibebar/chatgpt_chat_history.json`. `ChatGPTChatRequestPolicy` admits the
+list with paging fields only and single conversations by UUID; nothing else.
 
 `ChatGPTChatAllowanceStore` learns a total only after three consistent observed
 reset boundaries. Initial reads, mismatches, missed boundaries, and account/plan

--- a/Sources/VibeBarApp/ChatGPTChatProbe.swift
+++ b/Sources/VibeBarApp/ChatGPTChatProbe.swift
@@ -8,6 +8,7 @@ enum ChatGPTChatProbe {
     static func run() async -> Int32 {
         var config = ChatGPTChatSettings()
         config.enabled = true
+        config.trackProModels = CommandLine.arguments.contains("--pro")
         let settings = config
         let fallback: ChatGPTChatQuotaAdapter.WebFallback?
         if CommandLine.arguments.contains("--cookie-only") {
@@ -27,10 +28,13 @@ enum ChatGPTChatProbe {
                 let transport: String
                 let buckets: [MCPQuotaBucketDTO]
                 let plan: String?
+                let history: MCPChatAllowanceDTO?
             }
-            let data = try JSONEncoder().encode(Output(transport: result.chatGPTChat?.transport ?? "unknown",
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            let data = try encoder.encode(Output(transport: result.chatGPTChat?.transport ?? "unknown",
                 buckets: result.buckets.map { MCPQuotaBucketDTO(bucket: $0, forecast: nil) },
-                plan: result.plan))
+                plan: result.plan, history: result.chatGPTChat.map(MCPChatAllowanceDTO.init)))
             print(String(decoding: data, as: UTF8.self))
             return 0
         } catch {

--- a/Sources/VibeBarApp/Views/ChatGPTChatViews.swift
+++ b/Sources/VibeBarApp/Views/ChatGPTChatViews.swift
@@ -6,9 +6,17 @@ struct QuotaLearningStatus: View {
     let bucket: QuotaBucket
     let fontSize: CGFloat
     var body: some View {
-        Text(bucket.quantity?.remaining.map { L10n.Quota.Chat.learningRemaining(count: $0) }
-             ?? L10n.Quota.Forecast.Confidence.learning)
-            .font(.system(size: fontSize, weight: .semibold)).foregroundStyle(.secondary)
+        Text(label).font(.system(size: fontSize, weight: .semibold)).foregroundStyle(.secondary)
+    }
+    private var label: String {
+        // A counted allowance whose history was not fully read is a partial
+        // count, not a total still being learned; say which.
+        if let quantity = bucket.quantity, !quantity.coverageComplete {
+            guard let used = quantity.used else { return L10n.Quota.Chat.partial }
+            return [L10n.Quota.Chat.used(count: used), L10n.Quota.Chat.partial].joined(separator: " · ")
+        }
+        return bucket.quantity?.remaining.map { L10n.Quota.Chat.learningRemaining(count: $0) }
+            ?? L10n.Quota.Forecast.Confidence.learning
     }
 }
 
@@ -43,6 +51,17 @@ struct ChatGPTChatSettingsSection: View {
             Text(L10n.Quota.Chat.featuresHelp).font(.caption).foregroundStyle(.secondary)
             if settingsStore.settings.chatGPTChat.enabled {
                 Text(L10n.Quota.Chat.allowanceLearningHelp).font(.caption).foregroundStyle(.secondary)
+                Toggle(L10n.Quota.Chat.historyToggle, isOn: $settingsStore.settings.chatGPTChat.trackProModels)
+                Text(L10n.Quota.Chat.privacy).font(.caption).foregroundStyle(.secondary)
+                if settingsStore.settings.chatGPTChat.trackProModels {
+                    Text(L10n.Quota.Chat.rolling).font(.caption).foregroundStyle(.secondary)
+                    if let history = environment.quota(for: .chatgptChat)?.chatGPTChat?.history {
+                        Text(history.complete ? L10n.Quota.Chat.complete : L10n.Quota.Chat.partial)
+                            .font(.caption).foregroundStyle(.secondary)
+                        Text(L10n.Quota.Chat.excluded(work: history.excludedWorkConversations, unknown: history.unclassifiedTurns))
+                            .font(.caption).foregroundStyle(.tertiary)
+                    }
+                }
                 Button(L10n.Quota.Chat.refresh) { environment.refresh(.chatgptChat) }
             }
         }

--- a/Sources/VibeBarCore/Adapters/ChatGPTChatClient.swift
+++ b/Sources/VibeBarCore/Adapters/ChatGPTChatClient.swift
@@ -14,10 +14,11 @@ public extension ChatGPTChatTransport {
     var ownsBearer: Bool { false }
 }
 
-/// The Codex CLI's OAuth bearer, sent the way the Codex quota adapter sends
-/// it. chatgpt.com's backend accepts it for the same read-only endpoints the
-/// web session token reaches — the plan, and the feature allowances — so a
-/// Codex login is a Chat login too, with no web cookie or WebView needed.
+/// The Codex CLI's OAuth bearer, sent with the `ChatGPT-Account-Id` the
+/// Codex quota adapter sends. chatgpt.com's backend accepts it for the same
+/// read-only endpoints the web session token reaches — the plan, the feature
+/// allowances, and the saved history — so a Codex login is a Chat login too,
+/// with no web cookie or WebView needed.
 public final class ChatGPTChatOAuthTransport: NSObject, ChatGPTChatTransport, URLSessionTaskDelegate, @unchecked Sendable {
     public let name = "oauth"
     public var ownsBearer: Bool { true }
@@ -43,7 +44,7 @@ public final class ChatGPTChatOAuthTransport: NSObject, ChatGPTChatTransport, UR
         request.httpBody = body
         request.timeoutInterval = 15
         request.setValue("Bearer " + credential.accessToken, forHTTPHeaderField: "Authorization")
-        request.setValue("codex-cli", forHTTPHeaderField: "User-Agent")
+        request.setValue(ChatGPTChatRequestPolicy.userAgent, forHTTPHeaderField: "User-Agent")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         if let id = credential.accountId, !id.isEmpty {
             request.setValue(id, forHTTPHeaderField: "ChatGPT-Account-Id")
@@ -62,14 +63,29 @@ public final class ChatGPTChatOAuthTransport: NSObject, ChatGPTChatTransport, UR
     }
 }
 
-/// Only first-party, read-like Chat endpoints are reachable through either transport.
+/// Only first-party, read-like Chat endpoints are reachable through any
+/// transport: the session, the plan, the allowances, and — for counting Pro
+/// model messages — the saved-conversation list and single conversations.
 public enum ChatGPTChatRequestPolicy {
+    /// chatgpt.com's edge answers the history endpoints only to a browser
+    /// user agent (a CLI or app string gets its challenge page instead);
+    /// the same string is accepted by every other Chat endpoint, so all
+    /// transports send it.
+    public static let userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15"
+    private static let listFields: Set<String> = ["offset", "limit", "order", "is_archived"]
+
     public static func allows(path: String, method: String) -> Bool {
         guard path.hasPrefix("/"), !path.hasPrefix("//"), !path.contains("#"), !path.contains("\\"),
               let parts = URLComponents(string: path), parts.host == nil, parts.scheme == nil else { return false }
         if method == "POST" { return path == "/backend-api/conversation/init" }
         guard method == "GET" else { return false }
-        return path == "/api/auth/session" || path == "/backend-api/wham/usage"
+        if path == "/api/auth/session" || path == "/backend-api/wham/usage" { return true }
+        if parts.path == "/backend-api/conversations" {
+            return (parts.queryItems ?? []).allSatisfy { listFields.contains($0.name) }
+        }
+        let prefix = "/backend-api/conversation/"
+        return parts.path.hasPrefix(prefix) && parts.query == nil
+            && UUID(uuidString: String(parts.path.dropFirst(prefix.count))) != nil
     }
 }
 
@@ -98,6 +114,7 @@ public final class ChatGPTChatCookieTransport: NSObject, ChatGPTChatTransport, U
         request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.setValue("https://chatgpt.com/", forHTTPHeaderField: "Referer")
+        request.setValue(ChatGPTChatRequestPolicy.userAgent, forHTTPHeaderField: "User-Agent")
         if let bearer { request.setValue("Bearer " + bearer, forHTTPHeaderField: "Authorization") }
         if body != nil { request.setValue("application/json", forHTTPHeaderField: "Content-Type") }
         let (bytes, response) = try await session.bytes(for: request)
@@ -143,9 +160,12 @@ public final class ChatGPTChatCookieTransport: NSObject, ChatGPTChatTransport, U
 public struct ChatGPTChatClient: Sendable {
     private let transport: any ChatGPTChatTransport
     private let store: ChatGPTChatAllowanceStore
-    public init(transport: any ChatGPTChatTransport, store: ChatGPTChatAllowanceStore = .shared) {
+    private let historyStore: ChatGPTChatHistoryStore
+    public init(transport: any ChatGPTChatTransport, store: ChatGPTChatAllowanceStore = .shared,
+                historyStore: ChatGPTChatHistoryStore = .shared) {
         self.transport = transport
         self.store = store
+        self.historyStore = historyStore
     }
 
     public func fetch(account: AccountIdentity, settings: ChatGPTChatSettings, now: Date = Date()) async throws -> AccountQuota {
@@ -192,14 +212,28 @@ public struct ChatGPTChatClient: Sendable {
         let identity = ChatGPTChatParser.identity(userID + ":" + (account.accountId ?? "personal"))
         let quantities = try await store.observe(localAccount: account.id, identity: identity,
                                                 plan: plan?.lowercased(), samples: samples)
-        let buckets = samples.map { sample in
+        var buckets = samples.map { sample in
             let title = sample.id == "image_gen" ? "Image Generation" : "Deep Research"
             return QuotaBucket(id: sample.id, title: title, shortLabel: title, usedPercent: 0,
                                resetAt: sample.resetAt, rawWindowSeconds: quantities[sample.id]?.windowSeconds,
                                quantity: quantities[sample.id]?.quantity)
         }
+        var summary = ChatGPTChatSummary(transport: transport.name, planVerified: plan != nil, accountIdentity: identity)
+        // The Pro models have no service count: their buckets are the saved
+        // history's turns against the plan's published allowance, and only
+        // when the plan is one that has Pro models. The same `init` reply
+        // names any model that is exhausted right now.
+        let allowances = ChatGPTChatProAllowances.allowances(plan: plan)
+        if settings.trackProModels, !allowances.isEmpty {
+            let history = await ChatGPTChatHistoryReader(transport: transport, store: historyStore)
+                .read(bearer: token, identity: identity, now: now)
+            try Task.checkCancellation()
+            summary.history = history.summary
+            buckets += ChatGPTChatParser.proBuckets(allowances: allowances, turns: history.turns,
+                                                   limits: ChatGPTChatParser.modelLimits(data, now: now),
+                                                   complete: history.summary.complete, now: now)
+        }
         return AccountQuota(accountId: account.id, tool: .chatgptChat, buckets: buckets,
-                            plan: plan, email: email, queriedAt: now,
-                            chatGPTChat: ChatGPTChatSummary(transport: transport.name, planVerified: plan != nil, accountIdentity: identity))
+                            plan: plan, email: email, queriedAt: now, chatGPTChat: summary)
     }
 }

--- a/Sources/VibeBarCore/Adapters/ChatGPTChatProModels.swift
+++ b/Sources/VibeBarCore/Adapters/ChatGPTChatProModels.swift
@@ -1,0 +1,212 @@
+import Foundation
+
+/// One Pro-model allowance as OpenAI publishes it for a plan's Chat surface.
+///
+/// Source: "GPT-5.6 and GPT-6 Pro in ChatGPT", help.openai.com article
+/// 20001354, read 2026-09-07. The service reports no count for these models
+/// — `conversation/init` names a model only once it is exhausted — so the
+/// count comes from the saved history and the total from this table. Work
+/// and Codex have their own rules and are never charged here.
+public struct ChatGPTChatProAllowance: Hashable, Sendable {
+    public let id: String
+    public let title: String
+    public let models: Set<String>
+    public let limit: Int
+    public let windowSeconds: Int
+    public init(id: String, title: String, models: Set<String>, limit: Int, windowSeconds: Int) {
+        self.id = id; self.title = title; self.models = models; self.limit = limit; self.windowSeconds = windowSeconds
+    }
+}
+
+public enum ChatGPTChatProAllowances {
+    /// The picker slugs, as `/backend-api/models` lists them for a Pro account.
+    public static let gpt6Pro = "gpt-6-pro"
+    public static let solPro = "gpt-5-6-pro"
+    public static let week = 7 * 86_400
+    public static let day = 86_400
+
+    /// `plan_type` as `/backend-api/wham/usage` reports it: `pro` is the
+    /// $200 plan and `prolite` the $100 one. Plans without Pro models get
+    /// nothing; so does an unrecognized plan, rather than a guessed total.
+    public static func allowances(plan: String?) -> [ChatGPTChatProAllowance] {
+        switch plan?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "pro":
+            return [
+                ChatGPTChatProAllowance(id: "gpt6_pro_weekly", title: "GPT-6 Pro · Weekly", models: [gpt6Pro], limit: 200, windowSeconds: week),
+                ChatGPTChatProAllowance(id: "sol_pro_daily", title: "GPT-5.6 Sol Pro · Daily", models: [solPro], limit: 170, windowSeconds: day),
+                ChatGPTChatProAllowance(id: "pro_daily", title: "Pro Models · Daily", models: [gpt6Pro, solPro], limit: 200, windowSeconds: day)
+            ]
+        case "prolite":
+            return [ChatGPTChatProAllowance(id: "pro_weekly", title: "Pro Models · Weekly", models: [gpt6Pro, solPro], limit: 50, windowSeconds: week)]
+        default:
+            return []
+        }
+    }
+}
+
+/// A user message and the model that answered it. The id is a
+/// privacy-preserving hash of the conversation and message ids; no text is kept.
+public struct ChatGPTChatTurn: Codable, Hashable, Sendable {
+    public let id: String
+    public let createdAt: Date
+    public let model: String
+    public init(id: String, createdAt: Date, model: String) { self.id = id; self.createdAt = createdAt; self.model = model }
+}
+
+/// A model the service reports as unavailable until `resetsAt`, during which
+/// the picker substitutes `fallbackModel`. This is the only reset the
+/// service ever states for a Pro model.
+public struct ChatGPTChatModelLimit: Hashable, Sendable {
+    public let model: String
+    public let resetsAt: Date?
+    public let fallbackModel: String?
+    public init(model: String, resetsAt: Date?, fallbackModel: String?) {
+        self.model = model; self.resetsAt = resetsAt; self.fallbackModel = fallbackModel
+    }
+}
+
+/// What the reader keeps of one conversation: when it last changed, and the
+/// turns inside the window with their models.
+public struct ChatGPTChatConversation: Codable, Hashable, Sendable {
+    public var updatedAt: Date
+    public var turns: [ChatGPTChatTurn]
+    public var isWork: Bool
+    public var unclassifiedTurns: Int
+    public init(updatedAt: Date, turns: [ChatGPTChatTurn], isWork: Bool, unclassifiedTurns: Int) {
+        self.updatedAt = updatedAt; self.turns = turns; self.isWork = isWork; self.unclassifiedTurns = unclassifiedTurns
+    }
+}
+
+extension ChatGPTChatParser {
+    /// `model_limits` as the ChatGPT client's own schema reads it:
+    /// `{model_slug, resets_after, using_default_model_slug, description?}`,
+    /// kept only while `resets_after` lies ahead. An empty list means no
+    /// model is throttled right now, not that any allowance is full.
+    public static func modelLimits(_ data: Data, now: Date) -> [ChatGPTChatModelLimit] {
+        guard let root = try? object(data), let rows = root["model_limits"] as? [[String: Any]] else { return [] }
+        return rows.compactMap { row in
+            guard let model = row["model_slug"] as? String, validModel(model) else { return nil }
+            let reset = date(row["resets_after"])
+            if let reset, reset <= now { return nil }
+            let fallback = (row["using_default_model_slug"] as? String).flatMap { validModel($0) ? $0 : nil }
+            return ChatGPTChatModelLimit(model: model, resetsAt: reset, fallbackModel: fallback)
+        }
+    }
+
+    /// Work conversations carry `conversation_origin` `tpp` or `flora` and
+    /// answer with `-wm` models; both are ChatGPT Agentic's, never Chat's.
+    public static func isWork(origin: String?, model: String?) -> Bool {
+        ["tpp", "flora", "codex"].contains(origin?.lowercased() ?? "")
+            || (model?.lowercased().hasSuffix("-wm") ?? false)
+            || (model?.lowercased().contains("codex") ?? false)
+    }
+
+    /// The user turns of one saved conversation, each charged to the model
+    /// of its final answer. The user message itself names no model; the
+    /// assistant and tool nodes under it do, and a regenerated answer keeps
+    /// the same user node, so a turn is counted once however often it was
+    /// retried. Turns before `since` are dropped, as is every message body.
+    public static func conversation(_ data: Data, id: String, updatedAt: Date, since: Date) throws -> ChatGPTChatConversation {
+        let root = try object(data)
+        guard root["conversation_id"] as? String == id,
+              let mapping = root["mapping"] as? [String: [String: Any]] else {
+            throw QuotaError.parseFailure("ChatGPT Chat conversation identity or mapping is missing.")
+        }
+        let origin = root["conversation_origin"] as? String
+        let defaultModel = root["default_model_slug"] as? String
+        if isWork(origin: origin, model: defaultModel) {
+            return ChatGPTChatConversation(updatedAt: updatedAt, turns: [], isWork: true, unclassifiedTurns: 0)
+        }
+        // A newly introduced origin is not automatically a Chat origin.
+        let knownOrigin = origin == nil || origin == "chat" || origin == "chatgpt"
+        var users: [String: [String: Any]] = [:]
+        for (key, node) in mapping {
+            if let message = node["message"] as? [String: Any], role(of: message) == "user" {
+                if let created = date(message["create_time"]), created < since { continue }
+                users[key] = message
+            }
+        }
+        // Walk each final answer up to the user turn it answers.
+        var replies: [String: [[String: Any]]] = [:]
+        var owners = Dictionary(users.keys.map { ($0, $0) }, uniquingKeysWith: { first, _ in first })
+        var orphans: Set<String> = []
+        for (key, node) in mapping {
+            guard let message = node["message"] as? [String: Any], role(of: message) == "assistant",
+                  message["recipient"] as? String == "all",
+                  message["status"] as? String == "finished_successfully",
+                  message["channel"] == nil || message["channel"] is NSNull || message["channel"] as? String == "final",
+                  let contentType = (message["content"] as? [String: Any])?["content_type"] as? String,
+                  contentType == "text" || contentType == "multimodal_text"
+            else { continue }
+            var cursor: String? = key
+            var path: [String] = []
+            var visited: Set<String> = []
+            var owner: String?
+            while let current = cursor, visited.insert(current).inserted {
+                if let known = owners[current] { owner = known; break }
+                if orphans.contains(current) { break }
+                // An older user turn is a boundary, not a path to a newer one.
+                if let candidate = mapping[current]?["message"] as? [String: Any], role(of: candidate) == "user" { break }
+                path.append(current)
+                cursor = mapping[current]?["parent"] as? String
+            }
+            if let owner {
+                for node in path { owners[node] = owner }
+                replies[owner, default: []].append(message)
+            } else { orphans.formUnion(path) }
+        }
+        var turns: [String: ChatGPTChatTurn] = [:]
+        var unknown = 0
+        for (nodeID, user) in users {
+            guard knownOrigin,
+                  let messageID = user["id"] as? String, !messageID.isEmpty,
+                  let created = date(user["create_time"]),
+                  let reply = replies[nodeID]?.max(by: { (date($0["create_time"]) ?? .distantPast) < (date($1["create_time"]) ?? .distantPast) }),
+                  let metadata = reply["metadata"] as? [String: Any],
+                  let model = metadata["model_slug"] as? String, validModel(model)
+            else { unknown += 1; continue }
+            if isWork(origin: origin, model: model) { continue }
+            let key = identity(id + ":" + messageID)
+            turns[key] = ChatGPTChatTurn(id: key, createdAt: created, model: model)
+        }
+        return ChatGPTChatConversation(updatedAt: updatedAt, turns: Array(turns.values), isWork: false, unclassifiedTurns: unknown)
+    }
+
+    /// Each allowance as a quota bucket: the messages charged to its models
+    /// inside a window ending now, against the published total. The service
+    /// states no window start, so the count is a trailing window and is
+    /// marked estimated; a throttled model overrides it with the service's
+    /// own exhausted state and reset. A shared allowance counts as
+    /// throttled only when every model it covers is.
+    public static func proBuckets(allowances: [ChatGPTChatProAllowance], turns: [ChatGPTChatTurn],
+                                  limits: [ChatGPTChatModelLimit], complete: Bool, now: Date) -> [QuotaBucket] {
+        let unique = Dictionary(turns.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first }).values
+        let limited = Dictionary(limits.map { ($0.model, $0) }, uniquingKeysWith: { first, _ in first })
+        return allowances.map { allowance in
+            let start = now.addingTimeInterval(-TimeInterval(allowance.windowSeconds))
+            let used = unique.filter { allowance.models.contains($0.model) && $0.createdAt > start && $0.createdAt <= now }.count
+            let exhausted = allowance.models.allSatisfy { limited[$0] != nil }
+            let quantity: QuotaQuantity
+            let resetAt: Date?
+            if exhausted {
+                quantity = QuotaQuantity(used: allowance.limit, remaining: 0, limit: allowance.limit, isEstimated: true)
+                resetAt = allowance.models.compactMap { limited[$0]?.resetsAt }.max()
+            } else {
+                quantity = QuotaQuantity(used: used, remaining: complete ? max(0, allowance.limit - used) : nil,
+                                         limit: allowance.limit, isEstimated: true, coverageComplete: complete)
+                resetAt = nil
+            }
+            return QuotaBucket(id: allowance.id, title: allowance.title, shortLabel: allowance.title,
+                               usedPercent: quantity.usedPercent ?? 0, resetAt: resetAt,
+                               rawWindowSeconds: allowance.windowSeconds, quantity: quantity)
+        }
+    }
+
+    private static func role(of message: [String: Any]) -> String? {
+        (message["author"] as? [String: Any])?["role"] as? String
+    }
+
+    static func validModel(_ value: String) -> Bool {
+        value.range(of: "^[A-Za-z0-9][A-Za-z0-9._-]{0,99}$", options: .regularExpression) != nil
+    }
+}

--- a/Sources/VibeBarCore/MCP/MCPDTOs.swift
+++ b/Sources/VibeBarCore/MCP/MCPDTOs.swift
@@ -901,7 +901,16 @@ public struct MCPQuotaQuantityDTO: Codable, Equatable, Sendable {
 public struct MCPChatAllowanceDTO: Codable, Equatable, Sendable {
     public let transport: String
     public let planVerified: Bool?
+    /// Present when Pro model messages are counted from the saved history.
+    public let historyComplete: Bool?
+    public let historyObservedFrom: Date?
+    public let excludedWorkConversations: Int?
+    public let unclassifiedTurns: Int?
+    public let failedConversations: Int?
     public init(_ value: ChatGPTChatSummary) {
         transport = value.transport; planVerified = value.planVerified
+        historyComplete = value.history?.complete; historyObservedFrom = value.history?.observedFrom
+        excludedWorkConversations = value.history?.excludedWorkConversations
+        unclassifiedTurns = value.history?.unclassifiedTurns; failedConversations = value.history?.failedConversations
     }
 }

--- a/Sources/VibeBarCore/Models/ChatGPTChatSettings.swift
+++ b/Sources/VibeBarCore/Models/ChatGPTChatSettings.swift
@@ -2,20 +2,49 @@ import Foundation
 
 public struct ChatGPTChatSettings: Codable, Hashable, Sendable {
     public var enabled = false
+    /// Count GPT-6 Pro and GPT-5.6 Sol Pro messages in the account's saved
+    /// conversation history against the allowances OpenAI publishes for the
+    /// plan. Off by default: it reads the model and time of every recent
+    /// message, which the feature allowances never need.
+    public var trackProModels = false
     public init() {}
-    private enum CodingKeys: String, CodingKey { case enabled }
+    private enum CodingKeys: String, CodingKey { case enabled, trackProModels }
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         enabled = try c.decodeIfPresent(Bool.self, forKey: .enabled) ?? false
+        trackProModels = try c.decodeIfPresent(Bool.self, forKey: .trackProModels) ?? false
     }
     public var sanitized: Self { self }
+}
+
+/// What one read of the saved history covered, so a count can say how much
+/// of the window it actually saw.
+public struct ChatGPTChatHistorySummary: Codable, Hashable, Sendable {
+    public var queriedAt: Date
+    public var observedFrom: Date
+    /// Every conversation updated inside the window was read this round or
+    /// was already cached at its current revision.
+    public var complete: Bool
+    public var conversationsRead: Int
+    public var excludedWorkConversations: Int
+    public var unclassifiedTurns: Int
+    public var failedConversations: Int
+    public init(queriedAt: Date, observedFrom: Date, complete: Bool, conversationsRead: Int,
+                excludedWorkConversations: Int, unclassifiedTurns: Int, failedConversations: Int) {
+        self.queriedAt = queriedAt; self.observedFrom = observedFrom; self.complete = complete
+        self.conversationsRead = conversationsRead; self.excludedWorkConversations = excludedWorkConversations
+        self.unclassifiedTurns = unclassifiedTurns; self.failedConversations = failedConversations
+    }
 }
 
 public struct ChatGPTChatSummary: Codable, Hashable, Sendable {
     public var transport: String
     public var planVerified: Bool?
     public var accountIdentity: String?
-    public init(transport: String, planVerified: Bool? = nil, accountIdentity: String? = nil) {
+    public var history: ChatGPTChatHistorySummary?
+    public init(transport: String, planVerified: Bool? = nil, accountIdentity: String? = nil,
+                history: ChatGPTChatHistorySummary? = nil) {
         self.transport = transport; self.planVerified = planVerified; self.accountIdentity = accountIdentity
+        self.history = history
     }
 }

--- a/Sources/VibeBarCore/Models/MenuBarSettings.swift
+++ b/Sources/VibeBarCore/Models/MenuBarSettings.swift
@@ -467,7 +467,11 @@ public enum MenuBarFieldCatalog {
 
     public static let chatGPTChatFields: [MenuBarFieldOption] = [
         option(.chatgptChat, "image_gen", "Image Generation", "Image Generation"),
-        option(.chatgptChat, "deep_research", "Deep Research", "Deep Research")
+        option(.chatgptChat, "deep_research", "Deep Research", "Deep Research"),
+        option(.chatgptChat, "gpt6_pro_weekly", "GPT-6 Pro · Weekly", "GPT-6 Pro"),
+        option(.chatgptChat, "sol_pro_daily", "GPT-5.6 Sol Pro · Daily", "Sol Pro"),
+        option(.chatgptChat, "pro_daily", "Pro Models · Daily", "Pro Daily"),
+        option(.chatgptChat, "pro_weekly", "Pro Models · Weekly", "Pro Weekly")
     ]
 
     public static let claudeFields: [MenuBarFieldOption] = [

--- a/Sources/VibeBarCore/Services/ChatGPTChatHistoryReader.swift
+++ b/Sources/VibeBarCore/Services/ChatGPTChatHistoryReader.swift
@@ -1,0 +1,123 @@
+import Foundation
+
+/// The reader's cache: one entry per saved conversation at the revision it
+/// was last parsed, so an unchanged conversation is never fetched twice.
+/// Keyed by the Chat account identity; holds hashed ids, times and model
+/// slugs only.
+public actor ChatGPTChatHistoryStore {
+    public static let shared = ChatGPTChatHistoryStore()
+    public struct Cache: Codable, Sendable {
+        public var conversations: [String: ChatGPTChatConversation] = [:]
+        public init() {}
+    }
+    private let url: URL
+    public init(url: URL = VibeBarLocalStore.chatGPTChatHistoryURL) { self.url = url }
+
+    public func load(identity: String) -> Cache {
+        (try? VibeBarLocalStore.readJSON([String: Cache].self, from: url))?[identity] ?? Cache()
+    }
+
+    public func save(_ value: Cache, identity: String) {
+        var all = (try? VibeBarLocalStore.readJSON([String: Cache].self, from: url)) ?? [:]
+        all[identity] = value
+        try? VibeBarLocalStore.writeJSON(all, to: url)
+    }
+}
+
+/// Reads the account's saved conversations updated inside the counting
+/// window and collects their turns. The list is walked newest first and
+/// stops at the first conversation older than the window; only
+/// conversations whose revision changed are fetched in full, within a
+/// per-refresh budget so one refresh cannot run away on a busy account.
+/// Whatever the budget or a failure left unread is reported, not hidden.
+public struct ChatGPTChatHistoryReader: Sendable {
+    public struct Result: Sendable {
+        public let turns: [ChatGPTChatTurn]
+        public let summary: ChatGPTChatHistorySummary
+    }
+    /// The longest published Pro window: a week.
+    public static let windowSeconds: TimeInterval = 7 * 86_400
+    public static let pageSize = 50
+    public static let maxPages = 4
+    public static let detailBudget = 24
+    public static let deadlineSeconds: TimeInterval = 25
+
+    private let transport: any ChatGPTChatTransport
+    private let store: ChatGPTChatHistoryStore
+    public init(transport: any ChatGPTChatTransport, store: ChatGPTChatHistoryStore = .shared) {
+        self.transport = transport
+        self.store = store
+    }
+
+    public func read(bearer: String?, identity: String, now: Date) async -> Result {
+        let cutoff = now.addingTimeInterval(-Self.windowSeconds)
+        var cache = await store.load(identity: identity)
+        cache.conversations = cache.conversations.filter { $0.value.updatedAt >= now.addingTimeInterval(-2 * Self.windowSeconds) }
+        var seen: Set<String> = []
+        var streamsFinished = 0, failures = 0, work = 0, unknown = 0, fetched = 0, read = 0
+        var turns: [ChatGPTChatTurn] = []
+        let deadline = Date().addingTimeInterval(Self.deadlineSeconds)
+        do {
+            for archived in [false, true] {
+                var offset = 0
+                var reachedEnd = false
+                for _ in 0..<Self.maxPages {
+                    try Task.checkCancellation()
+                    guard Date() < deadline else { break }
+                    let path = "/backend-api/conversations?offset=\(offset)&limit=\(Self.pageSize)&order=updated&is_archived=\(archived)"
+                    let data = try await transport.request(path: path, method: "GET", bearer: bearer, body: nil)
+                    let root = try ChatGPTChatParser.object(data)
+                    guard let items = root["items"] as? [[String: Any]] else {
+                        throw QuotaError.parseFailure("ChatGPT Chat history list has no items.")
+                    }
+                    let before = seen.count
+                    for item in items {
+                        guard let id = item["id"] as? String, !id.isEmpty, seen.insert(id).inserted else { continue }
+                        let updated = ChatGPTChatParser.date(item["update_time"])
+                        if let updated, updated < cutoff { reachedEnd = true; continue }
+                        // A Work row is known from the list alone; no transcript is read for it.
+                        if ChatGPTChatParser.isWork(origin: item["conversation_origin"] as? String, model: nil) { work += 1; continue }
+                        if item["is_temporary_chat"] as? Bool == true { continue }
+                        guard UUID(uuidString: id) != nil, let updatedAt = updated else { failures += 1; continue }
+                        let key = ChatGPTChatParser.identity(id)
+                        var parsed = cache.conversations[key]
+                        if parsed?.updatedAt != updatedAt {
+                            if fetched < Self.detailBudget, Date() < deadline {
+                                fetched += 1
+                                do {
+                                    let detail = try await transport.request(path: "/backend-api/conversation/" + id,
+                                                                             method: "GET", bearer: bearer, body: nil)
+                                    parsed = try ChatGPTChatParser.conversation(detail, id: id, updatedAt: updatedAt, since: cutoff)
+                                    cache.conversations[key] = parsed
+                                } catch is CancellationError {
+                                    throw CancellationError()
+                                } catch { failures += 1 }
+                            } else { failures += 1 }
+                        }
+                        if let parsed {
+                            read += 1
+                            if parsed.isWork { work += 1 }
+                            unknown += parsed.unclassifiedTurns
+                            turns += parsed.turns
+                        }
+                    }
+                    offset += items.count
+                    if items.isEmpty { reachedEnd = true }
+                    if let total = ChatGPTChatParser.integer(root["total"]), offset >= total { reachedEnd = true }
+                    if reachedEnd { break }
+                    if seen.count == before { failures += 1; break }
+                }
+                if reachedEnd { streamsFinished += 1 }
+            }
+        } catch is CancellationError {
+            // Reported below as incomplete; nothing partial is saved.
+        } catch { failures += 1 }
+        if !Task.isCancelled { await store.save(cache, identity: identity) }
+        let recent = turns.filter { $0.createdAt >= cutoff && $0.createdAt <= now }
+        let complete = streamsFinished == 2 && failures == 0 && !Task.isCancelled
+        let summary = ChatGPTChatHistorySummary(queriedAt: now, observedFrom: cutoff, complete: complete,
+                                                conversationsRead: read, excludedWorkConversations: work,
+                                                unclassifiedTurns: unknown, failedConversations: failures)
+        return Result(turns: recent, summary: summary)
+    }
+}

--- a/Sources/VibeBarCore/Storage/VibeBarLocalStore.swift
+++ b/Sources/VibeBarCore/Storage/VibeBarLocalStore.swift
@@ -40,6 +40,7 @@ public enum VibeBarLocalStore {
     }
 
     public static var chatGPTChatLearningURL: URL { baseDirectory.appendingPathComponent("chatgpt_chat_learning.json") }
+    public static var chatGPTChatHistoryURL: URL { baseDirectory.appendingPathComponent("chatgpt_chat_history.json") }
 
     public static var openAIWebViewCookieURL: URL {
         baseDirectory

--- a/Tests/VibeBarCoreTests/ChatGPTChatTests.swift
+++ b/Tests/VibeBarCoreTests/ChatGPTChatTests.swift
@@ -91,20 +91,266 @@ final class ChatGPTChatTests: XCTestCase {
         XCTAssertNil(result["image_gen"]?.quantity.limit)
     }
 
-    func testClientReusesPlanEndpointAndDoesNotReadModelsOrConversations() async throws {
+    func testClientReusesPlanEndpointAndReadsHistoryOnlyWhenAsked() async throws {
         let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         defer { try? FileManager.default.removeItem(at: directory) }
         let transport = ChatFixtureTransport()
-        let client = ChatGPTChatClient(transport: transport, store: ChatGPTChatAllowanceStore(url: directory.appendingPathComponent("learning.json")))
+        let client = ChatGPTChatClient(transport: transport, store: ChatGPTChatAllowanceStore(url: directory.appendingPathComponent("learning.json")),
+                                       historyStore: ChatGPTChatHistoryStore(url: directory.appendingPathComponent("history.json")))
         let quota = try await client.fetch(account: AccountIdentity(id: "local", tool: .chatgptChat, source: .webCookie), settings: .init(), now: base)
         XCTAssertEqual(quota.plan, "prolite")
         XCTAssertEqual(quota.buckets.map(\.id), ["image_gen", "deep_research"])
         XCTAssertTrue(quota.buckets.allSatisfy { !$0.hasPercentage })
+        XCTAssertNil(quota.chatGPTChat?.history)
         let calls = await transport.calls
         XCTAssertEqual(calls, ["/api/auth/session", "/backend-api/wham/usage", "/backend-api/conversation/init"])
-        for path in ["/backend-api/conversations", "/backend-api/models", "/backend-api/conversation/00000000-0000-4000-8000-000000000000"] {
-            XCTAssertFalse(ChatGPTChatRequestPolicy.allows(path: path, method: "GET"))
+        XCTAssertFalse(ChatGPTChatRequestPolicy.allows(path: "/backend-api/models", method: "GET"))
+
+        // Asked to count Pro messages, the same client walks the saved list
+        // and gets the plan's shared weekly allowance, complete at zero.
+        var settings = ChatGPTChatSettings()
+        settings.trackProModels = true
+        let counted = try await client.fetch(account: AccountIdentity(id: "local", tool: .chatgptChat, source: .webCookie), settings: settings, now: base)
+        XCTAssertEqual(counted.buckets.map(\.id), ["image_gen", "deep_research", "pro_weekly"])
+        let pro = try XCTUnwrap(counted.buckets.last)
+        XCTAssertEqual(pro.quantity?.used, 0)
+        XCTAssertEqual(pro.quantity?.remaining, 50)
+        XCTAssertEqual(pro.quantity?.limit, 50)
+        XCTAssertTrue(pro.hasPercentage)
+        XCTAssertEqual(pro.rawWindowSeconds, 7 * 86_400)
+        XCTAssertEqual(counted.chatGPTChat?.history?.complete, true)
+        let later = await transport.calls
+        XCTAssertEqual(later.filter { $0.hasPrefix("/backend-api/conversations?") }.count, 2)
+    }
+
+    // MARK: - Pro models
+
+    private func conversationData(id: String, origin: String? = nil, defaultModel: String? = nil, nodes: [[String: Any]]) throws -> Data {
+        var mapping: [String: Any] = ["root": ["id": "root", "message": NSNull(), "parent": NSNull()]]
+        for node in nodes { mapping[node["id"] as! String] = node }
+        var root: [String: Any] = ["conversation_id": id, "mapping": mapping]
+        if let origin { root["conversation_origin"] = origin }
+        if let defaultModel { root["default_model_slug"] = defaultModel }
+        return try JSONSerialization.data(withJSONObject: root)
+    }
+
+    private func node(_ id: String, parent: String, role: String, at: TimeInterval, model: String? = nil,
+                      type: String = "text", recipient: String = "all", status: String = "finished_successfully") -> [String: Any] {
+        var metadata: [String: Any] = ["request_id": "req-" + id]
+        if let model { metadata["model_slug"] = model; metadata["resolved_model_slug"] = model }
+        return ["id": id, "parent": parent, "message": [
+            "id": "msg-" + id, "author": ["role": role], "create_time": base.timeIntervalSince1970 + at,
+            "status": status, "recipient": recipient, "content": ["content_type": type, "parts": ["secret body " + id]],
+            "metadata": metadata]]
+    }
+
+    func testConversationChargesEachUserTurnToItsFinalAnswerOnce() throws {
+        let data = try conversationData(id: "c1", nodes: [
+            node("u1", parent: "root", role: "user", at: 100),
+            node("t1", parent: "u1", role: "tool", at: 101, model: "gpt-6-pro"),
+            node("a1-thoughts", parent: "t1", role: "assistant", at: 105, model: "gpt-6-pro", type: "thoughts"),
+            node("a1", parent: "a1-thoughts", role: "assistant", at: 110, model: "gpt-6-pro"),
+            node("a1-retry", parent: "t1", role: "assistant", at: 120, model: "gpt-6-pro"),
+            node("u2", parent: "a1", role: "user", at: 200),
+            node("a2", parent: "u2", role: "assistant", at: 210, model: "gpt-5-6-thinking", type: "multimodal_text"),
+            node("u-old", parent: "a2", role: "user", at: 20),
+            node("a-old", parent: "u-old", role: "assistant", at: 25, model: "gpt-6-pro"),
+            node("u3", parent: "a-old", role: "user", at: 300),
+            node("a3", parent: "u3", role: "assistant", at: 305, model: "gpt-6-pro", status: "in_progress")
+        ])
+        let parsed = try ChatGPTChatParser.conversation(data, id: "c1", updatedAt: base, since: base.addingTimeInterval(60))
+        XCTAssertFalse(parsed.isWork)
+        XCTAssertEqual(parsed.turns.count, 2, "a retried answer and a turn before the window add nothing")
+        XCTAssertEqual(Set(parsed.turns.map(\.model)), ["gpt-6-pro", "gpt-5-6-thinking"])
+        XCTAssertEqual(parsed.unclassifiedTurns, 1, "an unanswered turn is reported, not guessed")
+        for turn in parsed.turns {
+            XCTAssertFalse(turn.id.contains("msg-"), "turn ids are hashed")
+            XCTAssertFalse(turn.id.contains("secret"))
         }
+        let encoded = String(decoding: try JSONEncoder().encode(parsed), as: UTF8.self)
+        XCTAssertFalse(encoded.contains("secret body"), "no message text is retained")
+        XCTAssertThrowsError(try ChatGPTChatParser.conversation(data, id: "other", updatedAt: base, since: base))
+    }
+
+    func testWorkConversationsAndWorkModelsAreNeverChargedToChat() throws {
+        let work = try conversationData(id: "w1", origin: "tpp", nodes: [
+            node("u1", parent: "root", role: "user", at: 100),
+            node("a1", parent: "u1", role: "assistant", at: 110, model: "gpt-6-pro")
+        ])
+        let parsedWork = try ChatGPTChatParser.conversation(work, id: "w1", updatedAt: base, since: base)
+        XCTAssertTrue(parsedWork.isWork)
+        XCTAssertTrue(parsedWork.turns.isEmpty)
+
+        let mixed = try conversationData(id: "m1", nodes: [
+            node("u1", parent: "root", role: "user", at: 100),
+            node("a1", parent: "u1", role: "assistant", at: 110, model: "gpt-6-astra-wm"),
+            node("u2", parent: "a1", role: "user", at: 200),
+            node("a2", parent: "u2", role: "assistant", at: 210, model: "gpt-5-6-pro")
+        ])
+        let parsedMixed = try ChatGPTChatParser.conversation(mixed, id: "m1", updatedAt: base, since: base)
+        XCTAssertEqual(parsedMixed.turns.map(\.model), ["gpt-5-6-pro"])
+        XCTAssertEqual(parsedMixed.unclassifiedTurns, 0)
+
+        XCTAssertTrue(ChatGPTChatParser.isWork(origin: "flora", model: nil))
+        XCTAssertTrue(ChatGPTChatParser.isWork(origin: nil, model: "gpt-5.6-sol-wm"))
+        XCTAssertFalse(ChatGPTChatParser.isWork(origin: nil, model: "gpt-6-pro"))
+    }
+
+    func testModelLimitsFollowTheClientSchemaAndDropExpiredEntries() throws {
+        let future = ISO8601DateFormatter().string(from: base.addingTimeInterval(3_600))
+        let past = ISO8601DateFormatter().string(from: base.addingTimeInterval(-3_600))
+        let data = Data("""
+        {"model_limits":[
+          {"model_slug":"gpt-6-pro","resets_after":"\(future)","using_default_model_slug":"gpt-5-6-thinking","description":null},
+          {"model_slug":"gpt-5-6-pro","resets_after":"\(past)","using_default_model_slug":"gpt-5-6-thinking"},
+          {"resets_after":"\(future)"}
+        ],"limits_progress":[]}
+        """.utf8)
+        let limits = ChatGPTChatParser.modelLimits(data, now: base)
+        XCTAssertEqual(limits.map(\.model), ["gpt-6-pro"])
+        XCTAssertEqual(limits.first?.resetsAt, base.addingTimeInterval(3_600))
+        XCTAssertEqual(limits.first?.fallbackModel, "gpt-5-6-thinking")
+        XCTAssertTrue(ChatGPTChatParser.modelLimits(Data("{}".utf8), now: base).isEmpty)
+    }
+
+    func testProAllowancesFollowThePublishedPlanTable() {
+        let pro = ChatGPTChatProAllowances.allowances(plan: "pro")
+        XCTAssertEqual(pro.map(\.id), ["gpt6_pro_weekly", "sol_pro_daily", "pro_daily"])
+        XCTAssertEqual(pro.map(\.limit), [200, 170, 200])
+        XCTAssertEqual(pro.map(\.windowSeconds), [7 * 86_400, 86_400, 86_400])
+        XCTAssertEqual(pro[0].models, ["gpt-6-pro"])
+        XCTAssertEqual(pro[1].models, ["gpt-5-6-pro"])
+        XCTAssertEqual(pro[2].models, ["gpt-6-pro", "gpt-5-6-pro"])
+        let lite = ChatGPTChatProAllowances.allowances(plan: "prolite")
+        XCTAssertEqual(lite.map(\.id), ["pro_weekly"])
+        XCTAssertEqual(lite.first?.limit, 50)
+        XCTAssertEqual(lite.first?.models, ["gpt-6-pro", "gpt-5-6-pro"])
+        XCTAssertTrue(ChatGPTChatProAllowances.allowances(plan: "plus").isEmpty)
+        XCTAssertTrue(ChatGPTChatProAllowances.allowances(plan: nil).isEmpty)
+        let ids = Set(MenuBarFieldCatalog.chatGPTChatFields.map(\.bucketId))
+        for allowance in pro + lite { XCTAssertTrue(ids.contains(allowance.id), allowance.id) }
+    }
+
+    func testProBucketsCountATrailingWindowAndHonourServiceThrottles() {
+        func turn(_ model: String, ago: TimeInterval) -> ChatGPTChatTurn {
+            ChatGPTChatTurn(id: "\(model)-\(ago)", createdAt: base.addingTimeInterval(-ago), model: model)
+        }
+        let turns = [
+            turn("gpt-6-pro", ago: 3_600), turn("gpt-6-pro", ago: 3 * 86_400), turn("gpt-6-pro", ago: 7 * 86_400 - 1),
+            turn("gpt-6-pro", ago: 8 * 86_400),
+            turn("gpt-5-6-pro", ago: 600), turn("gpt-5-6-pro", ago: 7_200), turn("gpt-5-6-pro", ago: 2 * 86_400),
+            turn("gpt-5-6-thinking", ago: 60)
+        ] + [turn("gpt-5-6-pro", ago: 600)]
+        let pro = ChatGPTChatProAllowances.allowances(plan: "pro")
+        let buckets = ChatGPTChatParser.proBuckets(allowances: pro, turns: turns, limits: [], complete: true, now: base)
+        XCTAssertEqual(buckets.map(\.id), ["gpt6_pro_weekly", "sol_pro_daily", "pro_daily"])
+        XCTAssertEqual(buckets[0].quantity?.used, 3)
+        XCTAssertEqual(buckets[0].quantity?.remaining, 197)
+        XCTAssertEqual(buckets[0].usedPercent, 1.5)
+        XCTAssertEqual(buckets[1].quantity?.used, 2, "a duplicate turn id counts once")
+        XCTAssertEqual(buckets[1].quantity?.remaining, 168)
+        XCTAssertEqual(buckets[2].quantity?.used, 3)
+        XCTAssertNil(buckets[0].resetAt, "no window start is known, so no reset is claimed")
+        XCTAssertTrue(buckets.allSatisfy { $0.quantity?.isEstimated == true && $0.hasPercentage })
+
+        let partial = ChatGPTChatParser.proBuckets(allowances: pro, turns: turns, limits: [], complete: false, now: base)
+        XCTAssertEqual(partial[0].quantity?.used, 3)
+        XCTAssertNil(partial[0].quantity?.remaining)
+        XCTAssertFalse(partial[0].hasPercentage, "a partial count is not a percentage")
+
+        let reset = base.addingTimeInterval(5 * 3_600)
+        let oneLimited = ChatGPTChatParser.proBuckets(allowances: pro, turns: turns,
+            limits: [ChatGPTChatModelLimit(model: "gpt-6-pro", resetsAt: reset, fallbackModel: "gpt-5-6-thinking")], complete: false, now: base)
+        XCTAssertEqual(oneLimited[0].quantity?.used, 200)
+        XCTAssertEqual(oneLimited[0].quantity?.remaining, 0)
+        XCTAssertEqual(oneLimited[0].usedPercent, 100)
+        XCTAssertEqual(oneLimited[0].resetAt, reset)
+        XCTAssertTrue(oneLimited[0].hasPercentage, "the service's exhausted state needs no history")
+        XCTAssertEqual(oneLimited[2].quantity?.used, 3, "one throttled model does not exhaust a shared allowance")
+        XCTAssertNil(oneLimited[2].resetAt)
+
+        let bothLimited = ChatGPTChatParser.proBuckets(allowances: pro, turns: turns, limits: [
+            ChatGPTChatModelLimit(model: "gpt-6-pro", resetsAt: reset, fallbackModel: nil),
+            ChatGPTChatModelLimit(model: "gpt-5-6-pro", resetsAt: base.addingTimeInterval(3_600), fallbackModel: nil)
+        ], complete: true, now: base)
+        XCTAssertEqual(bothLimited[2].quantity?.remaining, 0)
+        XCTAssertEqual(bothLimited[2].resetAt, reset)
+    }
+
+    func testRequestPolicyAdmitsOnlyTheHistoryReadsTheCounterMakes() {
+        let detail = "/backend-api/conversation/00000000-0000-4000-8000-000000000000"
+        XCTAssertTrue(ChatGPTChatRequestPolicy.allows(path: "/backend-api/conversations?offset=0&limit=50&order=updated&is_archived=false", method: "GET"))
+        XCTAssertTrue(ChatGPTChatRequestPolicy.allows(path: "/backend-api/conversations", method: "GET"))
+        XCTAssertTrue(ChatGPTChatRequestPolicy.allows(path: detail, method: "GET"))
+        for path in ["/backend-api/conversations?search=secret", "/backend-api/conversations/other",
+                     detail + "?x=1", "/backend-api/conversation/not-a-uuid", "/backend-api/conversation/",
+                     "/backend-api/models", "/backend-api/conversation/00000000-0000-4000-8000-000000000000/share"] {
+            XCTAssertFalse(ChatGPTChatRequestPolicy.allows(path: path, method: "GET"), path)
+        }
+        XCTAssertFalse(ChatGPTChatRequestPolicy.allows(path: "/backend-api/conversations", method: "POST"))
+        XCTAssertFalse(ChatGPTChatRequestPolicy.allows(path: detail, method: "DELETE"))
+    }
+
+    func testHistoryReaderFetchesAChangedConversationOnceAndReportsCoverage() async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = ChatGPTChatHistoryStore(url: directory.appendingPathComponent("history.json"))
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let chat = "11111111-1111-4111-8111-111111111111"
+        let work = "22222222-2222-4222-8222-222222222222"
+        let stale = "33333333-3333-4333-8333-333333333333"
+        func list(chatUpdated: Date) -> Data {
+            let items: [[String: Any]] = [
+                ["id": chat, "update_time": iso.string(from: chatUpdated), "conversation_origin": NSNull(), "is_temporary_chat": false],
+                ["id": work, "update_time": iso.string(from: base.addingTimeInterval(-7_200)), "conversation_origin": "tpp"],
+                ["id": stale, "update_time": iso.string(from: base.addingTimeInterval(-9 * 86_400)), "conversation_origin": NSNull()]
+            ]
+            return try! JSONSerialization.data(withJSONObject: ["items": items, "total": 3, "limit": 50, "offset": 0])
+        }
+        let empty = Data(#"{"items":[],"total":0,"limit":50,"offset":0}"#.utf8)
+        let detail = try conversationData(id: chat, nodes: [
+            node("u1", parent: "root", role: "user", at: -3_600),
+            node("a1", parent: "u1", role: "assistant", at: -3_500, model: "gpt-6-pro")
+        ])
+        let transport = HistoryFixtureTransport(responses: [
+            "/backend-api/conversations?offset=0&limit=50&order=updated&is_archived=false": list(chatUpdated: base.addingTimeInterval(-3_500)),
+            "/backend-api/conversations?offset=0&limit=50&order=updated&is_archived=true": empty,
+            "/backend-api/conversation/" + chat: detail
+        ])
+        let reader = ChatGPTChatHistoryReader(transport: transport, store: store)
+
+        let first = await reader.read(bearer: nil, identity: "acct", now: base)
+        XCTAssertEqual(first.turns.map(\.model), ["gpt-6-pro"])
+        XCTAssertTrue(first.summary.complete)
+        XCTAssertEqual(first.summary.conversationsRead, 1)
+        XCTAssertEqual(first.summary.excludedWorkConversations, 1)
+        XCTAssertEqual(first.summary.failedConversations, 0)
+        XCTAssertEqual(first.summary.observedFrom, base.addingTimeInterval(-7 * 86_400))
+        var calls = await transport.calls
+        XCTAssertEqual(calls.filter { $0.hasPrefix("/backend-api/conversation/") }, ["/backend-api/conversation/" + chat],
+                       "a Work row and a row older than the window are never fetched")
+
+        // Unchanged revision: the cache answers and the transcript is not read again.
+        let second = await reader.read(bearer: nil, identity: "acct", now: base.addingTimeInterval(600))
+        XCTAssertEqual(second.turns.count, 1)
+        XCTAssertTrue(second.summary.complete)
+        calls = await transport.calls
+        XCTAssertEqual(calls.filter { $0.hasPrefix("/backend-api/conversation/") }.count, 1)
+
+        // A new revision is fetched again; a failed fetch leaves the count marked partial.
+        await transport.set("/backend-api/conversations?offset=0&limit=50&order=updated&is_archived=false", list(chatUpdated: base.addingTimeInterval(-100)))
+        await transport.set("/backend-api/conversation/" + chat, nil)
+        let third = await reader.read(bearer: nil, identity: "acct", now: base.addingTimeInterval(1_200))
+        XCTAssertFalse(third.summary.complete)
+        XCTAssertEqual(third.summary.failedConversations, 1)
+        XCTAssertEqual(third.turns.count, 1, "the cached turns still count while the new revision is unread")
+        calls = await transport.calls
+        XCTAssertEqual(calls.filter { $0.hasPrefix("/backend-api/conversation/") }.count, 2)
+
+        let cached = String(decoding: try Data(contentsOf: directory.appendingPathComponent("history.json")), as: UTF8.self)
+        XCTAssertFalse(cached.contains("secret body"))
+        XCTAssertFalse(cached.contains(chat), "conversation ids are hashed at rest")
     }
 
     func testMenuBarDefaultSwitchesFromEstimatedCountToPercentage() {
@@ -121,10 +367,24 @@ final class ChatGPTChatTests: XCTestCase {
     func testLegacySettingsDecodeWithoutRestoringModelTracking() throws {
         let settings = try JSONDecoder().decode(ChatGPTChatSettings.self, from: Data(#"{"enabled":true,"includeHistory":true,"astraWeeklyLimit":200}"#.utf8))
         XCTAssertTrue(settings.enabled)
+        XCTAssertFalse(settings.trackProModels, "counting Pro messages is opt-in, and an old history flag does not opt in")
         let data = try JSONSerialization.jsonObject(with: JSONEncoder().encode(settings)) as! [String: Any]
-        XCTAssertEqual(Set(data.keys), ["enabled"])
-        XCTAssertEqual(MenuBarFieldCatalog.chatGPTChatFields.count, 2)
+        XCTAssertEqual(Set(data.keys), ["enabled", "trackProModels"])
+        XCTAssertEqual(MenuBarFieldCatalog.chatGPTChatFields.count, 6)
         XCTAssertEqual(ToolType.codex.coreProviderMembers.first, .chatgptChat)
+    }
+}
+
+private actor HistoryFixtureTransport: ChatGPTChatTransport {
+    nonisolated let name = "history-fixture"
+    private(set) var calls: [String] = []
+    private var responses: [String: Data]
+    init(responses: [String: Data]) { self.responses = responses }
+    func set(_ path: String, _ data: Data?) { responses[path] = data }
+    func request(path: String, method: String, bearer: String?, body: Data?) async throws -> Data {
+        calls.append(path)
+        guard let data = responses[path] else { throw QuotaError.network("fixture has no \(path)") }
+        return data
     }
 }
 
@@ -133,6 +393,7 @@ private actor ChatFixtureTransport: ChatGPTChatTransport {
     private(set) var calls: [String] = []
     func request(path: String, method: String, bearer: String?, body: Data?) async throws -> Data {
         calls.append(path)
+        if path.hasPrefix("/backend-api/conversations?") { return Data(#"{"items":[],"total":0,"limit":50,"offset":0}"#.utf8) }
         switch path {
         case "/api/auth/session": return Data(#"{"accessToken":"synthetic-token","user":{"id":"synthetic-user"}}"#.utf8)
         case "/backend-api/wham/usage": return Data(#"{"plan_type":"prolite"}"#.utf8)

--- a/docs/chatgpt-chat.md
+++ b/docs/chatgpt-chat.md
@@ -1,8 +1,10 @@
 # ChatGPT Chat allowances
 
 ChatGPT Chat appears above ChatGPT Agentic under OpenAI. It tracks Image
-Generation and Deep Research only. Enable it in OpenAI settings and use the
-existing browser import or built-in login. No browser extension is required.
+Generation and Deep Research, and — when asked to — the GPT-6 Pro and
+GPT-5.6 Sol Pro message allowances. Enable it in OpenAI settings; a Codex
+login is enough, and the existing browser import or built-in login works
+too. No browser extension is required.
 
 ## Learning totals
 
@@ -24,6 +26,42 @@ remaining count. Once the total and window are learned, the source returns a nor
 bucket. The existing primary-provider quota row, forecast bar, pace, history,
 menu bar, and mini-window paths handle it without a separate Chat presentation.
 Learning state uses the same bar height and track, with indeterminate fill.
+
+## Pro model messages
+
+The service reports no count for GPT-6 Pro or GPT-5.6 Sol Pro. Its
+`conversation/init` reply names a model only once it is exhausted
+(`model_limits`: `model_slug`, `resets_after`, `using_default_model_slug`),
+and `/backend-api/models` carries no allowance fields. What OpenAI publishes
+is the total per plan, in "GPT-5.6 and GPT-6 Pro in ChatGPT" (help article
+20001354, read 2026-09-07):
+
+| Plan | GPT-6 Pro | GPT-5.6 Sol Pro |
+| --- | --- | --- |
+| Pro $200 (`pro`) | 200 messages per week | 170 per day; both models together 200 per day |
+| Pro $100 (`prolite`) | one shared allowance of 50 messages per week | |
+
+"Sync saved Chat history across devices" in OpenAI settings turns the count
+on. It is off by default. The reader lists the account's saved conversations
+newest first, stops at the first one not updated inside the last week, skips
+Work rows (`conversation_origin` `tpp` or `flora`) and temporary chats, and
+fetches only conversations whose revision changed, at most 24 per refresh
+and within 25 seconds. Each user turn is charged to the model of its final
+answer, once, however often it was regenerated. Only hashed ids, times and
+model slugs are cached, under `~/.vibebar/chatgpt_chat_history.json`.
+
+The service states no window start, so each bucket is the count inside a
+trailing window ending now, against the published total, marked estimated.
+While part of the window is unread — the budget ran out, a fetch failed, or
+the list was cut short — the row shows the count and "history sync is
+incomplete" instead of a percentage. A throttled model overrides the count
+with the service's own exhausted state and reset time; a shared allowance
+is treated as exhausted only when every model it covers is.
+
+Plans other than `pro` and `prolite` get no Pro buckets, because the table
+above does not cover them. Temporary chats, deleted conversations and turns
+whose answer never finished are not counted; the settings pane reports the
+excluded Work conversations and unclassified turns.
 
 ## Subscription labels
 
@@ -61,5 +99,5 @@ The review app has a separate identity, `com.astroqore.VibeBar.ChatReview`, and
 uses synthetic data with provider polling disabled. It coexists with the
 installed app. No merge or release is implied by building this demo.
 
-The app pins localization catalog 0.6.0, including the allowance, reset-record,
-and subscription-format strings.
+The localization catalog carries the allowance, reset-record, history,
+and subscription-format strings; see `Package.swift` for the pinned version.


### PR DESCRIPTION
The service reports no count for GPT-6 Pro or GPT-5.6 Sol Pro. `conversation/init` names a model only once it is exhausted, `/backend-api/models` carries no allowance field, and every other candidate endpoint is a 403 challenge page or a 404 (probed live with the Codex bearer, 2026-09-07). What OpenAI publishes is the total per plan. So the count now comes from the account's saved history, and the total from that table.

## What changes

- `ChatGPTChatSettings.trackProModels` (off by default) turns the count on; the OpenAI settings pane exposes it as the existing "Sync saved Chat history across devices" toggle with the privacy and estimate captions the catalog already had, plus the coverage line.
- `ChatGPTChatHistoryReader` walks `/backend-api/conversations` newest first inside a one-week window, skips Work rows and temporary chats from the list alone, fetches only conversations whose revision changed (24 per refresh, 25 s), and caches hashed ids, times and model slugs under `~/.vibebar/chatgpt_chat_history.json`. Unread parts of the window are reported, never hidden.
- `ChatGPTChatParser.conversation` charges each user turn to the model of its final answer, once, however often it was regenerated; the user message itself names no model. `modelLimits` reads `model_limits` the way the ChatGPT client's own schema does (`model_slug`, `resets_after`, `using_default_model_slug`, kept only while the reset lies ahead).
- `ChatGPTChatProAllowances` holds the published totals per `plan_type` — `pro`: 200/week GPT-6 Pro, 170/day Sol Pro, 200/day for both; `prolite`: 50/week shared (help article 20001354, read 2026-09-07). Other plans get no Pro buckets rather than a guessed total.
- Buckets are trailing-window counts marked estimated with no claimed reset. A throttled model overrides its bucket with the service's exhausted state and reset; a shared allowance is exhausted only when every model it covers is. Partial coverage shows the count and "history sync is incomplete" instead of a percentage.
- All Chat transports send a browser user agent: chatgpt.com's edge serves the history endpoints only to one (a CLI or app string gets the challenge page) and accepts it on every other Chat endpoint — so the Codex OAuth login reads the history too, with no cookie.
- `ChatGPTChatRequestPolicy` admits the list with paging fields only and single conversations by UUID; `/backend-api/models` stays out.
- Four menu bar fields, the MCP chat-allowance DTO's history fields, the probe's `--pro` flag, and docs (`docs/chatgpt-chat.md`, AGENTS.md).

## Verification

- `swift build`; `swift test`: 2346 tests, 3 skipped, 0 failures; `./Scripts/build_app.sh release`; `codesign -d --entitlements -` → empty dict; no sandbox container.
- Live probe on the packaged build (`--chatgpt-chat-probe --pro`) against a Pro $200 account through the Codex OAuth bearer: transport `oauth`, plan `pro`, GPT-6 Pro · Weekly 6/200, GPT-5.6 Sol Pro · Daily 0/170, Pro Models · Daily 4/200, history complete, 2 Work conversations excluded, 2 unclassified turns, 21 conversations cached with hashed ids only. First read 31 s (19 transcripts), the cached re-read a few seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
