### PR TITLE
Keep the Studio's subject controls out of the notch band

### DIFF
--- a/Sources/VibeBarApp/Views/LayoutStudioView.swift
+++ b/Sources/VibeBarApp/Views/LayoutStudioView.swift
@@ -1053,8 +1053,11 @@ struct LayoutStudioView: View {
     private var topBar: some View {
         HStack(spacing: 10) {
             subjectMenu
-            Spacer(minLength: 8)
-            centreControls
+            // Beside the subject, not centred: on a notched Mac a notch
+            // companion keeps an invisible window over the top centre of the
+            // screen, and a pill under it never sees the click. The corners
+            // are the one part of the top edge nothing else claims.
+            subjectControls
             Spacer(minLength: 8)
             HStack(spacing: 8) {
                 if !model.undoStack.isEmpty {
@@ -1138,7 +1141,7 @@ struct LayoutStudioView: View {
     }
 
     @ViewBuilder
-    private var centreControls: some View {
+    private var subjectControls: some View {
         switch model.subject {
         case let .popoverPage(page):
             let context = pageContext(page)


### PR DESCRIPTION
"The Studio's top controls still can't be clicked" — with the Studio at the top of the display, the pills centred along its top edge sit under a notch companion's invisible window. `CGWindowListCopyWindowInfo` on the maintainer's Mac shows Alcove holding two windows at x 716–1340, y 0–320 at a near-top window level; the appearance, style and layout pills were inside that band, while the subject picker (left) and the zoom / inspector controls (right) were outside it and worked. #352 fixed the glass buttons' own hit-testing, which was a separate problem.

The pills now sit beside the subject picker, in the corner, which nothing else claims. Nothing else about the top bar changes.

## Verification

- `swift build`, `swift test` (full suite), `./Scripts/build_app.sh release`, `codesign -d --entitlements -` → empty dict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
