### PR TITLE
Let the Workbench timelines record ChatGPT Chat's buckets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1027,7 +1027,10 @@ under `~/.vibebar/chatgpt_chat_learning.json`.
 
 `QuotaBucket.quantity` carries the count and learned total. Once the total and
 window are learned, the bucket enters the same percentage forecast, pace and
-history pipeline as other primary providers. Learning is a state of the standard
+history pipeline as other primary providers, including the Workbench fill and
+forecast timelines (`UsageFillTimelineStore` / `UsageForecastTimelineStore`
+take every `dedicatedCardProviders` member; buckets without a percentage are
+never stored as zero). Learning is a state of the standard
 quota row, not a separate Chat card implementation. Completed reset
 cycles retain `resetDetails` in `SubscriptionHistoryStore`, and verified Codex
 redemption receipts are retained separately in the same history file. A reduced

--- a/Sources/VibeBarCore/Services/UsageFillTimelineStore.swift
+++ b/Sources/VibeBarCore/Services/UsageFillTimelineStore.swift
@@ -47,7 +47,11 @@ public actor UsageFillTimelineStore {
     /// Defensive cap on the legacy import: a JSON file past this size is
     /// corrupt, not legitimate history.
     private static let maxLegacyFileBytes = 24 * 1024 * 1024
-    private static let supportedTools: Set<ToolType> = [.codex, .claude, .gemini, .antigravity, .grok, .cursor]
+    /// The providers with a dedicated card, ChatGPT Chat included. The list
+    /// used to be written out by hand and missed a provider twice: Cursor
+    /// when it was promoted, and Chat from the day it was added, whose
+    /// learned and counted buckets never reached the Workbench timelines.
+    private static let supportedTools = Set(ToolType.dedicatedCardProviders)
 
     public init(fileURL: URL = UsageFillTimelineStore.defaultFileURL(), legacyJSONURL: URL? = nil) {
         self.fileURL = fileURL

--- a/Sources/VibeBarCore/Services/UsageForecastTimelineStore.swift
+++ b/Sources/VibeBarCore/Services/UsageForecastTimelineStore.swift
@@ -50,7 +50,11 @@ public actor UsageForecastTimelineStore {
     /// Defensive cap on the legacy import: a JSON file past this size is
     /// corrupt, not legitimate history.
     private static let maxLegacyFileBytes = 24 * 1024 * 1024
-    private static let supportedTools: Set<ToolType> = [.codex, .claude, .gemini, .antigravity, .grok, .cursor]
+    /// The providers with a dedicated card, ChatGPT Chat included. The list
+    /// used to be written out by hand and missed a provider twice: Cursor
+    /// when it was promoted, and Chat from the day it was added, whose
+    /// learned and counted buckets never reached the Workbench timelines.
+    private static let supportedTools = Set(ToolType.dedicatedCardProviders)
 
     public init(fileURL: URL = UsageForecastTimelineStore.defaultFileURL(), legacyJSONURL: URL? = nil) {
         self.fileURL = fileURL

--- a/Tests/VibeBarCoreTests/UsageFillTimelineStoreTests.swift
+++ b/Tests/VibeBarCoreTests/UsageFillTimelineStoreTests.swift
@@ -131,6 +131,25 @@ final class UsageFillTimelineStoreTests: XCTestCase {
         XCTAssertTrue(points.isEmpty)
     }
 
+    /// Membership is the capability axis, not a list kept here: every
+    /// provider with a dedicated card is recorded, no Misc provider is.
+    func testEveryDedicatedCardProviderIsRecordedAndNoMiscProviderIs() async {
+        let store = UsageFillTimelineStore(fileURL: tempURL)
+        let now = Date(timeIntervalSince1970: 1_780_000_123)
+        for tool in ToolType.dedicatedCardProviders {
+            let account = "card-" + tool.rawValue
+            await store.observe(quota(tool: tool, accountId: account, buckets: [bucket(id: "weekly", used: 50)]), now: now)
+            let points = await store.points(accountId: account, bucketId: "weekly")
+            XCTAssertEqual(points.count, 1, "\(tool) has a dedicated card, so its buckets belong in the timeline")
+        }
+        for tool in ToolType.miscPageProviders {
+            let account = "misc-" + tool.rawValue
+            await store.observe(quota(tool: tool, accountId: account, buckets: [bucket(id: "weekly", used: 50)]), now: now)
+            let points = await store.points(accountId: account, bucketId: "weekly")
+            XCTAssertTrue(points.isEmpty, "\(tool) is a Misc provider and stays out")
+        }
+    }
+
     func testChatBucketsJoinTheTimelineOnceTheyHaveAPercentage() async {
         let store = UsageFillTimelineStore(fileURL: tempURL)
         let now = Date(timeIntervalSince1970: 1_780_000_123)

--- a/Tests/VibeBarCoreTests/UsageFillTimelineStoreTests.swift
+++ b/Tests/VibeBarCoreTests/UsageFillTimelineStoreTests.swift
@@ -131,6 +131,28 @@ final class UsageFillTimelineStoreTests: XCTestCase {
         XCTAssertTrue(points.isEmpty)
     }
 
+    func testChatBucketsJoinTheTimelineOnceTheyHaveAPercentage() async {
+        let store = UsageFillTimelineStore(fileURL: tempURL)
+        let now = Date(timeIntervalSince1970: 1_780_000_123)
+        // A counted Pro allowance has a percentage but no reset the service
+        // ever stated; a feature still learning its total has neither.
+        let counted = QuotaBucket(id: "gpt6_pro_weekly", title: "GPT-6 Pro · Weekly", shortLabel: "GPT-6 Pro",
+                                  usedPercent: 0, rawWindowSeconds: 604_800,
+                                  quantity: .init(used: 6, remaining: 194, limit: 200, isEstimated: true))
+        let learning = QuotaBucket(id: "image_gen", title: "Image Generation", shortLabel: "Image Generation",
+                                   usedPercent: 0, resetAt: now.addingTimeInterval(3_600),
+                                   quantity: .init(remaining: 998, isEstimated: true))
+        await store.observe(quota(tool: .chatgptChat, buckets: [counted, learning]), now: now)
+
+        let pro = await store.points(accountId: "acct-1", bucketId: "gpt6_pro_weekly")
+        XCTAssertEqual(pro.count, 1)
+        XCTAssertEqual(pro.first?.usedPercent, 3)
+        XCTAssertNil(pro.first?.resetAt)
+        XCTAssertEqual(pro.first?.rawWindowSeconds, 604_800)
+        let image = await store.points(accountId: "acct-1", bucketId: "image_gen")
+        XCTAssertTrue(image.isEmpty, "a bucket without a percentage is not stored as zero")
+    }
+
     func testPruneRespectsHorizon() async {
         let store = UsageFillTimelineStore(fileURL: tempURL)
         let old = Date(timeIntervalSince1970: 1_780_000_000)

--- a/Tests/VibeBarCoreTests/UsageForecastTimelineStoreTests.swift
+++ b/Tests/VibeBarCoreTests/UsageForecastTimelineStoreTests.swift
@@ -110,6 +110,15 @@ final class UsageForecastTimelineStoreTests: XCTestCase {
         XCTAssertTrue(points.isEmpty)
     }
 
+    func testChatForecastsAreRecordedLikeTheCoreProviders() async {
+        let store = UsageForecastTimelineStore(fileURL: tempURL)
+        await store.observe([observation(bucketId: "deep_research", projected: 40, windowSeconds: 30 * 86_400)],
+                            accountId: "acct-1", tool: .chatgptChat)
+        let points = await store.points(accountId: "acct-1", bucketId: "deep_research")
+        XCTAssertEqual(points.count, 1)
+        XCTAssertEqual(points.first?.projectedUsedPercent, 40)
+    }
+
     func testNonFiniteProjectionsAreDropped() async {
         let store = UsageForecastTimelineStore(fileURL: tempURL)
         await store.observe(

--- a/Tests/VibeBarCoreTests/UsageForecastTimelineStoreTests.swift
+++ b/Tests/VibeBarCoreTests/UsageForecastTimelineStoreTests.swift
@@ -110,6 +110,22 @@ final class UsageForecastTimelineStoreTests: XCTestCase {
         XCTAssertTrue(points.isEmpty)
     }
 
+    func testEveryDedicatedCardProviderIsRecordedAndNoMiscProviderIs() async {
+        let store = UsageForecastTimelineStore(fileURL: tempURL)
+        for tool in ToolType.dedicatedCardProviders {
+            let account = "card-" + tool.rawValue
+            await store.observe([observation(bucketId: "weekly", projected: 60)], accountId: account, tool: tool)
+            let points = await store.points(accountId: account, bucketId: "weekly")
+            XCTAssertEqual(points.count, 1, "\(tool) has a dedicated card, so its forecasts belong in the timeline")
+        }
+        for tool in ToolType.miscPageProviders {
+            let account = "misc-" + tool.rawValue
+            await store.observe([observation(bucketId: "weekly", projected: 60)], accountId: account, tool: tool)
+            let points = await store.points(accountId: account, bucketId: "weekly")
+            XCTAssertTrue(points.isEmpty, "\(tool) is a Misc provider and stays out")
+        }
+    }
+
     func testChatForecastsAreRecordedLikeTheCoreProviders() async {
         let store = UsageForecastTimelineStore(fileURL: tempURL)
         await store.observe([observation(bucketId: "deep_research", projected: 40, windowSeconds: 30 * 86_400)],


### PR DESCRIPTION
`UsageFillTimelineStore` and `UsageForecastTimelineStore` still carried the hand-written six-provider list from `ed7d8ed`. The reset-history store's copy of that list was replaced by `Set(ToolType.dedicatedCardProviders)` in `cad63fc` after Cursor's promotion slipped past it; these two copies were not, and ChatGPT Chat joined `dedicatedCardProviders` (#350) without reaching them. So a Chat bucket with a percentage — a learned Image Generation / Deep Research total, or a counted Pro allowance from #356 — never appeared in the Workbench's fill and forecast timelines, while the popover's cycle strip (which reads the reset-history store) already had it.

Both stores now derive their provider set from `dedicatedCardProviders`. Their loops already skip buckets without a percentage, so a feature still learning its total is not stored as zero; a test pins that for Chat.

## Verification

- `swift build`, `swift test` (full suite), `./Scripts/build_app.sh release`, `codesign -d --entitlements -` → empty dict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
