### PR TITLE
Give every Chat bucket a group, a window row and a reset

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -919,7 +919,7 @@ SubProvider → L3 quota / model group. Source of truth:
 | L1 company | L2 SubProvider        | L3 quota / model groups                  |
 | ---------- | --------------------- | ---------------------------------------- |
 | OpenAI     | ChatGPT Agentic       | All Models, Codex Spark …                 |
-| OpenAI     | ChatGPT Chat          | Image Generation, Deep Research, GPT-6 Astra Pro · Weekly, GPT-5.6 Sol Pro · Daily, Pro Models · Daily/Weekly |
+| OpenAI     | ChatGPT Chat          | Image Generation · Daily, Deep Research · Monthly, GPT-6 Astra Pro · Weekly, GPT-5.6 Sol Pro · Daily, Pro Models · Daily/Weekly |
 | Anthropic  | Claude                | All Models, Sonnet, Opus, Fable …         |
 | Google AI  | Gemini Web            | 5 Hours, Weekly                           |
 | Google AI  | AntiGravity           | Gemini Models, Claude & GPT Models        |
@@ -1040,9 +1040,15 @@ counts the account's saved conversations instead: `ChatGPTChatHistoryReader`
 walks `/backend-api/conversations` newest first inside a one-week window,
 skips Work rows and temporary chats, fetches only changed revisions (24 per
 refresh, 25 s), and `ChatGPTChatParser.conversation` charges each user turn
-to the model of its final answer, once. The buckets file under the model as their L3 group (GPT-6 Astra Pro,
-GPT-5.6 Sol Pro, Pro Models) with the window (Weekly, Daily) as the row, the
-way Codex's Spark lanes are drawn. `ChatGPTChatProAllowances` holds the
+to the model of its final answer, once. Every Chat bucket files under what it meters as its L3 group — Image
+Generation, Deep Research, GPT-6 Astra Pro, GPT-5.6 Sol Pro, Pro Models —
+with its window as the row (`ChatGPTChatWindow.label(seconds:)` names one
+from its length, tolerantly, because the service reports "now + window" on
+an untouched allowance). A feature with no known window keeps the feature
+name as its row and no group. A Pro bucket's reset is the oldest message
+still inside its window plus the window, or a whole window from now when
+nothing was spent — the rolling shape the service reports for the features
+it does time — so the Pro rows pace and forecast like every other row. `ChatGPTChatProAllowances` holds the
 published totals per `plan_type` (`pro`: 200/week GPT-6 Pro, 170/day Sol Pro,
 200/day both; `prolite`: 50/week shared — help article 20001354, read
 2026-09-07); other plans get no Pro buckets. Counts are trailing-window

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1048,7 +1048,14 @@ an untouched allowance). A feature with no known window keeps the feature
 name as its row and no group. A Pro bucket's reset is the oldest message
 still inside its window plus the window, or a whole window from now when
 nothing was spent — the rolling shape the service reports for the features
-it does time — so the Pro rows pace and forecast like every other row. `ChatGPTChatProAllowances` holds the
+it does time — so the Pro rows pace and forecast like every other row. Such
+a bucket sets `QuotaBucket.hasRollingReset`, which keeps
+`SubscriptionHistoryStore` out of it: a message ageing out returns one unit
+and moves the date, and reading that as a completed cycle would fill the
+reset history with cycles nothing ever reset. Every Chat field is
+`isBranchStyleField`, since each carries an L3 group; `shortLabel` stays the
+feature or model name, because the menu bar prints that one and "Daily"
+alone does not say daily what. `ChatGPTChatProAllowances` holds the
 published totals per `plan_type` (`pro`: 200/week GPT-6 Pro, 170/day Sol Pro,
 200/day both; `prolite`: 50/week shared — help article 20001354, read
 2026-09-07); other plans get no Pro buckets. Counts are trailing-window

