### PR TITLE
Bump the version to 1.6.3 (build 75) for the Main release

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -24,9 +24,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.2</string>
+	<string>1.6.3</string>
 	<key>CFBundleVersion</key>
-	<string>74</string>
+	<string>75</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
1.6.3 carries #359 (Chat totals from the first read, Pro lanes under their models, defaults on, still learning bar) and #360 (Studio controls out of the notch band) on top of 1.6.2. Build 75 follows 74. The tag `v1.6.3` follows the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)