### PR TITLE
Let the user choose which browsers cookie imports read

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -875,6 +875,37 @@ capture against § 8 before committing it — a screenshot is source content.
   `CostUsageScanner.forEachJSONLLine`, which forwards to the package's
   `JSONLLineScanner.forEachLine`: a moving cursor, not `removeSubrange`.
 
+### 7.0 Browser cookie imports
+
+Three rules keep the browser-cookie importers (the four core providers'
+`*BrowserCookieImporter`s and `MiscCookieResolver`) honest:
+
+- **A browser is a source only when it is installed.**
+  `BrowserDetection.isCookieSourceAvailable` and `hasUsableProfileData`
+  require the app bundle (`/Applications` or `~/Applications`) as well
+  as data on disk; Safari is exempt. An uninstalled browser leaves its
+  profile and cookie store behind but takes its Safe Storage key with
+  it, and a read of that leftover fails as if Keychain had refused —
+  which used to park the browser in a six-hour cooldown that every
+  other provider's empty import then got blamed on.
+- **The silent gate asks each browser about its own key.**
+  `BrowserCookieAccessGate.shouldAttempt` preflights the browser's own
+  `safeStorageLabels` (the whole catalogue only for a channel that lists
+  none, as SweetCookieKit does): readable → read; would prompt → cooldown;
+  absent → skip with no cooldown, because a missing key is not a refusal.
+  `activeCooldowns` leaves uninstalled browsers out.
+- **The user's browser choice is one setting, read everywhere.**
+  `AppSettings.cookieImportBrowsers` (SweetCookieKit `Browser` raw values
+  in preference order; nil = every installed browser) is mirrored into
+  `BrowserCookieImportPreference` by `AppEnvironment`. The core importers
+  take `BrowserCookieImportPreference.order` as their default order and
+  the misc resolver narrows each provider's order with `restrict(_:)`; a
+  provider's own `preferredBrowser` still wins for that provider.
+  `BrowserSelectionView` is the picker, shown in Settings › Misc
+  Providers and in the setup assistant's browser-cookies step; it lists
+  `BrowserCookieImportPreference.available()` — installed browsers with a
+  cookie store — and ticking every browser back on clears the choice.
+
 ### 7.1 Provider and harness naming
 
 Vibe Bar names a provider along **two orthogonal axes**. A surface picks

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
         // `bump-vibe-bar-i18n.yml` opens the pull request that moves the pin.
         // `Package.resolved` is not committed, so the exact pin is what makes
         // two machines build the same strings.
-        .package(url: "https://github.com/AstroQore/vibe-bar-i18n.git", exact: "0.7.0"),
+        .package(url: "https://github.com/AstroQore/vibe-bar-i18n.git", exact: "0.8.0"),
         // Sparkle is the standard update framework for independently
         // distributed macOS applications. Pin the exact reviewed release:
         // update verification and installation are security-sensitive.

