### PR TITLE
Bump the build number to 74 for the 1.6.2 Main release

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -26,7 +26,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.6.2</string>
 	<key>CFBundleVersion</key>
-	<string>73</string>
+	<string>74</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
Version stays 1.6.2; the build number moves past the last Dev build (73) so the Main promotion is never a downgrade. The tag `v1.6.2` follows the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)