### PR TITLE
Read cookies only from browsers that are installed, and preflight each one's own key

### DIFF
--- a/Sources/VibeBarCore/BrowserCookies/BrowserCookieAccessGate.swift
+++ b/Sources/VibeBarCore/BrowserCookies/BrowserCookieAccessGate.swift
@@ -34,8 +34,12 @@ public enum BrowserCookieAccessGate {
     ///   `KeychainAccessGate.isDisabled` and this browser needs
     ///   Keychain to decrypt cookies, or
     /// - the cooldown window from a prior denial is still active, or
-    /// - a non-interactive Keychain preflight reports
-    ///   `interactionRequired` (we'd prompt if we tried for real).
+    /// - a non-interactive Keychain preflight of *this browser's* Safe
+    ///   Storage item reports `interactionRequired` (we'd prompt if we
+    ///   tried for real), or
+    /// - that item does not exist at all — there is no key to decrypt
+    ///   with, so the read could only fail, and a failure that is not a
+    ///   refusal must not park the browser in a denial cooldown.
     public static func shouldAttempt(_ browser: Browser, now: Date = Date()) -> Bool {
         guard browser.usesKeychainForCookieDecryption else { return true }
         guard !KeychainAccessGate.isDisabled else { return false }
@@ -53,17 +57,57 @@ public enum BrowserCookieAccessGate {
         }
         guard shouldCheckKeychain else { return false }
 
-        let requiresInteraction = chromiumKeychainRequiresInteraction()
-        return lock.withLock { state in
-            loadIfNeeded(&state)
-            if requiresInteraction {
+        switch keychainPreflight(for: browser) {
+        case .allowed:
+            return true
+        case .absent:
+            return false
+        case .interactionRequired:
+            return lock.withLock { state in
+                loadIfNeeded(&state)
                 state.deniedUntilByBrowser[browser.rawValue] = now.addingTimeInterval(cooldownInterval)
                 persist(state)
                 SafeLog.info("Browser cookie access for \(browser.displayName) requires Keychain interaction; suppressing for \(Int(cooldownInterval / 60))m")
                 return false
             }
-            return true
         }
+    }
+
+    /// What a silent read of `browser`'s Safe Storage item would meet.
+    enum Preflight: Equatable {
+        /// The item is readable now, without a prompt.
+        case allowed
+        /// The item exists but reading it would prompt.
+        case interactionRequired
+        /// No item under any of the browser's labels: nothing to decrypt with.
+        case absent
+    }
+
+    /// The Keychain lookup the preflight runs. A seam for tests, which
+    /// cannot put items in the login keychain.
+    nonisolated(unsafe) static var preflight: @Sendable (_ service: String, _ account: String?) -> KeychainAccessPreflight.Outcome = {
+        KeychainAccessPreflight.checkGenericPassword(service: $0, account: $1)
+    }
+
+    /// Preflights the browser's own labels — Chrome's item being readable
+    /// says nothing about Atlas's — falling back to every catalogued label
+    /// for a channel the catalogue lists none for, the way SweetCookieKit
+    /// itself resolves the key.
+    static func keychainPreflight(for browser: Browser) -> Preflight {
+        let own = browser.safeStorageLabels
+        let labels = own.isEmpty ? Browser.safeStorageLabels : own
+        var interaction = false
+        for label in labels {
+            switch preflight(label.service, label.account) {
+            case .allowed:
+                return .allowed
+            case .interactionRequired:
+                interaction = true
+            case .notFound, .failure:
+                continue
+            }
+        }
+        return interaction ? .interactionRequired : .absent
     }
 
     /// Record an explicit denial coming back from SweetCookieKit's
@@ -122,13 +166,18 @@ public enum BrowserCookieAccessGate {
     /// touching Keychain, so the importer honestly finds nothing and used
     /// to tell the user to go sign in again — advice that could not
     /// possibly help.
-    public static func activeCooldowns(now: Date = Date()) -> [Cooldown] {
+    ///
+    /// A cooldown on a browser that is no longer installed is left out:
+    /// nothing will read that browser again, so a card saying it "declined"
+    /// would only send the user looking for a browser that is not there.
+    public static func activeCooldowns(now: Date = Date(), detection: BrowserDetection = BrowserDetection()) -> [Cooldown] {
         let raw: [String: Date] = lock.withLock { state in
             loadIfNeeded(&state)
             return state.deniedUntilByBrowser
         }
         return raw
             .filter { $0.value > now }
+            .filter { key, _ in Browser(rawValue: key).map(detection.isAppInstalled) ?? true }
             .map { key, value in
                 Cooldown(
                     browserName: Browser(rawValue: key)?.displayName ?? key,
@@ -147,22 +196,6 @@ public enum BrowserCookieAccessGate {
             UserDefaults.standard.removeObject(forKey: defaultsKey)
         }
     }
-
-    private static func chromiumKeychainRequiresInteraction() -> Bool {
-        for label in safeStorageLabels {
-            switch KeychainAccessPreflight.checkGenericPassword(service: label.service, account: label.account) {
-            case .allowed:
-                return false
-            case .interactionRequired:
-                return true
-            case .notFound, .failure:
-                continue
-            }
-        }
-        return false
-    }
-
-    private static let safeStorageLabels: [(service: String, account: String)] = Browser.safeStorageLabels
 
     private static func loadIfNeeded(_ state: inout State) {
         guard !state.loaded else { return }

--- a/Sources/VibeBarCore/BrowserCookies/BrowserDetection.swift
+++ b/Sources/VibeBarCore/BrowserCookies/BrowserDetection.swift
@@ -73,16 +73,28 @@ public final class BrowserDetection: Sendable {
     /// Stricter than `isAppInstalled` — for Chromium browsers we
     /// require an actual cookie store on disk so we don't pop a
     /// Safe-Storage Keychain prompt for an installed-but-unused app.
+    ///
+    /// And stricter than the data alone: the app has to be installed.
+    /// Uninstalling a browser leaves its profile behind, cookie store
+    /// and all, but takes its Safe Storage key with it — so a leftover
+    /// profile reads as "Keychain denied" and parks the browser in a
+    /// cooldown every other provider then gets blamed on. Nothing on
+    /// this Mac can sign in to a browser that is not here.
     public func isCookieSourceAvailable(_ browser: Browser) -> Bool {
         if browser == .safari { return true }
+        guard isAppInstalled(browser) else { return false }
         if requiresProfileValidation(browser) {
             return hasUsableCookieStore(browser)
         }
         return hasUsableProfileData(browser)
     }
 
+    /// Profile data on disk for an installed browser. Same installed
+    /// requirement as `isCookieSourceAvailable`: a localStorage read of
+    /// an uninstalled browser's leftovers is not a session either.
     public func hasUsableProfileData(_ browser: Browser) -> Bool {
-        cachedBool(browser: browser, kind: .usableProfileData) {
+        guard browser == .safari || isAppInstalled(browser) else { return false }
+        return cachedBool(browser: browser, kind: .usableProfileData) {
             self.detectUsableProfileData(for: browser)
         }
     }

--- a/Tests/VibeBarCoreTests/BrowserCookieGateTests.swift
+++ b/Tests/VibeBarCoreTests/BrowserCookieGateTests.swift
@@ -3,6 +3,14 @@ import XCTest
 import SweetCookieKit
 
 final class BrowserCookieGateTests: XCTestCase {
+    /// Every browser present, so the list under test is the gate's own and
+    /// not this Mac's set of installed apps.
+    private let allInstalled = BrowserDetection(
+        homeDirectory: "/Users/example",
+        fileExists: { _ in true },
+        directoryContents: { _ in ["Default"] }
+    )
+
     override func setUp() {
         super.setUp()
         BrowserCookieAccessGate.reset()
@@ -79,7 +87,7 @@ final class BrowserCookieGateTests: XCTestCase {
         let blockedUntil = BrowserCookieAccessGate.blockedUntil(.chrome, now: now)
         XCTAssertEqual(blockedUntil, now.addingTimeInterval(60 * 60 * 6))
 
-        let cooldowns = BrowserCookieAccessGate.activeCooldowns(now: now)
+        let cooldowns = BrowserCookieAccessGate.activeCooldowns(now: now, detection: allInstalled)
         XCTAssertEqual(cooldowns.count, 1)
         XCTAssertEqual(cooldowns.first?.browserName, Browser.chrome.displayName)
         XCTAssertEqual(cooldowns.first?.until, now.addingTimeInterval(60 * 60 * 6))
@@ -90,19 +98,19 @@ final class BrowserCookieGateTests: XCTestCase {
         BrowserCookieAccessGate.recordDenied(for: .brave, now: now.addingTimeInterval(60))
         BrowserCookieAccessGate.recordDenied(for: .chrome, now: now)
 
-        let names = BrowserCookieAccessGate.activeCooldowns(now: now).map(\.browserName)
+        let names = BrowserCookieAccessGate.activeCooldowns(now: now, detection: allInstalled).map(\.browserName)
         XCTAssertEqual(names, [Browser.chrome.displayName, Browser.brave.displayName])
 
         let afterEverything = now.addingTimeInterval(60 * 60 * 7)
-        XCTAssertTrue(BrowserCookieAccessGate.activeCooldowns(now: afterEverything).isEmpty)
+        XCTAssertTrue(BrowserCookieAccessGate.activeCooldowns(now: afterEverything, detection: allInstalled).isEmpty)
         XCTAssertNil(BrowserCookieAccessGate.blockedUntil(.chrome, now: afterEverything))
     }
 
     func testResetClearsTheReportedCooldowns() {
         BrowserCookieAccessGate.recordDenied(for: .chrome)
-        XCTAssertFalse(BrowserCookieAccessGate.activeCooldowns().isEmpty)
+        XCTAssertFalse(BrowserCookieAccessGate.activeCooldowns(detection: allInstalled).isEmpty)
         BrowserCookieAccessGate.reset()
-        XCTAssertTrue(BrowserCookieAccessGate.activeCooldowns().isEmpty)
+        XCTAssertTrue(BrowserCookieAccessGate.activeCooldowns(detection: allInstalled).isEmpty)
     }
 }
 

--- a/Tests/VibeBarCoreTests/BrowserCookieSourceTests.swift
+++ b/Tests/VibeBarCoreTests/BrowserCookieSourceTests.swift
@@ -1,0 +1,101 @@
+import XCTest
+@testable import VibeBarCore
+import SweetCookieKit
+
+/// An uninstalled browser is not a cookie source, however much of its
+/// profile it left behind — and the silent gate asks each browser's own
+/// Safe Storage item, so one browser's answer never stands in for another's.
+///
+/// The case that motivated this: ChatGPT Atlas uninstalled, its profile and
+/// cookie store still on disk, its Safe Storage key gone. It was picked as
+/// the one Chromium browser an import may read, failed for want of a key,
+/// was recorded as a *denial*, and every provider's empty result was then
+/// blamed on "ChatGPT Atlas Keychain access declined" — while Chrome, which
+/// had the sessions, was never read.
+final class BrowserCookieSourceTests: XCTestCase {
+    private let originalPreflight = BrowserCookieAccessGate.preflight
+
+    override func setUp() {
+        super.setUp()
+        BrowserCookieAccessGate.reset()
+        KeychainAccessGate.isDisabled = false
+    }
+
+    override func tearDown() {
+        BrowserCookieAccessGate.preflight = originalPreflight
+        BrowserCookieAccessGate.reset()
+        KeychainAccessGate.isDisabled = false
+        super.tearDown()
+    }
+
+    /// Chrome installed with data; Atlas's data present but its app gone.
+    private func leftoverAtlasDetection() -> BrowserDetection {
+        BrowserDetection(
+            homeDirectory: "/Users/example",
+            fileExists: { path in
+                if path.hasSuffix(".app") { return path.hasSuffix("/Google Chrome.app") }
+                return true
+            },
+            directoryContents: { _ in ["Default"] }
+        )
+    }
+
+    func testAnUninstalledBrowserWithLeftoverDataIsNotACookieSource() {
+        let detection = leftoverAtlasDetection()
+        XCTAssertTrue(detection.isAppInstalled(.chrome))
+        XCTAssertFalse(detection.isAppInstalled(.chatgptAtlas))
+        XCTAssertTrue(detection.isCookieSourceAvailable(.chrome))
+        XCTAssertTrue(detection.isCookieSourceAvailable(.safari), "Safari is part of macOS")
+        XCTAssertFalse(detection.isCookieSourceAvailable(.chatgptAtlas), "a profile without its app is a leftover, not a source")
+        XCTAssertFalse(detection.hasUsableProfileData(.chatgptAtlas))
+        XCTAssertTrue(detection.hasUsableProfileData(.chrome))
+    }
+
+    func testTheOneChromiumBrowserAnImportMayReadIsAnInstalledOne() {
+        let detection = leftoverAtlasDetection()
+        let order: [Browser] = [.safari, .chatgptAtlas, .chrome, .edge]
+        XCTAssertEqual(order.cookieImportCandidates(using: detection, allowKeychainPrompt: true), [.safari, .chrome])
+    }
+
+    func testAnUninstalledBrowserInCooldownIsNeitherReadNorBlamed() {
+        let now = Date(timeIntervalSince1970: 1_715_000_000)
+        BrowserCookieAccessGate.recordDenied(for: .chatgptAtlas, now: now)
+        let partition = MiscCookieResolver.cooldownPartition([.chatgptAtlas, .chrome], detection: leftoverAtlasDetection(), now: now)
+        XCTAssertEqual(partition.eligible, [.chrome])
+        XCTAssertTrue(partition.blocked.isEmpty, "a browser that could not have been read cannot be what blocked the import")
+    }
+
+    func testTheSettingsCardDoesNotListACooldownForABrowserThatIsGone() {
+        let now = Date(timeIntervalSince1970: 1_715_000_000)
+        BrowserCookieAccessGate.recordDenied(for: .chatgptAtlas, now: now)
+        BrowserCookieAccessGate.recordDenied(for: .chrome, now: now)
+        let listed = BrowserCookieAccessGate.activeCooldowns(now: now, detection: leftoverAtlasDetection())
+        XCTAssertEqual(listed.map(\.browserName), [Browser.chrome.displayName])
+    }
+
+    func testTheSilentGateAsksEachBrowsersOwnKeyAndSkipsAnAbsentOneWithoutACooldown() {
+        let now = Date(timeIntervalSince1970: 1_715_000_000)
+        BrowserCookieAccessGate.preflight = { service, _ in
+            if service.hasPrefix("Chrome") { return .allowed }
+            if service.hasPrefix("Microsoft Edge") { return .interactionRequired }
+            return .notFound
+        }
+        XCTAssertEqual(BrowserCookieAccessGate.keychainPreflight(for: .chrome), .allowed)
+        XCTAssertEqual(BrowserCookieAccessGate.keychainPreflight(for: .chatgptAtlas), .absent)
+        XCTAssertEqual(BrowserCookieAccessGate.keychainPreflight(for: .edge), .interactionRequired)
+
+        XCTAssertTrue(BrowserCookieAccessGate.shouldAttempt(.chrome, now: now))
+        XCTAssertFalse(BrowserCookieAccessGate.shouldAttempt(.chatgptAtlas, now: now), "no key, no read")
+        XCTAssertNil(BrowserCookieAccessGate.blockedUntil(.chatgptAtlas, now: now), "a missing key is not a refusal")
+        XCTAssertFalse(BrowserCookieAccessGate.shouldAttempt(.edge, now: now))
+        XCTAssertNotNil(BrowserCookieAccessGate.blockedUntil(.edge, now: now), "a read that would prompt is parked")
+        XCTAssertTrue(BrowserCookieAccessGate.shouldAttempt(.chrome, now: now), "Chrome's cooldown is Chrome's alone")
+        XCTAssertTrue(BrowserCookieAccessGate.shouldAttempt(.safari, now: now))
+    }
+
+    func testAChannelWithoutItsOwnLabelsFallsBackToTheCatalogue() {
+        BrowserCookieAccessGate.preflight = { service, _ in service.hasPrefix("Chrome") ? .allowed : .notFound }
+        XCTAssertTrue(Browser.chromeBeta.safeStorageLabels.isEmpty)
+        XCTAssertEqual(BrowserCookieAccessGate.keychainPreflight(for: .chromeBeta), .allowed)
+    }
+}


### PR DESCRIPTION
"Import Browser Cookies for All Providers" reported "ChatGPT Atlas Keychain access declined until 9:34 AM" on every cookie provider, while Chrome — installed, signed in, sessions present — was never imported. Atlas had been uninstalled; its profile and cookie store were still under `~/Library/Application Support/com.openai.atlas`, its Safe Storage key was gone.

## What happened

- `BrowserDetection.isCookieSourceAvailable` only looked at the data on disk, so the leftover profile made Atlas a candidate.
- The silent gate's preflight asked one question for *every* Chromium browser at once — is any catalogued Safe Storage item readable? Chrome's was, so Atlas passed the gate, SweetCookieKit failed to find its key, reported that as a denial, and Atlas was parked in a six-hour cooldown.
- On the next manual import `cooldownPartition` counted Atlas as "would have been read", so each provider whose walk stored nothing was blamed on the Atlas cooldown.

Reproduced on the maintainer's Mac: with a clean gate, `attemptBrowserImport` for Bailian, Volcengine, Tencent Hunyuan and Baidu Qianfan all found a session in "Chrome Default"; the prompting candidate list was `[safari, chrome]`; Atlas's three labels preflight `notFound`, Chrome's and Edge's `allowed`.

## What changes

- `BrowserDetection`: a browser whose app is not installed is not a cookie source and has no usable profile data, whatever it left behind. Safari is exempt (part of macOS).
- `BrowserCookieAccessGate.shouldAttempt` preflights the browser's own Safe Storage labels (falling back to the catalogue for a channel that lists none, as SweetCookieKit does): allowed → read; would prompt → cooldown, as before; absent → skip, with no cooldown, since a missing key is not a refusal.
- `activeCooldowns` leaves out browsers that are no longer installed, so the Settings card stops saying a browser that is not there "declined".
- Tests cover the leftover-Atlas case end to end: not a source, not the one Chromium browser a prompting import reads, not blamed when in cooldown, not listed; and the per-browser preflight seam.

## Verification

- `swift build`, `swift test` (full suite), `./Scripts/build_app.sh release`, `codesign -d --entitlements -` → empty dict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