--- a/Sources/VibeBarCore/Adapters/ChatGPTChatClient.swift
+++ b/Sources/VibeBarCore/Adapters/ChatGPTChatClient.swift
@@ -220,7 +220,10 @@ public struct ChatGPTChatClient: Sendable {
             // known the feature name is the row and there is no group, so a
             // first read never files a bucket under a group of one.
             let row = ChatGPTChatWindow.label(seconds: window)
-            return QuotaBucket(id: sample.id, title: row ?? feature, shortLabel: row ?? feature, usedPercent: 0,
+            // The row is the window, but `shortLabel` stays the feature: it
+            // is what the menu bar and the compact mini layouts print, and
+            // "Daily" alone would not say daily *what*.
+            return QuotaBucket(id: sample.id, title: row ?? feature, shortLabel: feature, usedPercent: 0,
                                resetAt: sample.resetAt, rawWindowSeconds: window,
                                groupTitle: row == nil ? nil : feature,
                                quantity: quantities[sample.id]?.quantity)

--- a/Sources/VibeBarCore/Adapters/ChatGPTChatClient.swift
+++ b/Sources/VibeBarCore/Adapters/ChatGPTChatClient.swift
@@ -213,9 +213,16 @@ public struct ChatGPTChatClient: Sendable {
         let quantities = try await store.observe(localAccount: account.id, identity: identity,
                                                 plan: plan?.lowercased(), samples: samples)
         var buckets = samples.map { sample in
-            let title = sample.id == "image_gen" ? "Image Generation" : "Deep Research"
-            return QuotaBucket(id: sample.id, title: title, shortLabel: title, usedPercent: 0,
-                               resetAt: sample.resetAt, rawWindowSeconds: quantities[sample.id]?.windowSeconds,
+            let feature = sample.id == "image_gen" ? "Image Generation" : "Deep Research"
+            let window = quantities[sample.id]?.windowSeconds
+            // The feature is the group and its window is the row, the way
+            // Codex's Spark lanes and the Pro models read. Until a window is
+            // known the feature name is the row and there is no group, so a
+            // first read never files a bucket under a group of one.
+            let row = ChatGPTChatWindow.label(seconds: window)
+            return QuotaBucket(id: sample.id, title: row ?? feature, shortLabel: row ?? feature, usedPercent: 0,
+                               resetAt: sample.resetAt, rawWindowSeconds: window,
+                               groupTitle: row == nil ? nil : feature,
                                quantity: quantities[sample.id]?.quantity)
         }
         var summary = ChatGPTChatSummary(transport: transport.name, planVerified: plan != nil, accountIdentity: identity)

--- a/Sources/VibeBarCore/Adapters/ChatGPTChatProModels.swift
+++ b/Sources/VibeBarCore/Adapters/ChatGPTChatProModels.swift
@@ -1,5 +1,26 @@
 import Foundation
 
+/// The contract name for a Chat allowance's window, so every Chat row reads
+/// the way the rest of the app's rows do: the thing being metered is the
+/// group, the window is the row.
+///
+/// Ranges rather than exact matches, because the window is usually inferred
+/// from the service's own `reset_after` — which is "now + window" on an
+/// allowance nothing has been spent from, so a read a few minutes into the
+/// window is a few minutes short of a whole one.
+public enum ChatGPTChatWindow {
+    public static func label(seconds: Int?) -> String? {
+        guard let seconds, seconds > 0 else { return nil }
+        switch seconds {
+        case (4 * 3_600)...(6 * 3_600): return "5 Hours"
+        case (20 * 3_600)...(28 * 3_600): return "Daily"
+        case (6 * 86_400)...(8 * 86_400): return "Weekly"
+        case (28 * 86_400)...(32 * 86_400): return "Monthly"
+        default: return nil
+        }
+    }
+}
+
 /// One Pro-model allowance as OpenAI publishes it for a plan's Chat surface.
 ///
 /// Source: "GPT-5.6 and GPT-6 Pro in ChatGPT", help.openai.com article
@@ -183,11 +204,18 @@ extension ChatGPTChatParser {
     }
 
     /// Each allowance as a quota bucket: the messages charged to its models
-    /// inside a window ending now, against the published total. The service
-    /// states no window start, so the count is a trailing window and is
-    /// marked estimated; a throttled model overrides it with the service's
-    /// own exhausted state and reset. A shared allowance counts as
-    /// throttled only when every model it covers is.
+    /// inside a window ending now, against the published total, marked
+    /// estimated.
+    ///
+    /// The reset is the moment the count next falls — the oldest message
+    /// still inside the window, plus the window — and a full allowance
+    /// resets a whole window from now. That is the same rolling shape the
+    /// service reports for the feature allowances it *does* time: an unused
+    /// Image Generation allowance comes back as "now + 24h" on every read.
+    /// With it the Pro rows carry the pace, forecast and history every other
+    /// quota row has. A throttled model overrides both count and reset with
+    /// the service's own; a shared allowance counts as throttled only when
+    /// every model it covers is.
     public static func proBuckets(allowances: [ChatGPTChatProAllowance], turns: [ChatGPTChatTurn],
                                   limits: [ChatGPTChatModelLimit], complete: Bool, now: Date) -> [QuotaBucket] {
         let unique = Dictionary(turns.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first }).values
@@ -204,7 +232,11 @@ extension ChatGPTChatParser {
             } else {
                 quantity = QuotaQuantity(used: used, remaining: complete ? max(0, allowance.limit - used) : nil,
                                          limit: allowance.limit, isEstimated: true, coverageComplete: complete)
-                resetAt = nil
+                let oldest = unique
+                    .filter { allowance.models.contains($0.model) && $0.createdAt > start && $0.createdAt <= now }
+                    .map(\.createdAt)
+                    .min()
+                resetAt = (oldest ?? now).addingTimeInterval(TimeInterval(allowance.windowSeconds))
             }
             return QuotaBucket(id: allowance.id, title: allowance.title, shortLabel: allowance.title,
                                usedPercent: quantity.usedPercent ?? 0, resetAt: resetAt,

--- a/Sources/VibeBarCore/Adapters/ChatGPTChatProModels.swift
+++ b/Sources/VibeBarCore/Adapters/ChatGPTChatProModels.swift
@@ -226,6 +226,9 @@ extension ChatGPTChatParser {
             let exhausted = allowance.models.allSatisfy { limited[$0] != nil }
             let quantity: QuotaQuantity
             let resetAt: Date?
+            // The service's own reset is a real deadline; the one derived
+            // below is the next expiry of a rolling count.
+            var rolling = false
             if exhausted {
                 quantity = QuotaQuantity(used: allowance.limit, remaining: 0, limit: allowance.limit, isEstimated: true)
                 resetAt = allowance.models.compactMap { limited[$0]?.resetsAt }.max()
@@ -237,10 +240,12 @@ extension ChatGPTChatParser {
                     .map(\.createdAt)
                     .min()
                 resetAt = (oldest ?? now).addingTimeInterval(TimeInterval(allowance.windowSeconds))
+                rolling = true
             }
             return QuotaBucket(id: allowance.id, title: allowance.title, shortLabel: allowance.title,
                                usedPercent: quantity.usedPercent ?? 0, resetAt: resetAt,
-                               rawWindowSeconds: allowance.windowSeconds, groupTitle: allowance.group, quantity: quantity)
+                               rawWindowSeconds: allowance.windowSeconds, groupTitle: allowance.group,
+                               quantity: quantity, hasRollingReset: rolling)
         }
     }
 

--- a/Sources/VibeBarCore/Models/MenuBarQuotaGrouping.swift
+++ b/Sources/VibeBarCore/Models/MenuBarQuotaGrouping.swift
@@ -58,6 +58,11 @@ public extension MenuBarFieldCatalog {
             return field.dynamicGroupTitle != nil
         }
         switch field.bucketId {
+        // Every ChatGPT Chat bucket files under what it meters — the
+        // feature or the model — with its window as the row.
+        case "image_gen", "deep_research",
+             "gpt6_pro_weekly", "sol_pro_daily", "pro_daily", "pro_weekly":
+            return true
         case "gpt_5_3_codex_spark_five_hour",
              "gpt_5_3_codex_spark_weekly",
              "weekly_sonnet",

--- a/Sources/VibeBarCore/Models/QuotaBucket.swift
+++ b/Sources/VibeBarCore/Models/QuotaBucket.swift
@@ -9,6 +9,16 @@ public struct QuotaBucket: Codable, Identifiable, Hashable, Sendable {
     public var rawWindowSeconds: Int?
     public var groupTitle: String?
     public var quantity: QuotaQuantity?
+    /// True when `resetAt` is the moment this bucket's count next *falls*
+    /// rather than the moment its cycle ends.
+    ///
+    /// A trailing-window count has no cycle: every message that ages out
+    /// returns one unit and moves the date, so a deadline that advanced
+    /// says nothing happened except time passing. It is exactly what pace
+    /// and forecast need, and exactly what the cycle history must not see —
+    /// `SubscriptionHistoryStore` would read each expiry as a completed
+    /// cycle and fill the reset history with them.
+    public var hasRollingReset: Bool
 
     public var hasPercentage: Bool { quantity.map { $0.usedPercent != nil } ?? true }
     public var supportsForecast: Bool { hasPercentage }
@@ -21,8 +31,10 @@ public struct QuotaBucket: Codable, Identifiable, Hashable, Sendable {
         resetAt: Date? = nil,
         rawWindowSeconds: Int? = nil,
         groupTitle: String? = nil,
-        quantity: QuotaQuantity? = nil
+        quantity: QuotaQuantity? = nil,
+        hasRollingReset: Bool = false
     ) {
+        self.hasRollingReset = hasRollingReset
         self.quantity = quantity
         self.id = id
         self.title = VisibleSecretRedactor.redact(title) ?? ""
@@ -51,6 +63,7 @@ public struct QuotaBucket: Codable, Identifiable, Hashable, Sendable {
         case rawWindowSeconds
         case groupTitle
         case quantity
+        case hasRollingReset
     }
 
     public init(from decoder: Decoder) throws {
@@ -63,7 +76,8 @@ public struct QuotaBucket: Codable, Identifiable, Hashable, Sendable {
             resetAt: try container.decodeIfPresent(Date.self, forKey: .resetAt),
             rawWindowSeconds: try container.decodeIfPresent(Int.self, forKey: .rawWindowSeconds),
             groupTitle: try container.decodeIfPresent(String.self, forKey: .groupTitle),
-            quantity: try container.decodeIfPresent(QuotaQuantity.self, forKey: .quantity)
+            quantity: try container.decodeIfPresent(QuotaQuantity.self, forKey: .quantity),
+            hasRollingReset: try container.decodeIfPresent(Bool.self, forKey: .hasRollingReset) ?? false
         )
     }
 
@@ -77,6 +91,9 @@ public struct QuotaBucket: Codable, Identifiable, Hashable, Sendable {
         try container.encodeIfPresent(rawWindowSeconds, forKey: .rawWindowSeconds)
         try container.encodeIfPresent(groupTitle, forKey: .groupTitle)
         try container.encodeIfPresent(quantity, forKey: .quantity)
+        // Absent means false, which is what every bucket written before this
+        // was; only the buckets that carry one pay a key.
+        if hasRollingReset { try container.encode(true, forKey: .hasRollingReset) }
     }
 
     /// Quota-window names are ordinary UI copy, not telemetry codes. Keep

--- a/Sources/VibeBarCore/Services/MockDataProvider.swift
+++ b/Sources/VibeBarCore/Services/MockDataProvider.swift
@@ -190,20 +190,25 @@ public enum MockDataProvider {
         switch account.tool {
         case .chatgptChat:
             buckets = [
-                QuotaBucket(id: "image_gen", title: "Image Generation", shortLabel: "Image Generation", usedPercent: 0,
+                QuotaBucket(id: "image_gen", title: "Daily", shortLabel: "Daily", usedPercent: 0,
                             resetAt: now.addingTimeInterval(36000), rawWindowSeconds: 86_400,
+                            groupTitle: "Image Generation",
                             quantity: .init(used: 2, remaining: 998, limit: 1000, isEstimated: true)),
-                QuotaBucket(id: "deep_research", title: "Deep Research", shortLabel: "Deep Research", usedPercent: 0,
+                QuotaBucket(id: "deep_research", title: "Monthly", shortLabel: "Monthly", usedPercent: 0,
                             resetAt: now.addingTimeInterval(1209600), rawWindowSeconds: 30 * 86_400,
+                            groupTitle: "Deep Research",
                             quantity: .init(used: 3, remaining: 247, limit: 250, isEstimated: true)),
                 QuotaBucket(id: "gpt6_pro_weekly", title: "Weekly", shortLabel: "Weekly", usedPercent: 0,
-                            rawWindowSeconds: 7 * 86_400, groupTitle: "GPT-6 Astra Pro",
+                            resetAt: now.addingTimeInterval(4 * 86_400), rawWindowSeconds: 7 * 86_400,
+                            groupTitle: "GPT-6 Astra Pro",
                             quantity: .init(used: 6, remaining: 194, limit: 200, isEstimated: true)),
                 QuotaBucket(id: "sol_pro_daily", title: "Daily", shortLabel: "Daily", usedPercent: 0,
-                            rawWindowSeconds: 86_400, groupTitle: "GPT-5.6 Sol Pro",
+                            resetAt: now.addingTimeInterval(19 * 3_600), rawWindowSeconds: 86_400,
+                            groupTitle: "GPT-5.6 Sol Pro",
                             quantity: .init(used: 0, remaining: 170, limit: 170, isEstimated: true)),
                 QuotaBucket(id: "pro_daily", title: "Daily", shortLabel: "Daily", usedPercent: 0,
-                            rawWindowSeconds: 86_400, groupTitle: "Pro Models",
+                            resetAt: now.addingTimeInterval(11 * 3_600), rawWindowSeconds: 86_400,
+                            groupTitle: "Pro Models",
                             quantity: .init(used: 4, remaining: 196, limit: 200, isEstimated: true))
             ]
         case .codex:

--- a/Sources/VibeBarCore/Services/SubscriptionHistoryStore.swift
+++ b/Sources/VibeBarCore/Services/SubscriptionHistoryStore.swift
@@ -150,7 +150,10 @@ public actor SubscriptionHistoryStore {
             storage.redemptions = saved.values.sorted { $0.credit.redeemedAt < $1.credit.redeemedAt }
         }
         if observeFeatures(quota, now: now, storage: &storage) { dirty = true }
-        for bucket in quota.buckets where bucket.supportsForecast {
+        // A rolling reset is the next expiry of a trailing count, not the
+        // end of a cycle: reading each expiry as a completed cycle would
+        // fill the history with cycles nothing ever reset.
+        for bucket in quota.buckets where bucket.supportsForecast && !bucket.hasRollingReset {
             guard let resetAt = bucket.resetAt, bucket.usedPercent.isFinite else { continue }
             let used = clamp(bucket.usedPercent)
             let key = SubscriptionHistoryKey(accountId: quota.accountId, bucketId: bucket.id)
@@ -656,7 +659,9 @@ public actor SubscriptionHistoryStore {
     private func observeFeatures(_ quota: AccountQuota, now: Date, storage: inout Storage) -> Bool {
         var changed = false
         for bucket in quota.buckets {
-            guard let remaining = bucket.quantity?.remaining else { continue }
+            // Same reason as the cycle loop: a message ageing out returns a
+            // unit without anything having reset.
+            guard !bucket.hasRollingReset, let remaining = bucket.quantity?.remaining else { continue }
             let key = PrivacyPreservingHash.fileComponent(prefix: "feature", rawValue: quota.accountId + ":" + bucket.id)
             let sample = ChatGPTChatAllowanceSample(id: bucket.id, remaining: remaining, resetAt: bucket.resetAt, observedAt: now)
             let previous = storage.featureObservations?[key]

--- a/Tests/VibeBarCoreTests/ChatGPTChatTests.swift
+++ b/Tests/VibeBarCoreTests/ChatGPTChatTests.swift
@@ -152,6 +152,14 @@ final class ChatGPTChatTests: XCTestCase {
         // The feature is the group, its window is the row.
         XCTAssertEqual(quota.buckets.map(\.groupTitle), ["Image Generation", "Deep Research"])
         XCTAssertEqual(quota.buckets.map(\.title), ["Daily", "Monthly"])
+        // The compact surfaces still name the feature: "Daily" alone would
+        // not say daily what.
+        XCTAssertEqual(quota.buckets.map(\.shortLabel), ["Image Generation", "Deep Research"])
+        XCTAssertFalse(quota.buckets.contains(where: \.hasRollingReset), "these resets are the service's own")
+        for field in MenuBarFieldCatalog.chatGPTChatFields {
+            XCTAssertTrue(MenuBarFieldCatalog.isBranchStyleField(field),
+                          "\(field.bucketId) carries an L3 group, so every surface that composes one must know")
+        }
         XCTAssertNotNil(UsagePace.compute(bucket: quota.buckets[0], now: base))
         XCTAssertNil(quota.chatGPTChat?.history)
         let calls = await transport.calls
@@ -331,6 +339,8 @@ final class ChatGPTChatTests: XCTestCase {
         XCTAssertTrue(buckets.allSatisfy { $0.quantity?.isEstimated == true && $0.hasPercentage })
         XCTAssertNotNil(UsagePace.compute(bucket: buckets[0], now: base), "a Pro row paces like every other row")
         XCTAssertNotNil(QuotaPaceForecast.compute(bucket: buckets[0], observations: [], cycles: [], now: base))
+        // A rolling reset paces and forecasts, and is not a cycle boundary.
+        XCTAssertTrue(buckets.allSatisfy(\.hasRollingReset))
         // Nothing spent: a whole window from now, as the service reports for
         // an untouched feature allowance.
         let untouched = ChatGPTChatParser.proBuckets(allowances: pro, turns: [], limits: [], complete: true, now: base)
@@ -350,6 +360,8 @@ final class ChatGPTChatTests: XCTestCase {
         XCTAssertEqual(oneLimited[0].quantity?.remaining, 0)
         XCTAssertEqual(oneLimited[0].usedPercent, 100)
         XCTAssertEqual(oneLimited[0].resetAt, reset)
+        XCTAssertFalse(oneLimited[0].hasRollingReset, "a service-reported reset is a real deadline")
+        XCTAssertTrue(oneLimited[2].hasRollingReset)
         XCTAssertTrue(oneLimited[0].hasPercentage, "the service's exhausted state needs no history")
         XCTAssertEqual(oneLimited[2].quantity?.used, 3, "one throttled model does not exhaust a shared allowance")
         XCTAssertEqual(oneLimited[2].resetAt, base.addingTimeInterval(-7_200 + 86_400),

--- a/Tests/VibeBarCoreTests/ChatGPTChatTests.swift
+++ b/Tests/VibeBarCoreTests/ChatGPTChatTests.swift
@@ -149,6 +149,10 @@ final class ChatGPTChatTests: XCTestCase {
         XCTAssertTrue(quota.buckets.allSatisfy { $0.hasPercentage && $0.quantity?.isEstimated == true },
                       "the first read already shows an estimated percentage")
         XCTAssertEqual(quota.buckets.first?.quantity?.limit, 998)
+        // The feature is the group, its window is the row.
+        XCTAssertEqual(quota.buckets.map(\.groupTitle), ["Image Generation", "Deep Research"])
+        XCTAssertEqual(quota.buckets.map(\.title), ["Daily", "Monthly"])
+        XCTAssertNotNil(UsagePace.compute(bucket: quota.buckets[0], now: base))
         XCTAssertNil(quota.chatGPTChat?.history)
         let calls = await transport.calls
         XCTAssertEqual(calls, ["/api/auth/session", "/backend-api/wham/usage", "/backend-api/conversation/init"])
@@ -263,6 +267,20 @@ final class ChatGPTChatTests: XCTestCase {
         XCTAssertTrue(ChatGPTChatParser.modelLimits(Data("{}".utf8), now: base).isEmpty)
     }
 
+    func testAWindowIsNamedByItsLengthAndTolerantOfAReadInsideIt() {
+        XCTAssertEqual(ChatGPTChatWindow.label(seconds: 86_400), "Daily")
+        XCTAssertEqual(ChatGPTChatWindow.label(seconds: 86_400 - 120), "Daily", "the service reports now + window")
+        XCTAssertEqual(ChatGPTChatWindow.label(seconds: 7 * 86_400), "Weekly")
+        XCTAssertEqual(ChatGPTChatWindow.label(seconds: 30 * 86_400 - 3_600), "Monthly")
+        XCTAssertEqual(ChatGPTChatWindow.label(seconds: 18_000), "5 Hours")
+        XCTAssertNil(ChatGPTChatWindow.label(seconds: 3 * 86_400), "a window with no standard name gets none")
+        XCTAssertNil(ChatGPTChatWindow.label(seconds: nil))
+        XCTAssertNil(ChatGPTChatWindow.label(seconds: 0))
+        for label in ["Daily", "Weekly", "Monthly", "5 Hours"] {
+            XCTAssertNotEqual(QuotaGroupLabelLocalizer.display(label), "", "\(label) is a label the catalogue translates")
+        }
+    }
+
     func testProAllowancesFollowThePublishedPlanTable() {
         let pro = ChatGPTChatProAllowances.allowances(plan: "pro")
         XCTAssertEqual(pro.map(\.id), ["gpt6_pro_weekly", "sol_pro_daily", "pro_daily"])
@@ -305,8 +323,20 @@ final class ChatGPTChatTests: XCTestCase {
         XCTAssertEqual(buckets[1].quantity?.used, 2, "a duplicate turn id counts once")
         XCTAssertEqual(buckets[1].quantity?.remaining, 168)
         XCTAssertEqual(buckets[2].quantity?.used, 3)
-        XCTAssertNil(buckets[0].resetAt, "no window start is known, so no reset is claimed")
+        // The reset is when the count next falls: the oldest message inside
+        // the window, plus the window.
+        XCTAssertEqual(buckets[0].resetAt, base.addingTimeInterval(-(7 * 86_400 - 1) + 7 * 86_400))
+        XCTAssertEqual(buckets[1].resetAt, base.addingTimeInterval(-7_200 + 86_400),
+                       "the day-old Sol Pro message is outside the daily window; the two-hour-old one is the oldest inside it")
         XCTAssertTrue(buckets.allSatisfy { $0.quantity?.isEstimated == true && $0.hasPercentage })
+        XCTAssertNotNil(UsagePace.compute(bucket: buckets[0], now: base), "a Pro row paces like every other row")
+        XCTAssertNotNil(QuotaPaceForecast.compute(bucket: buckets[0], observations: [], cycles: [], now: base))
+        // Nothing spent: a whole window from now, as the service reports for
+        // an untouched feature allowance.
+        let untouched = ChatGPTChatParser.proBuckets(allowances: pro, turns: [], limits: [], complete: true, now: base)
+        XCTAssertEqual(untouched.map(\.resetAt), [base.addingTimeInterval(7 * 86_400),
+                                                  base.addingTimeInterval(86_400),
+                                                  base.addingTimeInterval(86_400)])
 
         let partial = ChatGPTChatParser.proBuckets(allowances: pro, turns: turns, limits: [], complete: false, now: base)
         XCTAssertEqual(partial[0].quantity?.used, 3)
@@ -322,7 +352,8 @@ final class ChatGPTChatTests: XCTestCase {
         XCTAssertEqual(oneLimited[0].resetAt, reset)
         XCTAssertTrue(oneLimited[0].hasPercentage, "the service's exhausted state needs no history")
         XCTAssertEqual(oneLimited[2].quantity?.used, 3, "one throttled model does not exhaust a shared allowance")
-        XCTAssertNil(oneLimited[2].resetAt)
+        XCTAssertEqual(oneLimited[2].resetAt, base.addingTimeInterval(-7_200 + 86_400),
+                       "the shared lane keeps its own rolling reset")
 
         let bothLimited = ChatGPTChatParser.proBuckets(allowances: pro, turns: turns, limits: [
             ChatGPTChatModelLimit(model: "gpt-6-pro", resetsAt: reset, fallbackModel: nil),
@@ -454,6 +485,8 @@ private actor HistoryFixtureTransport: ChatGPTChatTransport {
 
 private actor ChatFixtureTransport: ChatGPTChatTransport {
     nonisolated let name = "fixture"
+    nonisolated static let base = Date(timeIntervalSince1970: 1_800_000_000)
+    nonisolated static let iso = ISO8601DateFormatter()
     private(set) var calls: [String] = []
     func request(path: String, method: String, bearer: String?, body: Data?) async throws -> Data {
         calls.append(path)
@@ -461,7 +494,17 @@ private actor ChatFixtureTransport: ChatGPTChatTransport {
         switch path {
         case "/api/auth/session": return Data(#"{"accessToken":"synthetic-token","user":{"id":"synthetic-user"}}"#.utf8)
         case "/backend-api/wham/usage": return Data(#"{"plan_type":"prolite"}"#.utf8)
-        case "/backend-api/conversation/init": return Data(#"{"limits_progress":[{"feature_name":"image_gen","remaining":998},{"feature_name":"deep_research","remaining":250}]}"#.utf8)
+        case "/backend-api/conversation/init":
+            // `reset_after` as the service sends it: a whole window from now
+            // on an allowance nothing has been spent from.
+            let day = ChatFixtureTransport.iso.string(from: ChatFixtureTransport.base.addingTimeInterval(86_400 - 120))
+            let month = ChatFixtureTransport.iso.string(from: ChatFixtureTransport.base.addingTimeInterval(30 * 86_400 - 3_600))
+            return Data("""
+            {"limits_progress":[
+              {"feature_name":"image_gen","remaining":998,"reset_after":"\(day)"},
+              {"feature_name":"deep_research","remaining":250,"reset_after":"\(month)"}
+            ]}
+            """.utf8)
         default: throw QuotaError.parseFailure("Unexpected endpoint")
         }
     }

--- a/Tests/VibeBarCoreTests/SubscriptionHistoryStoreTests.swift
+++ b/Tests/VibeBarCoreTests/SubscriptionHistoryStoreTests.swift
@@ -1209,3 +1209,52 @@ final class SubscriptionHistoryStoreTests: XCTestCase {
         ]
     }
 }
+
+extension SubscriptionHistoryStoreTests {
+    /// A trailing-window count has no cycle. Its reset moves every time a
+    /// message ages out, and the count falls with it — which the cycle
+    /// history would otherwise read as a quota that had just refilled, once
+    /// per expiry, for as long as the user keeps using the model.
+    func testARollingResetNeverRecordsACycleOrAFeatureReset() async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SubscriptionHistoryStore(fileURL: directory.appendingPathComponent("history.json"))
+        let start = Date(timeIntervalSince1970: 1_800_000_000)
+        func quota(used: Double, remaining: Int, resetAt: Date, rolling: Bool) -> AccountQuota {
+            AccountQuota(
+                accountId: "chat", tool: .chatgptChat,
+                buckets: [QuotaBucket(
+                    id: "gpt6_pro_weekly", title: "Weekly", shortLabel: "Weekly", usedPercent: used,
+                    resetAt: resetAt, rawWindowSeconds: 7 * 86_400, groupTitle: "GPT-6 Astra Pro",
+                    quantity: .init(used: Int(used * 2), remaining: remaining, limit: 200, isEstimated: true),
+                    hasRollingReset: rolling
+                )],
+                plan: "pro", email: nil, queriedAt: start
+            )
+        }
+        // Three expiries: the deadline walks forward a day at a time and the
+        // count falls with it.
+        for day in 0..<3 {
+            let now = start.addingTimeInterval(TimeInterval(day) * 86_400)
+            await store.observe(
+                quota(used: Double(30 - day * 10), remaining: 140 + day * 20,
+                      resetAt: now.addingTimeInterval(86_400), rolling: true),
+                now: now
+            )
+        }
+        let samples = await store.allSamples()
+        XCTAssertTrue(samples.isEmpty, "no cycle ended; time merely passed")
+
+        // The same shape without the flag is a real deadline, and is recorded.
+        for day in 0..<2 {
+            let now = start.addingTimeInterval(TimeInterval(day) * 86_400)
+            await store.observe(
+                quota(used: Double(90 - day * 80), remaining: 20 + day * 160,
+                      resetAt: now.addingTimeInterval(86_400), rolling: false),
+                now: now
+            )
+        }
+        let recorded = await store.allSamples()
+        XCTAssertFalse(recorded.isEmpty, "a bucket whose deadline is the provider's still records its cycles")
+    }
+}

--- a/docs/chatgpt-chat.md
+++ b/docs/chatgpt-chat.md
@@ -49,9 +49,11 @@ and `/backend-api/models` carries no allowance fields. What OpenAI publishes
 is the total per plan, in "GPT-5.6 and GPT-6 Pro in ChatGPT" (help article
 20001354, read 2026-09-07):
 
-The buckets are grouped the way Codex's Spark lanes are: the model is the
-group header (GPT-6 Astra Pro, GPT-5.6 Sol Pro, Pro Models) and the window
-(Weekly, Daily) is the row.
+Every Chat bucket is grouped the way Codex's Spark lanes are: the thing
+being metered is the group header — Image Generation, Deep Research,
+GPT-6 Astra Pro, GPT-5.6 Sol Pro, Pro Models — and its window (Daily,
+Weekly, Monthly) is the row. A feature whose window is not known yet keeps
+the feature name as its row and has no group.
 
 | Plan | GPT-6 Astra Pro | GPT-5.6 Sol Pro |
 | --- | --- | --- |
@@ -67,8 +69,12 @@ and within 25 seconds. Each user turn is charged to the model of its final
 answer, once, however often it was regenerated. Only hashed ids, times and
 model slugs are cached, under `~/.vibebar/chatgpt_chat_history.json`.
 
-The service states no window start, so each bucket is the count inside a
-trailing window ending now, against the published total, marked estimated.
+Each bucket is the count inside a window ending now, against the published
+total, marked estimated. Its reset is the moment the count next falls: the
+oldest message still inside the window, plus the window — and a whole window
+from now when nothing has been spent. That is the rolling shape the service
+itself reports for the feature allowances it does time, and it gives the Pro
+rows the same pace, forecast and reset history every other quota row has.
 While part of the window is unread — the budget ran out, a fetch failed, or
 the list was cut short — the row shows the count and "history sync is
 incomplete" instead of a percentage. A throttled model overrides the count

--- a/docs/contracts/quota-naming-v1.json
+++ b/docs/contracts/quota-naming-v1.json
@@ -6,6 +6,12 @@
         "antigravity"
       ],
       "buckets": [
+        "image_gen",
+        "deep_research",
+        "gpt6_pro_weekly",
+        "sol_pro_daily",
+        "pro_daily",
+        "pro_weekly",
         "gpt_5_3_codex_spark_five_hour",
         "gpt_5_3_codex_spark_weekly",
         "weekly_sonnet",


### PR DESCRIPTION
Two things the Chat rows still did differently from every other quota row, both visible in the OpenAI card after #359.

## The features had no group and no window

"Image Generation" and "Deep Research" sat as bare rows while the Pro lanes beside them read GPT-6 ASTRA PRO → Weekly. Now every Chat bucket is the same shape: what is being metered is the group header, its window is the row. `ChatGPTChatWindow.label(seconds:)` names the window from its length — deliberately tolerant, because the service reports "now + window" on an untouched allowance, so a read two minutes in is two minutes short of a whole day. A feature whose window is not known yet keeps the feature name as its row and gets no group, so a first read never files a bucket under a group of one.

## The Pro lanes had no reset, so no pace, forecast or history

#356 left `resetAt` nil for them: the service states no window start, and I did not want to invent one. It turns out the service answers the question itself — an unused Image Generation allowance comes back as `reset_after = now + 24h` on every read, which is a rolling window. The Pro count is a rolling-window count too, so its reset is well defined: the moment the count next falls, i.e. the oldest message still inside the window plus the window, and a whole window from now when nothing has been spent. With that the Pro rows carry the same pace, forecast, day-of-window and reset history as every other provider's rows. A throttled model still overrides both count and reset with the service's own.

## Verification

- `swift build`; `swift test`: 2364 tests, 3 skipped, 0 failures; `./Scripts/build_app.sh release`; `codesign -d --entitlements -` → empty dict.
- Live probe on the packaged build and a demo capture of the OpenAI card (in the comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