--- a/Scripts/lint_localization.py
+++ b/Scripts/lint_localization.py
@@ -65,6 +65,7 @@ MIGRATED = [
     "Sources/VibeBarApp/Views/DetailPopoverShell.swift",
     "Sources/VibeBarApp/Views/QuotaResetJournalView.swift",
     "Sources/VibeBarApp/Views/ChatGPTChatViews.swift",
+    "Sources/VibeBarApp/Views/BrowserSelectionView.swift",
     "Sources/VibeBarCore/Models/QuotaError.swift",
     "Sources/VibeBarCore/Models/ServiceStatus.swift",
     "Sources/VibeBarCore/Models/ResetHistoryComparison.swift",

--- a/Sources/VibeBarApp/AppEnvironment.swift
+++ b/Sources/VibeBarApp/AppEnvironment.swift
@@ -289,6 +289,16 @@ final class AppEnvironment: ObservableObject {
             }
             .store(in: &cancellables)
 
+        // The browsers cookie imports may read follow the setting from the
+        // first load on; the importers read the mirror, not the store.
+        BrowserCookieImportPreference.apply(settings.settings.cookieImportBrowsers)
+        settings.$settings
+            .map(\.cookieImportBrowsers)
+            .removeDuplicates()
+            .dropFirst()
+            .sink { BrowserCookieImportPreference.apply($0) }
+            .store(in: &cancellables)
+
         // Cost re-scan is the expensive path (full filesystem walk + JSONL
         // parse). Outside its own slow loop, only run it when the *data
         // source* actually changes — mock mode or claude usage mode. The

--- a/Sources/VibeBarApp/Views/BrowserSelectionView.swift
+++ b/Sources/VibeBarApp/Views/BrowserSelectionView.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+import SweetCookieKit
+import VibeBarCore
+
+/// The installed browsers Vibe Bar may read cookies from, each with a
+/// switch. Lives in Settings › Misc Providers and in the setup assistant's
+/// browser-cookies step; both edit `AppSettings.cookieImportBrowsers`.
+///
+/// Nothing chosen means every installed browser. Turning one off writes the
+/// rest as the choice; turning the last one back on clears the choice, so a
+/// user who only ever untick-and-reticks never ends up with a narrowed list
+/// that happens to match the machine today and not tomorrow.
+struct BrowserSelectionView: View {
+    @EnvironmentObject private var settingsStore: SettingsStore
+    @State private var available: [Browser] = []
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(L10n.Settings.Browsers.title)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(.secondary)
+            if available.isEmpty {
+                Text(L10n.Settings.Browsers.none)
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            } else {
+                ForEach(available, id: \.rawValue) { browser in
+                    Toggle(browser.displayName, isOn: binding(for: browser))
+                        .font(.system(size: 12))
+                }
+                Text(L10n.Settings.Browsers.help)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                if settingsStore.settings.cookieImportBrowsers != nil {
+                    Button(L10n.Settings.Browsers.readAll) {
+                        settingsStore.settings.cookieImportBrowsers = nil
+                    }
+                    .buttonStyle(.link)
+                    .font(.caption)
+                }
+            }
+        }
+        .onAppear { available = BrowserCookieImportPreference.available() }
+    }
+
+    private var chosen: [Browser] {
+        settingsStore.settings.cookieImportBrowsers?.compactMap(Browser.init(rawValue:)) ?? available
+    }
+
+    private func binding(for browser: Browser) -> Binding<Bool> {
+        Binding(
+            get: { chosen.contains(browser) },
+            set: { isOn in
+                var next = chosen.filter { $0 != browser }
+                if isOn { next.append(browser) }
+                // Back in catalogue order, so the list reads the same however
+                // it was clicked together, and the whole set means no choice.
+                let ordered = Browser.defaultImportOrder.filter(next.contains)
+                settingsStore.settings.cookieImportBrowsers = ordered.count == available.count && !ordered.isEmpty
+                    ? nil
+                    : ordered.map(\.rawValue)
+            }
+        )
+    }
+}

