### PR TITLE
Show Chat totals from the first read, and file its Pro lanes under their models

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -888,7 +888,7 @@ SubProvider → L3 quota / model group. Source of truth:
 | L1 company | L2 SubProvider        | L3 quota / model groups                  |
 | ---------- | --------------------- | ---------------------------------------- |
 | OpenAI     | ChatGPT Agentic       | All Models, Codex Spark …                 |
-| OpenAI     | ChatGPT Chat          | Image Generation, Deep Research, GPT-6 Pro · Weekly, GPT-5.6 Sol Pro · Daily, Pro Models · Daily/Weekly |
+| OpenAI     | ChatGPT Chat          | Image Generation, Deep Research, GPT-6 Astra Pro · Weekly, GPT-5.6 Sol Pro · Daily, Pro Models · Daily/Weekly |
 | Anthropic  | Claude                | All Models, Sonnet, Opus, Fable …         |
 | Google AI  | Gemini Web            | 5 Hours, Weekly                           |
 | Google AI  | AntiGravity           | Gemini Models, Claude & GPT Models        |
@@ -1004,12 +1004,14 @@ The GPT-6 Pro and GPT-5.6 Sol Pro allowances have no service count.
 `conversation/init` names a model in `model_limits` only once it is exhausted
 (`model_slug`, `resets_after`, `using_default_model_slug` — the ChatGPT
 client's own schema), and `/backend-api/models` carries no allowance field.
-With `ChatGPTChatSettings.trackProModels` on (off by default), the client
+With `ChatGPTChatSettings.trackProModels` on (the default), the client
 counts the account's saved conversations instead: `ChatGPTChatHistoryReader`
 walks `/backend-api/conversations` newest first inside a one-week window,
 skips Work rows and temporary chats, fetches only changed revisions (24 per
 refresh, 25 s), and `ChatGPTChatParser.conversation` charges each user turn
-to the model of its final answer, once. `ChatGPTChatProAllowances` holds the
+to the model of its final answer, once. The buckets file under the model as their L3 group (GPT-6 Astra Pro,
+GPT-5.6 Sol Pro, Pro Models) with the window (Weekly, Daily) as the row, the
+way Codex's Spark lanes are drawn. `ChatGPTChatProAllowances` holds the
 published totals per `plan_type` (`pro`: 200/week GPT-6 Pro, 170/day Sol Pro,
 200/day both; `prolite`: 50/week shared — help article 20001354, read
 2026-09-07); other plans get no Pro buckets. Counts are trailing-window
@@ -1019,11 +1021,18 @@ without a percentage. Only hashed ids, times and model slugs are cached, in
 `~/.vibebar/chatgpt_chat_history.json`. `ChatGPTChatRequestPolicy` admits the
 list with paging fields only and single conversations by UUID; nothing else.
 
-`ChatGPTChatAllowanceStore` learns a total only after three consistent observed
-reset boundaries. Initial reads, mismatches, missed boundaries, and account/plan
-changes withhold percentages; unknown totals use an indeterminate bar. No plan
-has a hardcoded feature total. The learned total and its samples live separately
-under `~/.vibebar/chatgpt_chat_learning.json`.
+`ChatGPTChatAllowanceStore` shows an *estimated* total from the first read —
+the largest remainder ever reported for the account and plan, with the
+service's distance to the reset (rounded to days or hours) as the window —
+and *confirms* it after three consistent observed reset boundaries, which
+takes the estimate mark off. A remainder above the total raises the estimate
+and withdraws the confirmation; an account/plan change starts over; a read
+that could not name the plan keeps what is known. No plan has a hardcoded
+feature total. The state lives under `~/.vibebar/chatgpt_chat_learning.json`.
+Both Chat switches default on (`ChatGPTChatSettings.defaultsVersion` applies
+new defaults once to older files); the Chat account is created only when a
+Codex OAuth login or a chatgpt.com web session exists
+(`AccountStore.hasChatGPTChatCredential`).
 
 `QuotaBucket.quantity` carries the count and learned total. Once the total and
 window are learned, the bucket enters the same percentage forecast, pace and

--- a/Scripts/demo_home.py
+++ b/Scripts/demo_home.py
@@ -71,6 +71,7 @@ FIXED_PRIMARY_IDS = {
     "oauth-grok": ("grok", "Grok OAuth", "oauthCLI"),
     "web-grok": ("grok", "Grok Web", "webCookie"),
     "misc-cursor": ("cursor", "Cursor", "cliDetected"),
+    "web-chatgpt-chat": ("chatgptChat", "ChatGPT Chat", "webCookie"),
 }
 CODEX_SOURCES = {"oauth-codex": "oauthCLI", "web-codex": "webCookie", "cli-codex": "cliDetected"}
 

--- a/Sources/VibeBarApp/Views/ChatGPTChatViews.swift
+++ b/Sources/VibeBarApp/Views/ChatGPTChatViews.swift
@@ -86,7 +86,7 @@ struct OpenAICombinedQuotaCard: View {
             }
             if settingsStore.settings.chatGPTChat.enabled {
                 subProviderHeader(.chatgptChat)
-                ProviderQuotaCard(tool: .chatgptChat, density: density, embedded: true, suppressGroupTitles: true)
+                ProviderQuotaCard(tool: .chatgptChat, density: density, embedded: true)
                 Divider()
             }
             subProviderHeader(.codex)

--- a/Sources/VibeBarApp/Views/QuotaBarShape.swift
+++ b/Sources/VibeBarApp/Views/QuotaBarShape.swift
@@ -5,9 +5,10 @@ struct QuotaBarShape: View {
     let percent: Double          // 0...100, value to render
     let mode: DisplayMode
     var height: CGFloat = 11
+    /// A bar with no percentage to show. It stays still: a track that keeps
+    /// moving asks for the eye and, over the popover's blur, for a frame
+    /// every tick.
     var indeterminate = false
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var sweeping = false
 
     var body: some View {
         GeometryReader { proxy in
@@ -17,16 +18,8 @@ struct QuotaBarShape: View {
                 Capsule(style: .continuous)
                     .fill(Theme.barTrack)
                 if indeterminate {
-                    if reduceMotion {
-                        Capsule(style: .continuous)
-                            .strokeBorder(.secondary.opacity(0.45), style: StrokeStyle(lineWidth: 1, dash: [3, 3]))
-                    } else {
-                        Capsule(style: .continuous)
-                            .fill(.secondary.opacity(0.45))
-                            .frame(width: max(height, width * 0.3))
-                            .offset(x: sweeping ? width : -width * 0.3)
-                            .animation(.linear(duration: 1.6).repeatForever(autoreverses: false), value: sweeping)
-                    }
+                    Capsule(style: .continuous)
+                        .strokeBorder(.secondary.opacity(0.4), style: StrokeStyle(lineWidth: 1, dash: [3, 3]))
                 } else {
                     Capsule(style: .continuous)
                         .fill(Theme.barColor(percent: percent, mode: mode))
@@ -36,8 +29,6 @@ struct QuotaBarShape: View {
             .clipShape(Capsule(style: .continuous))
         }
         .frame(height: height)
-        .onAppear { sweeping = indeterminate }
-        .onDisappear { sweeping = false }
     }
 }
 

--- a/Sources/VibeBarCore/Adapters/ChatGPTChatProModels.swift
+++ b/Sources/VibeBarCore/Adapters/ChatGPTChatProModels.swift
@@ -9,12 +9,17 @@ import Foundation
 /// and Codex have their own rules and are never charged here.
 public struct ChatGPTChatProAllowance: Hashable, Sendable {
     public let id: String
+    /// The L3 group the bucket files under — the model, as the picker names
+    /// it — so the card draws it the way it draws Codex's Spark lanes: the
+    /// model as a header, the window as the row.
+    public let group: String
+    /// The window, as the row's title: "Weekly" or "Daily".
     public let title: String
     public let models: Set<String>
     public let limit: Int
     public let windowSeconds: Int
-    public init(id: String, title: String, models: Set<String>, limit: Int, windowSeconds: Int) {
-        self.id = id; self.title = title; self.models = models; self.limit = limit; self.windowSeconds = windowSeconds
+    public init(id: String, group: String, title: String, models: Set<String>, limit: Int, windowSeconds: Int) {
+        self.id = id; self.group = group; self.title = title; self.models = models; self.limit = limit; self.windowSeconds = windowSeconds
     }
 }
 
@@ -24,6 +29,11 @@ public enum ChatGPTChatProAllowances {
     public static let solPro = "gpt-5-6-pro"
     public static let week = 7 * 86_400
     public static let day = 86_400
+    /// The names the help article and the picker use. GPT-6 Pro is
+    /// "powered by GPT-6 Astra"; the shared lane covers both Pro models.
+    public static let gpt6ProName = "GPT-6 Astra Pro"
+    public static let solProName = "GPT-5.6 Sol Pro"
+    public static let proModelsName = "Pro Models"
 
     /// `plan_type` as `/backend-api/wham/usage` reports it: `pro` is the
     /// $200 plan and `prolite` the $100 one. Plans without Pro models get
@@ -32,12 +42,12 @@ public enum ChatGPTChatProAllowances {
         switch plan?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
         case "pro":
             return [
-                ChatGPTChatProAllowance(id: "gpt6_pro_weekly", title: "GPT-6 Pro · Weekly", models: [gpt6Pro], limit: 200, windowSeconds: week),
-                ChatGPTChatProAllowance(id: "sol_pro_daily", title: "GPT-5.6 Sol Pro · Daily", models: [solPro], limit: 170, windowSeconds: day),
-                ChatGPTChatProAllowance(id: "pro_daily", title: "Pro Models · Daily", models: [gpt6Pro, solPro], limit: 200, windowSeconds: day)
+                ChatGPTChatProAllowance(id: "gpt6_pro_weekly", group: gpt6ProName, title: "Weekly", models: [gpt6Pro], limit: 200, windowSeconds: week),
+                ChatGPTChatProAllowance(id: "sol_pro_daily", group: solProName, title: "Daily", models: [solPro], limit: 170, windowSeconds: day),
+                ChatGPTChatProAllowance(id: "pro_daily", group: proModelsName, title: "Daily", models: [gpt6Pro, solPro], limit: 200, windowSeconds: day)
             ]
         case "prolite":
-            return [ChatGPTChatProAllowance(id: "pro_weekly", title: "Pro Models · Weekly", models: [gpt6Pro, solPro], limit: 50, windowSeconds: week)]
+            return [ChatGPTChatProAllowance(id: "pro_weekly", group: proModelsName, title: "Weekly", models: [gpt6Pro, solPro], limit: 50, windowSeconds: week)]
         default:
             return []
         }
@@ -198,7 +208,7 @@ extension ChatGPTChatParser {
             }
             return QuotaBucket(id: allowance.id, title: allowance.title, shortLabel: allowance.title,
                                usedPercent: quantity.usedPercent ?? 0, resetAt: resetAt,
-                               rawWindowSeconds: allowance.windowSeconds, quantity: quantity)
+                               rawWindowSeconds: allowance.windowSeconds, groupTitle: allowance.group, quantity: quantity)
         }
     }
 

--- a/Sources/VibeBarCore/Models/ChatGPTChatSettings.swift
+++ b/Sources/VibeBarCore/Models/ChatGPTChatSettings.swift
@@ -1,20 +1,36 @@
 import Foundation
 
 public struct ChatGPTChatSettings: Codable, Hashable, Sendable {
-    public var enabled = false
-    /// Count GPT-6 Pro and GPT-5.6 Sol Pro messages in the account's saved
-    /// conversation history against the allowances OpenAI publishes for the
-    /// plan. Off by default: it reads the model and time of every recent
-    /// message, which the feature allowances never need.
-    public var trackProModels = false
+    /// Bumped when a default changes for everyone. A file written under an
+    /// older version takes the new defaults once; a choice made after that
+    /// is kept. Version 1 (2026-09-07) turned both switches on.
+    public static let currentDefaultsVersion = 1
+    public var enabled = true
+    /// Count GPT-6 Astra Pro and GPT-5.6 Sol Pro messages in the account's
+    /// saved conversation history against the allowances OpenAI publishes
+    /// for the plan. It reads the model and time of every recent message;
+    /// no text is kept.
+    public var trackProModels = true
+    public var defaultsVersion = ChatGPTChatSettings.currentDefaultsVersion
     public init() {}
-    private enum CodingKeys: String, CodingKey { case enabled, trackProModels }
+    private enum CodingKeys: String, CodingKey { case enabled, trackProModels, defaultsVersion }
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
-        enabled = try c.decodeIfPresent(Bool.self, forKey: .enabled) ?? false
-        trackProModels = try c.decodeIfPresent(Bool.self, forKey: .trackProModels) ?? false
+        let version = try c.decodeIfPresent(Int.self, forKey: .defaultsVersion) ?? 0
+        if version >= Self.currentDefaultsVersion {
+            enabled = try c.decodeIfPresent(Bool.self, forKey: .enabled) ?? true
+            trackProModels = try c.decodeIfPresent(Bool.self, forKey: .trackProModels) ?? true
+        } else {
+            enabled = true
+            trackProModels = true
+        }
+        defaultsVersion = Self.currentDefaultsVersion
     }
-    public var sanitized: Self { self }
+    public var sanitized: Self {
+        var copy = self
+        copy.defaultsVersion = Self.currentDefaultsVersion
+        return copy
+    }
 }
 
 /// What one read of the saved history covered, so a count can say how much

--- a/Sources/VibeBarCore/Models/MenuBarSettings.swift
+++ b/Sources/VibeBarCore/Models/MenuBarSettings.swift
@@ -468,7 +468,7 @@ public enum MenuBarFieldCatalog {
     public static let chatGPTChatFields: [MenuBarFieldOption] = [
         option(.chatgptChat, "image_gen", "Image Generation", "Image Generation"),
         option(.chatgptChat, "deep_research", "Deep Research", "Deep Research"),
-        option(.chatgptChat, "gpt6_pro_weekly", "GPT-6 Pro · Weekly", "GPT-6 Pro"),
+        option(.chatgptChat, "gpt6_pro_weekly", "GPT-6 Astra Pro · Weekly", "Astra Pro"),
         option(.chatgptChat, "sol_pro_daily", "GPT-5.6 Sol Pro · Daily", "Sol Pro"),
         option(.chatgptChat, "pro_daily", "Pro Models · Daily", "Pro Daily"),
         option(.chatgptChat, "pro_weekly", "Pro Models · Weekly", "Pro Weekly")

--- a/Sources/VibeBarCore/Services/ChatGPTChatAllowanceLearning.swift
+++ b/Sources/VibeBarCore/Services/ChatGPTChatAllowanceLearning.swift
@@ -12,12 +12,27 @@ public struct ChatGPTChatAllowanceSample: Codable, Hashable, Sendable {
     }
 }
 
+/// What one feature's total is known to be.
+///
+/// The service reports a remainder and a reset, never a total. Two things
+/// stand in for it. From the first read, the largest remainder ever seen
+/// for this account and plan: the allowance is at least that, and on the
+/// day it refills it is exactly that. That is the estimate every read
+/// shows, so a monthly allowance has a percentage on day one instead of a
+/// season of "learning". Then, once three consistent reset boundaries have
+/// been watched, the total and its window are confirmed and the estimate
+/// mark comes off. A remainder above either figure raises the estimate and
+/// withdraws the confirmation, since the total was evidently larger.
 public struct ChatGPTChatAllowanceLearning: Codable, Sendable {
     public private(set) var previous: ChatGPTChatAllowanceSample?
+    /// The largest remainder reported so far. Never below a remainder that
+    /// was actually observed, so used = total − remaining cannot go negative.
+    public private(set) var observedMaximum: Int?
     public private(set) var candidateTotal: Int?
     public private(set) var matchingResets = 0
     public private(set) var candidateWindowSeconds: Int?
-    public var learnedWindowSeconds: Int? { matchingResets >= 3 ? candidateWindowSeconds : nil }
+    public var isConfirmed: Bool { matchingResets >= 3 && candidateWindowSeconds != nil && candidateTotal != nil }
+    public var learnedWindowSeconds: Int? { isConfirmed ? candidateWindowSeconds : nil }
 
     public init() {}
 
@@ -26,6 +41,7 @@ public struct ChatGPTChatAllowanceLearning: Codable, Sendable {
         if let previous, sample.observedAt <= previous.observedAt {
             return quantity(for: previous)
         }
+        observedMaximum = max(observedMaximum ?? 0, sample.remaining)
         if let previous, let oldReset = previous.resetAt, let newReset = sample.resetAt,
            newReset.timeIntervalSince(oldReset) > 60 {
             // An advancing date alone is not a refill: unused allowances can
@@ -60,16 +76,38 @@ public struct ChatGPTChatAllowanceLearning: Codable, Sendable {
         return quantity(for: sample)
     }
 
+    /// The window to show for a sample: the confirmed one, else the
+    /// service's own distance to the reset, rounded to whole days (or hours
+    /// for anything shorter than a day) so a read a minute into the window
+    /// does not shave the window.
+    public func windowSeconds(for sample: ChatGPTChatAllowanceSample) -> Int? {
+        if let learned = learnedWindowSeconds { return learned }
+        return Self.provisionalWindow(resetAt: sample.resetAt, observedAt: sample.observedAt)
+    }
+
+    static func provisionalWindow(resetAt: Date?, observedAt: Date) -> Int? {
+        guard let resetAt else { return nil }
+        let distance = resetAt.timeIntervalSince(observedAt)
+        guard distance > 0 else { return nil }
+        if distance >= 20 * 3_600 { return max(1, Int((distance / 86_400).rounded())) * 86_400 }
+        return max(1, Int((distance / 3_600).rounded())) * 3_600
+    }
+
     private func quantity(for sample: ChatGPTChatAllowanceSample) -> QuotaQuantity {
         let currentWindow = sample.resetAt.map { $0 > sample.observedAt } ?? false
-        let total = matchingResets >= 3 && candidateWindowSeconds != nil && currentWindow ? candidateTotal : nil
-        return QuotaQuantity(used: total.map { max(0, $0 - sample.remaining) },
-                             remaining: sample.remaining, limit: total, isEstimated: true)
+        let confirmed = isConfirmed && currentWindow
+        guard let total = confirmed ? candidateTotal : observedMaximum, total > 0 else {
+            return QuotaQuantity(remaining: sample.remaining, isEstimated: true)
+        }
+        return QuotaQuantity(used: max(0, total - sample.remaining), remaining: sample.remaining,
+                             limit: total, isEstimated: !confirmed)
     }
 }
 
-/// One current identity per local account. Switching accounts or changing any
-/// subscription identity starts over, including when switching back later.
+/// One current identity per local account. Switching accounts or changing
+/// plan starts over, including when switching back later. A read that could
+/// not name the plan keeps what is known rather than starting over, and
+/// the summary says the plan went unverified.
 public actor ChatGPTChatAllowanceStore {
     public static let shared = ChatGPTChatAllowanceStore()
     public struct Projection: Sendable {
@@ -89,14 +127,16 @@ public actor ChatGPTChatAllowanceStore {
         var all = (try? VibeBarLocalStore.readJSON([String: AccountState].self, from: url)) ?? [:]
         let key = ChatGPTChatParser.identity(localAccount)
         var state = all[key] ?? AccountState(identity: identity, plan: plan)
-        if state.identity != identity || state.plan != plan || plan == nil {
+        let planChanged = plan != nil && state.plan != nil && state.plan != plan
+        if state.identity != identity || planChanged {
             state = AccountState(identity: identity, plan: plan)
         }
+        if plan != nil { state.plan = plan }
         var result: [String: Projection] = [:]
         for sample in samples {
             var feature = state.features[sample.id] ?? ChatGPTChatAllowanceLearning()
             let quantity = feature.observe(sample)
-            result[sample.id] = Projection(quantity: quantity, windowSeconds: feature.learnedWindowSeconds)
+            result[sample.id] = Projection(quantity: quantity, windowSeconds: feature.windowSeconds(for: sample))
             state.features[sample.id] = feature
         }
         all[key] = state

--- a/Sources/VibeBarCore/Services/MockDataProvider.swift
+++ b/Sources/VibeBarCore/Services/MockDataProvider.swift
@@ -191,9 +191,20 @@ public enum MockDataProvider {
         case .chatgptChat:
             buckets = [
                 QuotaBucket(id: "image_gen", title: "Image Generation", shortLabel: "Image Generation", usedPercent: 0,
-                            resetAt: now.addingTimeInterval(36000), groupTitle: "Image Generation", quantity: .init(remaining: 998)),
+                            resetAt: now.addingTimeInterval(36000), rawWindowSeconds: 86_400,
+                            quantity: .init(used: 2, remaining: 998, limit: 1000, isEstimated: true)),
                 QuotaBucket(id: "deep_research", title: "Deep Research", shortLabel: "Deep Research", usedPercent: 0,
-                            resetAt: now.addingTimeInterval(1209600), groupTitle: "Deep Research", quantity: .init(remaining: 247))
+                            resetAt: now.addingTimeInterval(1209600), rawWindowSeconds: 30 * 86_400,
+                            quantity: .init(used: 3, remaining: 247, limit: 250, isEstimated: true)),
+                QuotaBucket(id: "gpt6_pro_weekly", title: "Weekly", shortLabel: "Weekly", usedPercent: 0,
+                            rawWindowSeconds: 7 * 86_400, groupTitle: "GPT-6 Astra Pro",
+                            quantity: .init(used: 6, remaining: 194, limit: 200, isEstimated: true)),
+                QuotaBucket(id: "sol_pro_daily", title: "Daily", shortLabel: "Daily", usedPercent: 0,
+                            rawWindowSeconds: 86_400, groupTitle: "GPT-5.6 Sol Pro",
+                            quantity: .init(used: 0, remaining: 170, limit: 170, isEstimated: true)),
+                QuotaBucket(id: "pro_daily", title: "Daily", shortLabel: "Daily", usedPercent: 0,
+                            rawWindowSeconds: 86_400, groupTitle: "Pro Models",
+                            quantity: .init(used: 4, remaining: 196, limit: 200, isEstimated: true))
             ]
         case .codex:
             // Match the spec example: 56% used / 13% used.

--- a/Sources/VibeBarCore/Storage/AccountStore.swift
+++ b/Sources/VibeBarCore/Storage/AccountStore.swift
@@ -55,7 +55,10 @@ public final class AccountStore: ObservableObject {
             return
         }
 
-        if chatGPTChatEnabled {
+        // Chat reads the Codex OAuth login or a chatgpt.com web session;
+        // with neither on this Mac the account could only ever say "needs
+        // login", so it waits for one rather than nagging the OpenAI card.
+        if chatGPTChatEnabled, Self.hasChatGPTChatCredential() {
             detected.append(AccountIdentity(id: "web-chatgpt-chat", tool: .chatgptChat, alias: "ChatGPT Chat", source: .webCookie))
         }
         if let codex = autoDetectCodex(mode: codexUsageMode) {
@@ -126,6 +129,12 @@ public final class AccountStore: ObservableObject {
     }
 
     // MARK: - CLI auto detection
+
+    static func hasChatGPTChatCredential() -> Bool {
+        (try? CodexCredentialReader.loadFromOAuth()) != nil
+            || (try? CodexCredentialReader.loadFromCLI()) != nil
+            || OpenAIWebCookieStore.cachedCookieHeader() != nil
+    }
 
     private func autoDetectCodex(mode: CodexUsageMode) -> AccountIdentity? {
         let order = CodexSourcePlanner.resolve(mode: mode)

--- a/Tests/VibeBarCoreTests/ChatGPTChatTests.swift
+++ b/Tests/VibeBarCoreTests/ChatGPTChatTests.swift
@@ -12,15 +12,26 @@ final class ChatGPTChatTests: XCTestCase {
         return learning.observe(sample(total, at: boundary + 10, reset: boundary + 86_400))
     }
 
-    func testRequiresThreeIndependentConsistentResetsAndNeverCountsInitialValue() {
+    func testFirstReadGivesAnEstimatedTotalAndThreeResetsConfirmIt() {
         var learning = ChatGPTChatAllowanceLearning()
-        XCTAssertNil(learning.observe(sample(1000, at: 0, reset: 86_400)).limit)
-        XCTAssertNil(cycle(1, total: 1000, learning: &learning).usedPercent)
-        XCTAssertNil(cycle(2, total: 1000, learning: &learning).usedPercent)
-        XCTAssertEqual(cycle(3, total: 1000, learning: &learning).limit, 1000)
+        // Day one: the remainder is the estimate, marked as one, with the
+        // service's own distance to the reset as the window.
+        let first = learning.observe(sample(998, at: 0, reset: 86_400 - 120))
+        XCTAssertEqual(first.limit, 998)
+        XCTAssertEqual(first.used, 0)
+        XCTAssertTrue(first.isEstimated)
+        XCTAssertEqual(first.usedPercent, 0)
+        XCTAssertEqual(learning.windowSeconds(for: sample(998, at: 0, reset: 86_400 - 120)), 86_400)
+        XCTAssertNil(learning.learnedWindowSeconds)
+        XCTAssertTrue(cycle(1, total: 1000, learning: &learning).isEstimated)
+        XCTAssertTrue(cycle(2, total: 1000, learning: &learning).isEstimated)
+        let confirmed = cycle(3, total: 1000, learning: &learning)
+        XCTAssertEqual(confirmed.limit, 1000)
+        XCTAssertFalse(confirmed.isEstimated)
         let used = learning.observe(sample(998, at: 259_230, reset: 345_600))
         XCTAssertEqual(used.used, 2)
         XCTAssertEqual(used.usedPercent!, 0.2, accuracy: 0.0001)
+        XCTAssertFalse(used.isEstimated)
         XCTAssertEqual(learning.matchingResets, 3)
         XCTAssertEqual(learning.learnedWindowSeconds, 86_400)
         let bucket = QuotaBucket(id: "image_gen", title: "Image Generation", shortLabel: "Image Generation", usedPercent: 0,
@@ -35,28 +46,53 @@ final class ChatGPTChatTests: XCTestCase {
     func testDifferentTotalsRestartConfidenceWithoutAveraging() {
         var learning = ChatGPTChatAllowanceLearning()
         _ = cycle(1, total: 1000, learning: &learning)
-        XCTAssertNil(cycle(2, total: 900, learning: &learning).limit)
+        // The estimate never drops below a remainder that was seen.
+        XCTAssertEqual(cycle(2, total: 900, learning: &learning).limit, 1000)
+        XCTAssertTrue(cycle(2, total: 900, learning: &learning).isEstimated)
         XCTAssertEqual(learning.matchingResets, 1)
-        XCTAssertNil(cycle(3, total: 900, learning: &learning).limit)
-        XCTAssertEqual(cycle(4, total: 900, learning: &learning).limit, 900)
-        XCTAssertNil(cycle(5, total: 800, learning: &learning).limit)
+        XCTAssertTrue(cycle(3, total: 900, learning: &learning).isEstimated)
+        let confirmed = cycle(4, total: 900, learning: &learning)
+        XCTAssertEqual(confirmed.limit, 900)
+        XCTAssertFalse(confirmed.isEstimated)
+        XCTAssertTrue(cycle(5, total: 800, learning: &learning).isEstimated)
     }
 
     func testMovingUnusedResetAndRepeatedReadsNeverCreateConfidence() {
         var learning = ChatGPTChatAllowanceLearning()
         for n in 0..<200 {
             let now = Double(n) * 60
-            XCTAssertNil(learning.observe(sample(1000, at: now, reset: now + 86_400)).limit)
+            let quantity = learning.observe(sample(1000, at: now, reset: now + 86_400))
+            XCTAssertEqual(quantity.limit, 1000)
+            XCTAssertTrue(quantity.isEstimated)
         }
         XCTAssertEqual(learning.matchingResets, 0)
+        XCTAssertNil(learning.learnedWindowSeconds)
     }
 
     func testMissedBoundaryAndUnexpectedIncreaseInvalidateLearnedTotal() {
         var learning = ChatGPTChatAllowanceLearning()
         for n in 1...3 { _ = cycle(n, total: 1000, learning: &learning) }
-        XCTAssertNil(learning.observe(sample(1200, at: 259_230, reset: 345_600)).limit)
+        XCTAssertFalse(learning.isConfirmed == false)
+        // More than the confirmed total: the total was larger, so the
+        // confirmation goes and the larger figure becomes the estimate.
+        let raised = learning.observe(sample(1200, at: 259_230, reset: 345_600))
+        XCTAssertEqual(raised.limit, 1200)
+        XCTAssertTrue(raised.isEstimated)
+        XCTAssertFalse(learning.isConfirmed)
         for n in 4...6 { _ = cycle(n, total: 1200, learning: &learning) }
-        XCTAssertNil(learning.observe(sample(1190, at: 604_801, reset: 691_200)).limit)
+        XCTAssertTrue(learning.isConfirmed)
+        // A missed boundary drops the confirmation, not the estimate.
+        let missed = learning.observe(sample(1190, at: 604_801, reset: 691_200))
+        XCTAssertEqual(missed.limit, 1200)
+        XCTAssertTrue(missed.isEstimated)
+    }
+
+    func testProvisionalWindowRoundsToWholeDaysOrHours() {
+        XCTAssertEqual(ChatGPTChatAllowanceLearning.provisionalWindow(resetAt: base.addingTimeInterval(29 * 86_400 + 23 * 3_600), observedAt: base), 30 * 86_400)
+        XCTAssertEqual(ChatGPTChatAllowanceLearning.provisionalWindow(resetAt: base.addingTimeInterval(23 * 3_600 + 58 * 60), observedAt: base), 86_400)
+        XCTAssertEqual(ChatGPTChatAllowanceLearning.provisionalWindow(resetAt: base.addingTimeInterval(4 * 3_600 + 50 * 60), observedAt: base), 5 * 3_600)
+        XCTAssertNil(ChatGPTChatAllowanceLearning.provisionalWindow(resetAt: base.addingTimeInterval(-1), observedAt: base))
+        XCTAssertNil(ChatGPTChatAllowanceLearning.provisionalWindow(resetAt: nil, observedAt: base))
     }
 
     func testOnlyTwoFeaturesAreParsedAndMalformedCountsDoNotBecomeZero() throws {
@@ -78,17 +114,25 @@ final class ChatGPTChatTests: XCTestCase {
             let boundary = Double(n) * 86_400
             _ = try await store.observe(localAccount: "local", identity: identity, plan: "pro", samples: [sample(5, at: boundary-60, reset: boundary)])
             let values = try await store.observe(localAccount: "local", identity: identity, plan: "pro", samples: [sample(1000, at: boundary+10, reset: boundary+86_400)])
-            XCTAssertEqual(values["image_gen"]?.quantity.limit, n == 3 ? 1000 : nil)
+            XCTAssertEqual(values["image_gen"]?.quantity.limit, 1000)
+            XCTAssertEqual(values["image_gen"]?.quantity.isEstimated, n != 3)
         }
+        // A plan change starts over: the estimate is this plan's own first read.
         for (i, plan) in ["prolite", "pro"].enumerated() {
             let result = try await store.observe(localAccount: "local", identity: identity, plan: plan, samples: [sample(500, at: 259_230 + Double(i), reset: 345_600)])
-            XCTAssertNil(result["image_gen"]?.quantity.limit)
+            XCTAssertEqual(result["image_gen"]?.quantity.limit, 500)
+            XCTAssertEqual(result["image_gen"]?.quantity.isEstimated, true)
         }
+        // A read that could not name the plan keeps what is known.
+        let unnamed = try await store.observe(localAccount: "local", identity: identity, plan: nil, samples: [sample(400, at: 259_240, reset: 345_600)])
+        XCTAssertEqual(unnamed["image_gen"]?.quantity.limit, 500)
+        XCTAssertEqual(unnamed["image_gen"]?.quantity.used, 100)
         let text = try String(contentsOf: directory.appendingPathComponent("learning.json"), encoding: .utf8)
         XCTAssertFalse(text.contains("synthetic-user"))
         let reloaded = ChatGPTChatAllowanceStore(url: directory.appendingPathComponent("learning.json"))
-        let result = try await reloaded.observe(localAccount: "local", identity: ChatGPTChatParser.identity("another-user"), plan: "pro", samples: [sample(500, at: 259_240, reset: 345_600)])
-        XCTAssertNil(result["image_gen"]?.quantity.limit)
+        let result = try await reloaded.observe(localAccount: "local", identity: ChatGPTChatParser.identity("another-user"), plan: "pro", samples: [sample(300, at: 259_250, reset: 345_600)])
+        XCTAssertEqual(result["image_gen"]?.quantity.limit, 300)
+        XCTAssertEqual(result["image_gen"]?.quantity.used, 0)
     }
 
     func testClientReusesPlanEndpointAndReadsHistoryOnlyWhenAsked() async throws {
@@ -97,10 +141,14 @@ final class ChatGPTChatTests: XCTestCase {
         let transport = ChatFixtureTransport()
         let client = ChatGPTChatClient(transport: transport, store: ChatGPTChatAllowanceStore(url: directory.appendingPathComponent("learning.json")),
                                        historyStore: ChatGPTChatHistoryStore(url: directory.appendingPathComponent("history.json")))
-        let quota = try await client.fetch(account: AccountIdentity(id: "local", tool: .chatgptChat, source: .webCookie), settings: .init(), now: base)
+        var featuresOnly = ChatGPTChatSettings()
+        featuresOnly.trackProModels = false
+        let quota = try await client.fetch(account: AccountIdentity(id: "local", tool: .chatgptChat, source: .webCookie), settings: featuresOnly, now: base)
         XCTAssertEqual(quota.plan, "prolite")
         XCTAssertEqual(quota.buckets.map(\.id), ["image_gen", "deep_research"])
-        XCTAssertTrue(quota.buckets.allSatisfy { !$0.hasPercentage })
+        XCTAssertTrue(quota.buckets.allSatisfy { $0.hasPercentage && $0.quantity?.isEstimated == true },
+                      "the first read already shows an estimated percentage")
+        XCTAssertEqual(quota.buckets.first?.quantity?.limit, 998)
         XCTAssertNil(quota.chatGPTChat?.history)
         let calls = await transport.calls
         XCTAssertEqual(calls, ["/api/auth/session", "/backend-api/wham/usage", "/backend-api/conversation/init"])
@@ -108,8 +156,8 @@ final class ChatGPTChatTests: XCTestCase {
 
         // Asked to count Pro messages, the same client walks the saved list
         // and gets the plan's shared weekly allowance, complete at zero.
-        var settings = ChatGPTChatSettings()
-        settings.trackProModels = true
+        let settings = ChatGPTChatSettings()
+        XCTAssertTrue(settings.trackProModels, "counting Pro messages is the default")
         let counted = try await client.fetch(account: AccountIdentity(id: "local", tool: .chatgptChat, source: .webCookie), settings: settings, now: base)
         XCTAssertEqual(counted.buckets.map(\.id), ["image_gen", "deep_research", "pro_weekly"])
         let pro = try XCTUnwrap(counted.buckets.last)
@@ -118,6 +166,8 @@ final class ChatGPTChatTests: XCTestCase {
         XCTAssertEqual(pro.quantity?.limit, 50)
         XCTAssertTrue(pro.hasPercentage)
         XCTAssertEqual(pro.rawWindowSeconds, 7 * 86_400)
+        XCTAssertEqual(pro.groupTitle, "Pro Models")
+        XCTAssertEqual(pro.title, "Weekly")
         XCTAssertEqual(counted.chatGPTChat?.history?.complete, true)
         let later = await transport.calls
         XCTAssertEqual(later.filter { $0.hasPrefix("/backend-api/conversations?") }.count, 2)
@@ -216,6 +266,8 @@ final class ChatGPTChatTests: XCTestCase {
     func testProAllowancesFollowThePublishedPlanTable() {
         let pro = ChatGPTChatProAllowances.allowances(plan: "pro")
         XCTAssertEqual(pro.map(\.id), ["gpt6_pro_weekly", "sol_pro_daily", "pro_daily"])
+        XCTAssertEqual(pro.map(\.group), ["GPT-6 Astra Pro", "GPT-5.6 Sol Pro", "Pro Models"])
+        XCTAssertEqual(pro.map(\.title), ["Weekly", "Daily", "Daily"])
         XCTAssertEqual(pro.map(\.limit), [200, 170, 200])
         XCTAssertEqual(pro.map(\.windowSeconds), [7 * 86_400, 86_400, 86_400])
         XCTAssertEqual(pro[0].models, ["gpt-6-pro"])
@@ -244,6 +296,9 @@ final class ChatGPTChatTests: XCTestCase {
         let pro = ChatGPTChatProAllowances.allowances(plan: "pro")
         let buckets = ChatGPTChatParser.proBuckets(allowances: pro, turns: turns, limits: [], complete: true, now: base)
         XCTAssertEqual(buckets.map(\.id), ["gpt6_pro_weekly", "sol_pro_daily", "pro_daily"])
+        XCTAssertEqual(buckets.map(\.groupTitle), ["GPT-6 Astra Pro", "GPT-5.6 Sol Pro", "Pro Models"],
+                       "the model is the group header, the window the row, as Codex's Spark lanes are drawn")
+        XCTAssertEqual(buckets.map(\.title), ["Weekly", "Daily", "Daily"])
         XCTAssertEqual(buckets[0].quantity?.used, 3)
         XCTAssertEqual(buckets[0].quantity?.remaining, 197)
         XCTAssertEqual(buckets[0].usedPercent, 1.5)
@@ -365,11 +420,20 @@ final class ChatGPTChatTests: XCTestCase {
     }
 
     func testLegacySettingsDecodeWithoutRestoringModelTracking() throws {
-        let settings = try JSONDecoder().decode(ChatGPTChatSettings.self, from: Data(#"{"enabled":true,"includeHistory":true,"astraWeeklyLimit":200}"#.utf8))
-        XCTAssertTrue(settings.enabled)
-        XCTAssertFalse(settings.trackProModels, "counting Pro messages is opt-in, and an old history flag does not opt in")
-        let data = try JSONSerialization.jsonObject(with: JSONEncoder().encode(settings)) as! [String: Any]
-        XCTAssertEqual(Set(data.keys), ["enabled", "trackProModels"])
+        // A file from before the defaults changed takes them once — both
+        // switches on — whatever it said; its old model-tracking keys are dropped.
+        let legacy = try JSONDecoder().decode(ChatGPTChatSettings.self, from: Data(#"{"enabled":false,"includeHistory":false,"astraWeeklyLimit":200}"#.utf8))
+        XCTAssertTrue(legacy.enabled)
+        XCTAssertTrue(legacy.trackProModels)
+        XCTAssertEqual(legacy.defaultsVersion, ChatGPTChatSettings.currentDefaultsVersion)
+        let data = try JSONSerialization.jsonObject(with: JSONEncoder().encode(legacy)) as! [String: Any]
+        XCTAssertEqual(Set(data.keys), ["enabled", "trackProModels", "defaultsVersion"])
+        // A choice made under the current defaults is kept.
+        let chosen = try JSONDecoder().decode(ChatGPTChatSettings.self, from: Data(#"{"enabled":false,"trackProModels":false,"defaultsVersion":1}"#.utf8))
+        XCTAssertFalse(chosen.enabled)
+        XCTAssertFalse(chosen.trackProModels)
+        XCTAssertTrue(ChatGPTChatSettings().enabled)
+        XCTAssertTrue(ChatGPTChatSettings().trackProModels)
         XCTAssertEqual(MenuBarFieldCatalog.chatGPTChatFields.count, 6)
         XCTAssertEqual(ToolType.codex.coreProviderMembers.first, .chatgptChat)
     }

--- a/docs/chatgpt-chat.md
+++ b/docs/chatgpt-chat.md
@@ -6,26 +6,39 @@ GPT-5.6 Sol Pro message allowances. Enable it in OpenAI settings; a Codex
 login is enough, and the existing browser import or built-in login works
 too. No browser extension is required.
 
-## Learning totals
+## Defaults
+
+Both switches — tracking Chat, and counting Pro model messages — are on.
+The Chat account appears only when there is a credential it can use: the
+Codex OAuth login or a chatgpt.com web session. `ChatGPTChatSettings` carries
+a `defaultsVersion`; a settings file written under an older version takes the
+current defaults once, and a choice made after that is kept.
+
+## Estimated and confirmed totals
 
 The adapter reads the service remainder and reset time. It tries the Codex
 CLI's OAuth bearer first — the credential the Codex quota already reads — and
 only then the web cookie and the WebView session, so a Codex login needs no
 separate web login for Chat. It reuses Agentic's `/wham/usage` plan parser
-through whichever Chat transport answered. There are no fixed feature totals
-and no cloud-history or model-message collector.
+through whichever Chat transport answered. There are no fixed feature totals.
 
-A first observation is not a reset. Three independent reset observations with
-the same remainder establish a learned total. Reads must bracket the reported
-boundary and be close enough to it to avoid treating a long offline gap as a
-fresh full allowance. Moving unused reset times do not count. A changed total,
-account or plan starts learning again. A failed plan read withholds confidence.
+The service never states a total, so two figures stand in for it. From the
+first read, the largest remainder ever reported for the account and plan is
+the estimate: the allowance is at least that, and on the day it refills it is
+exactly that. Every read therefore shows a percentage, marked estimated, with
+the service's own distance to the reset (rounded to whole days, or hours
+below a day) as the window — a monthly allowance is a normal row on day one,
+not a season of "learning". Three consistent observed reset boundaries with
+the same remainder then confirm the total and its window and take the
+estimate mark off. Reads must bracket the reported boundary and be close
+enough to it to avoid treating a long offline gap as a fresh full allowance;
+moving unused reset times do not count. A remainder above the confirmed
+total raises the estimate and withdraws the confirmation. A changed account
+or plan starts over; a read that could not name the plan keeps what is known.
 
-While learning, every feature has an indeterminate bar and an estimated
-remaining count. Once the total and window are learned, the source returns a normal percentage
-bucket. The existing primary-provider quota row, forecast bar, pace, history,
-menu bar, and mini-window paths handle it without a separate Chat presentation.
-Learning state uses the same bar height and track, with indeterminate fill.
+Estimated and confirmed rows alike go through the standard quota row,
+forecast, pace, history, menu bar and mini-window paths. A row with no
+percentage at all draws a still, dashed track.
 
 ## Pro model messages
 
@@ -36,13 +49,17 @@ and `/backend-api/models` carries no allowance fields. What OpenAI publishes
 is the total per plan, in "GPT-5.6 and GPT-6 Pro in ChatGPT" (help article
 20001354, read 2026-09-07):
 
-| Plan | GPT-6 Pro | GPT-5.6 Sol Pro |
+The buckets are grouped the way Codex's Spark lanes are: the model is the
+group header (GPT-6 Astra Pro, GPT-5.6 Sol Pro, Pro Models) and the window
+(Weekly, Daily) is the row.
+
+| Plan | GPT-6 Astra Pro | GPT-5.6 Sol Pro |
 | --- | --- | --- |
 | Pro $200 (`pro`) | 200 messages per week | 170 per day; both models together 200 per day |
 | Pro $100 (`prolite`) | one shared allowance of 50 messages per week | |
 
-"Sync saved Chat history across devices" in OpenAI settings turns the count
-on. It is off by default. The reader lists the account's saved conversations
+"Sync saved Chat history across devices" in OpenAI settings is the switch,
+on by default. The reader lists the account's saved conversations
 newest first, stops at the first one not updated inside the last week, skips
 Work rows (`conversation_origin` `tpp` or `flora`) and temporary chats, and
 fetches only conversations whose revision changed, at most 24 per refresh


### PR DESCRIPTION
Three things the Chat rows were doing wrong, seen in the popover after #356.

## Estimated totals from the first read

The service never states a feature total, and confirming one from three observed reset boundaries meant Deep Research (30-day window) would spend about a season saying "Learning · about 250 left". `ChatGPTChatAllowanceLearning` now keeps the largest remainder ever reported for the account and plan as the *estimate* — the allowance is at least that, and on refill day exactly that — and uses the service's own distance to the reset (rounded to whole days, or hours below a day) as the window. Every row is a percentage row from the first read, `isEstimated` until three consistent boundaries confirm the total and window. A remainder above the total raises the estimate and withdraws the confirmation; an account or plan change starts over; a read that could not name the plan keeps what is known instead of starting over on every failed plan read.

## A still learning bar

`QuotaBarShape`'s indeterminate state was a capsule sweeping forever. It asked for the eye and, over the popover's blur, for a frame every tick. It is a dashed, still track now — and with estimated totals it hardly ever appears.

## Pro lanes under their models

The Pro buckets carried the window in their title ("GPT-6 Pro · Weekly") and the OpenAI card suppressed Chat's group titles, so they did not read like the rest of the card. They now file under the model as their group — GPT-6 Astra Pro, GPT-5.6 Sol Pro, Pro Models — with the window (Weekly, Daily) as the row, exactly how the card draws Codex's Spark lanes. Menu bar field titles follow.

## Defaults on

`ChatGPTChatSettings.enabled` and `.trackProModels` default to true. A `defaultsVersion` lets a settings file written before this take the new defaults once while keeping any choice made after. The Chat account is created only when there is a credential it can use (`AccountStore.hasChatGPTChatCredential`: Codex OAuth, Codex CLI Keychain, or a chatgpt.com web session), so an API-key-only Codex user does not get a permanent "needs login" row.

## Verification

- `swift build`; `swift test`: 2351 tests, 3 skipped, 0 failures; `./Scripts/build_app.sh release`; `codesign -d --entitlements -` → empty dict.
- Live probe on the packaged build (Pro $200, Codex OAuth): Image Generation 0/1000 and Deep Research 0/250 estimated from the first read with 1-day and 30-day windows; GPT-6 Astra Pro / Weekly 6 of 200, GPT-5.6 Sol Pro / Daily 0 of 170, Pro Models / Daily 4 of 200, history complete.
- Demo-mode capture of the OpenAI page: both feature rows draw the standard percentage row (axis, pace, forecast, day-of-window, reset history, "how this was calculated"), and the Pro lanes draw as GPT-6 ASTRA PRO → Weekly, GPT-5.6 SOL PRO → Daily, PRO MODELS → Daily, the way the Codex Spark lanes do.
- `Scripts/demo_home.py` now carries the Chat account so demos and README captures include it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