--- a/Sources/VibeBarApp/Views/MiscProviderLandingView.swift
+++ b/Sources/VibeBarApp/Views/MiscProviderLandingView.swift
@@ -24,6 +24,10 @@ struct MiscProviderLandingView: View {
 
             Divider()
 
+            BrowserSelectionView()
+
+            Divider()
+
             Text("Browser Cookies")
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundStyle(.secondary)

--- a/Sources/VibeBarApp/Views/Onboarding/OnboardingStepViews.swift
+++ b/Sources/VibeBarApp/Views/Onboarding/OnboardingStepViews.swift
@@ -297,6 +297,8 @@ struct OnboardingBrowserCookiesStep: View {
             Text(L10n.Onboarding.Cookies.intro)
                 .font(.system(size: 13))
                 .fixedSize(horizontal: false, vertical: true)
+            BrowserSelectionView()
+            Divider()
             Button {
                 environment.importOpenAIBrowserCookies()
                 environment.importClaudeBrowserCookies()

--- a/Sources/VibeBarCore/BrowserCookies/BrowserCookieImportPreference.swift
+++ b/Sources/VibeBarCore/BrowserCookies/BrowserCookieImportPreference.swift
@@ -1,0 +1,48 @@
+import Foundation
+import os.lock
+import SweetCookieKit
+
+/// The browsers cookie imports may read, as chosen in Settings or the setup
+/// assistant.
+///
+/// A process-wide mirror of `AppSettings.cookieImportBrowsers`, kept by the
+/// app whenever the setting loads or changes, so every importer that takes
+/// the default order — the four core providers' importers, the misc
+/// resolver — walks the chosen browsers without settings being threaded
+/// through each of them. `nil` means the choice was never narrowed: every
+/// installed browser, in the catalogue's order.
+public enum BrowserCookieImportPreference {
+    private static let selection = OSAllocatedUnfairLock<[Browser]?>(initialState: nil)
+
+    /// Adopt the setting: `Browser` raw values in preference order, or nil
+    /// for every installed browser. Unknown values — a browser a later
+    /// catalogue named — are dropped; an empty list is treated as nil
+    /// rather than as "read nothing", which is not a choice the picker
+    /// offers.
+    public static func apply(_ rawValues: [String]?) {
+        let browsers = rawValues?.compactMap(Browser.init(rawValue:))
+        selection.withLock { $0 = (browsers?.isEmpty ?? true) ? nil : browsers }
+    }
+
+    public static var selected: [Browser]? {
+        selection.withLock { $0 }
+    }
+
+    /// The order an importer with no preference of its own walks.
+    public static var order: [Browser] {
+        selected ?? BrowserCookieDefaults.importOrder
+    }
+
+    /// A provider's own order restricted to the chosen browsers, in the
+    /// chosen order; the provider's order untouched when nothing was chosen.
+    public static func restrict(_ order: [Browser]) -> [Browser] {
+        guard let selected else { return order }
+        return selected.filter(order.contains)
+    }
+
+    /// What the picker lists: the installed browsers with a cookie store on
+    /// this Mac, in the catalogue's order.
+    public static func available(using detection: BrowserDetection = BrowserDetection()) -> [Browser] {
+        Browser.defaultImportOrder.filter { detection.isCookieSourceAvailable($0) }
+    }
+}

--- a/Sources/VibeBarCore/BrowserCookies/ClaudeBrowserCookieImporter.swift
+++ b/Sources/VibeBarCore/BrowserCookies/ClaudeBrowserCookieImporter.swift
@@ -16,7 +16,7 @@ public enum ClaudeBrowserCookieImporter {
 
     public static func importAndStoreFromBrowsers(
         allowKeychainPrompt: Bool = false,
-        importOrder: BrowserCookieImportOrder = BrowserCookieDefaults.importOrder,
+        importOrder: BrowserCookieImportOrder = BrowserCookieImportPreference.order,
         detection: BrowserDetection = BrowserDetection(),
         client: BrowserCookieClient = BrowserCookieClient(),
         logger: ((String) -> Void)? = nil
@@ -36,7 +36,7 @@ public enum ClaudeBrowserCookieImporter {
 
     public static func importFromBrowsers(
         allowKeychainPrompt: Bool = false,
-        importOrder: BrowserCookieImportOrder = BrowserCookieDefaults.importOrder,
+        importOrder: BrowserCookieImportOrder = BrowserCookieImportPreference.order,
         detection: BrowserDetection = BrowserDetection(),
         client: BrowserCookieClient = BrowserCookieClient(),
         logger: ((String) -> Void)? = nil

--- a/Sources/VibeBarCore/BrowserCookies/GeminiBrowserCookieImporter.swift
+++ b/Sources/VibeBarCore/BrowserCookies/GeminiBrowserCookieImporter.swift
@@ -24,7 +24,7 @@ public enum GeminiBrowserCookieImporter {
 
     public static func importAndStoreFromBrowsers(
         allowKeychainPrompt: Bool = false,
-        importOrder: BrowserCookieImportOrder = BrowserCookieDefaults.importOrder,
+        importOrder: BrowserCookieImportOrder = BrowserCookieImportPreference.order,
         detection: BrowserDetection = BrowserDetection(),
         client: BrowserCookieClient = BrowserCookieClient(),
         logger: ((String) -> Void)? = nil
@@ -44,7 +44,7 @@ public enum GeminiBrowserCookieImporter {
 
     public static func importFromBrowsers(
         allowKeychainPrompt: Bool = false,
-        importOrder: BrowserCookieImportOrder = BrowserCookieDefaults.importOrder,
+        importOrder: BrowserCookieImportOrder = BrowserCookieImportPreference.order,
         detection: BrowserDetection = BrowserDetection(),
         client: BrowserCookieClient = BrowserCookieClient(),
         logger: ((String) -> Void)? = nil

--- a/Sources/VibeBarCore/BrowserCookies/GrokBrowserCookieImporter.swift
+++ b/Sources/VibeBarCore/BrowserCookies/GrokBrowserCookieImporter.swift
@@ -21,7 +21,7 @@ public enum GrokBrowserCookieImporter {
 
     public static func importAndStoreFromBrowsers(
         allowKeychainPrompt: Bool = false,
-        importOrder: BrowserCookieImportOrder = BrowserCookieDefaults.importOrder,
+        importOrder: BrowserCookieImportOrder = BrowserCookieImportPreference.order,
         detection: BrowserDetection = BrowserDetection(),
         client: BrowserCookieClient = BrowserCookieClient(),
         logger: ((String) -> Void)? = nil
@@ -41,7 +41,7 @@ public enum GrokBrowserCookieImporter {
 
     public static func importFromBrowsers(
         allowKeychainPrompt: Bool = false,
-        importOrder: BrowserCookieImportOrder = BrowserCookieDefaults.importOrder,
+        importOrder: BrowserCookieImportOrder = BrowserCookieImportPreference.order,
         detection: BrowserDetection = BrowserDetection(),
         client: BrowserCookieClient = BrowserCookieClient(),
         logger: ((String) -> Void)? = nil

--- a/Sources/VibeBarCore/BrowserCookies/MiscCookieResolver.swift
+++ b/Sources/VibeBarCore/BrowserCookies/MiscCookieResolver.swift
@@ -647,11 +647,14 @@ public enum MiscCookieResolver {
         attempt: BrowserImportAttempt = BrowserImportAttempt(),
         now: Date = Date()
     ) -> [BrowserImportResult] {
+        // A browser picked for this one provider is that provider's own
+        // answer; otherwise the provider's order, narrowed to the browsers
+        // chosen for every import.
         let preferred: [Browser]
         if let kind = settings.preferredBrowser {
             preferred = kind.sweetCookieKitBrowsers
         } else {
-            preferred = spec.importOrder
+            preferred = BrowserCookieImportPreference.restrict(spec.importOrder)
         }
 
         switch spec.browserCredentialSource {

--- a/Sources/VibeBarCore/BrowserCookies/OpenAIBrowserCookieImporter.swift
+++ b/Sources/VibeBarCore/BrowserCookies/OpenAIBrowserCookieImporter.swift
@@ -12,7 +12,7 @@ public enum OpenAIBrowserCookieImporter {
 
     public static func importAndStoreFromBrowsers(
         allowKeychainPrompt: Bool = false,
-        importOrder: BrowserCookieImportOrder = BrowserCookieDefaults.importOrder,
+        importOrder: BrowserCookieImportOrder = BrowserCookieImportPreference.order,
         detection: BrowserDetection = BrowserDetection(),
         client: BrowserCookieClient = BrowserCookieClient(),
         logger: ((String) -> Void)? = nil
@@ -32,7 +32,7 @@ public enum OpenAIBrowserCookieImporter {
 
     public static func importFromBrowsers(
         allowKeychainPrompt: Bool = false,
-        importOrder: BrowserCookieImportOrder = BrowserCookieDefaults.importOrder,
+        importOrder: BrowserCookieImportOrder = BrowserCookieImportPreference.order,
         detection: BrowserDetection = BrowserDetection(),
         client: BrowserCookieClient = BrowserCookieClient(),
         logger: ((String) -> Void)? = nil

--- a/Sources/VibeBarCore/Models/AppSettings.swift
+++ b/Sources/VibeBarCore/Models/AppSettings.swift
@@ -33,6 +33,10 @@ public struct AppSettings: Codable, Equatable, Sendable {
     /// Optional user-visible plan badge overrides. Empty means "Auto".
     public var providerPlanLabels: [ToolType: String]
     public var subscriptionNameFormat: SubscriptionNameFormat
+    /// The browsers cookie imports may read, as SweetCookieKit `Browser`
+    /// raw values in preference order. `nil` — the default — is every
+    /// installed browser. Mirrored into `BrowserCookieImportPreference`.
+    public var cookieImportBrowsers: [String]?
     /// L1 providers shown on the Overview surface. Hiding one keeps its
     /// credentials, refresh schedule, and history intact; it only removes the
     /// provider's Overview card, totals contribution, status tile, and tab.
@@ -342,6 +346,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         popoverDensity: PopoverDensity = .regular,
         providerPlanLabels: [ToolType: String] = AppSettings.defaultProviderPlanLabels,
         subscriptionNameFormat: SubscriptionNameFormat = .full,
+        cookieImportBrowsers: [String]? = nil,
         visibleCoreProviders: Set<ToolType> = AppSettings.defaultVisibleCoreProviders,
         coreProviderOrder: [ToolType] = AppSettings.defaultCoreProviderOrder,
         miscProviders: [ToolType: MiscProviderSettings] = AppSettings.defaultMiscProviders,
@@ -386,6 +391,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         self.popoverDensity = popoverDensity
         self.providerPlanLabels = Self.normalizedProviderPlanLabels(providerPlanLabels)
         self.subscriptionNameFormat = subscriptionNameFormat
+        self.cookieImportBrowsers = Self.normalizedCookieImportBrowsers(cookieImportBrowsers)
         self.visibleCoreProviders = Self.normalizedVisibleCoreProviders(visibleCoreProviders)
         self.coreProviderOrder = Self.normalizedCoreProviderOrder(coreProviderOrder)
         let normalizedLegacyProviders = Self.normalizedMiscProviders(miscProviders)
@@ -424,6 +430,15 @@ public struct AppSettings: Codable, Equatable, Sendable {
     /// Drops unnamed presets, collapses names that differ only by case (the
     /// first wins, which is what "save over the one already in the menu"
     /// produces), and caps each page's list.
+    /// Duplicates dropped, order kept; an empty choice is no choice.
+    static func normalizedCookieImportBrowsers(_ raw: [String]?) -> [String]? {
+        guard let raw else { return nil }
+        var seen: Set<String> = []
+        let kept = raw.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty && seen.insert($0).inserted }
+        return kept.isEmpty ? nil : kept
+    }
+
     static func normalizedPageLayoutPresets(
         _ presets: [PageLayoutPageID: [StoredPageLayoutPreset]]
     ) -> [PageLayoutPageID: [StoredPageLayoutPreset]] {
@@ -465,6 +480,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         case popoverDensity   // legacy single-value form
         case providerPlanLabels
         case subscriptionNameFormat
+        case cookieImportBrowsers
         case visibleCoreProviders
         case coreProviderOrder
         case miscProviders
@@ -546,6 +562,9 @@ public struct AppSettings: Codable, Equatable, Sendable {
         }
 
         subscriptionNameFormat = (try? c.decodeIfPresent(SubscriptionNameFormat.self, forKey: .subscriptionNameFormat)) ?? .full
+        cookieImportBrowsers = Self.normalizedCookieImportBrowsers(
+            try? c.decodeIfPresent([String].self, forKey: .cookieImportBrowsers)
+        )
 
         if let labels = try c.decodeIfPresent([String: String].self, forKey: .providerPlanLabels) {
             var map: [ToolType: String] = [:]
@@ -731,6 +750,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         let planLabels = Dictionary(uniqueKeysWithValues: providerPlanLabels.map { ($0.key.rawValue, $0.value) })
         try c.encode(planLabels, forKey: .providerPlanLabels)
         try c.encode(subscriptionNameFormat, forKey: .subscriptionNameFormat)
+        try c.encodeIfPresent(cookieImportBrowsers, forKey: .cookieImportBrowsers)
         let normalizedVisibleCore = Self.normalizedVisibleCoreProviders(visibleCoreProviders)
         let visibleCoreRaw = ToolType.coreProviderRepresentatives
             .filter { normalizedVisibleCore.contains($0) }

--- a/Tests/VibeBarCoreTests/BrowserCookieImportPreferenceTests.swift
+++ b/Tests/VibeBarCoreTests/BrowserCookieImportPreferenceTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import VibeBarCore
+import SweetCookieKit
+
+/// The browsers a user ticked are the browsers every import reads — the
+/// four core providers' importers through the default order, the misc
+/// resolver through its restricted one — and nothing else is.
+final class BrowserCookieImportPreferenceTests: XCTestCase {
+    override func tearDown() {
+        BrowserCookieImportPreference.apply(nil)
+        super.tearDown()
+    }
+
+    func testNoChoiceMeansTheCatalogueOrderAndAnUntouchedProviderOrder() {
+        BrowserCookieImportPreference.apply(nil)
+        XCTAssertNil(BrowserCookieImportPreference.selected)
+        XCTAssertEqual(BrowserCookieImportPreference.order, BrowserCookieDefaults.importOrder)
+        XCTAssertEqual(BrowserCookieImportPreference.restrict([.edge, .safari]), [.edge, .safari])
+    }
+
+    func testAChoiceIsTheOrderAndRestrictsAProviderToItInTheChosenOrder() {
+        BrowserCookieImportPreference.apply(["edge", "chrome"])
+        XCTAssertEqual(BrowserCookieImportPreference.selected, [.edge, .chrome])
+        XCTAssertEqual(BrowserCookieImportPreference.order, [.edge, .chrome])
+        XCTAssertEqual(BrowserCookieImportPreference.restrict([.safari, .chrome, .edge, .brave]), [.edge, .chrome],
+                       "the chosen order wins over the provider's")
+        XCTAssertEqual(BrowserCookieImportPreference.restrict([.safari, .firefox]), [],
+                       "a provider whose browsers were all left unticked reads nothing")
+    }
+
+    func testUnknownValuesAreDroppedAndAnEmptyChoiceIsNoChoice() {
+        BrowserCookieImportPreference.apply(["chrome", "netscape"])
+        XCTAssertEqual(BrowserCookieImportPreference.selected, [.chrome])
+        BrowserCookieImportPreference.apply([])
+        XCTAssertNil(BrowserCookieImportPreference.selected)
+        BrowserCookieImportPreference.apply(["netscape"])
+        XCTAssertNil(BrowserCookieImportPreference.selected)
+    }
+
+    func testThePickerListsInstalledBrowsersWithACookieStoreInCatalogueOrder() {
+        let detection = BrowserDetection(
+            homeDirectory: "/Users/example",
+            fileExists: { path in
+                if path.hasSuffix(".app") { return path.hasSuffix("/Google Chrome.app") || path.hasSuffix("/Microsoft Edge.app") }
+                return true
+            },
+            directoryContents: { _ in ["Default"] }
+        )
+        XCTAssertEqual(BrowserCookieImportPreference.available(using: detection), [.safari, .chrome, .edge])
+    }
+
+    func testTheSettingRoundTripsAndDropsDuplicatesAndBlanks() throws {
+        var settings = AppSettings.default
+        settings.cookieImportBrowsers = ["edge", " ", "chrome", "edge"]
+        let data = try JSONEncoder().encode(settings)
+        let decoded = try JSONDecoder().decode(AppSettings.self, from: data)
+        XCTAssertEqual(decoded.cookieImportBrowsers, ["edge", "chrome"])
+        let absent = try JSONDecoder().decode(AppSettings.self, from: Data("{}".utf8))
+        XCTAssertNil(absent.cookieImportBrowsers)
+        let empty = try JSONDecoder().decode(AppSettings.self, from: Data(#"{"cookieImportBrowsers":[]}"#.utf8))
+        XCTAssertNil(empty.cookieImportBrowsers, "an empty list is no choice, not a choice of nothing")
+    }
+}

--- a/Tests/VibeBarCoreTests/MiscCookieImportCooldownTests.swift
+++ b/Tests/VibeBarCoreTests/MiscCookieImportCooldownTests.swift
@@ -63,6 +63,24 @@ final class MiscCookieImportCooldownTests: XCTestCase {
         try super.tearDownWithError()
     }
 
+    // MARK: - The chosen browsers are the ones read
+
+    /// The provider's order narrowed to the browsers chosen for every
+    /// import, so an unticked browser is never read for a misc provider
+    /// either — and a provider's own preferred browser still wins.
+    func testTheMiscImportWalksOnlyTheChosenBrowsers() {
+        defer { BrowserCookieImportPreference.apply(nil) }
+        BrowserCookieImportPreference.apply(["edge"])
+        let spec = MiscCookieResolver.Spec(tool: .zai, domains: ["example.test"], requiredNames: [], importOrder: [.safari, .chrome, .edge])
+        let restricted = BrowserCookieImportPreference.restrict(spec.importOrder)
+        XCTAssertEqual(restricted, [.edge])
+        XCTAssertEqual(restricted.cookieImportCandidates(using: fakeDetection(), allowKeychainPrompt: true), [.edge])
+        var settings = MiscProviderSettings()
+        settings.preferredBrowser = .chrome
+        XCTAssertEqual(settings.preferredBrowser?.sweetCookieKitBrowsers.first, .chrome,
+                       "a browser picked for one provider is that provider's own answer")
+    }
+
     // MARK: - The cooldown is honoured, not bypassed
 
     func testAPromptingImportSkipsABrowserInsideItsCooldown() {


### PR DESCRIPTION
Follow-up to #362: the browsers a cookie import reads are now the user's choice, made once for every import, in Settings › Misc Providers and in the setup assistant's browser-cookies step.

## What changes

- `AppSettings.cookieImportBrowsers: [String]?` — SweetCookieKit `Browser` raw values in preference order; nil (the default) is every installed browser, as before. Duplicates and blanks are dropped; an empty list decodes as nil.
- `BrowserCookieImportPreference` mirrors the setting process-wide (`AppEnvironment` applies it on load and on change). The four core providers' importers take `BrowserCookieImportPreference.order` as their default order; `MiscCookieResolver` narrows each provider's own order with `restrict(_:)`, in the chosen order. A provider's own `preferredBrowser` still wins for that provider.
- `BrowserSelectionView` lists `BrowserCookieImportPreference.available()` — installed browsers with a cookie store, in the catalogue's order — one switch each, with a "Read every installed browser" reset. Ticking every browser back on clears the choice rather than pinning today's list, so the machine's browsers can change without the setting going stale.
- Catalog 0.8.0 carries the four `settings.browsers.*` strings (en, zh-Hans); `Package.swift` pins it.
- AGENTS.md § 7.0 writes down the three browser-cookie rules (installed only, per-browser preflight, one choice read everywhere).

## Verification

- `swift build`; `swift test`: 2363 tests, 3 skipped, 0 failures (the localization lint covers the new view); `./Scripts/build_app.sh release`; `codesign -d --entitlements -` → empty dict.
- Demo-mode captures: Settings › Misc Providers shows "Browsers to read" above the import button, and the setup assistant's Browser cookies step shows it above "Import from all browsers now". The demo home has no browser profiles, so only Safari is listed there; on the maintainer's real home the same detection lists Safari, Chrome and Edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
