### PR TITLE
Name the AntiGravity model in a session row

### DIFF
--- a/Sources/VibeBarApp/Controllers/SessionManagerModel.swift
+++ b/Sources/VibeBarApp/Controllers/SessionManagerModel.swift
@@ -258,9 +258,10 @@ final class SessionManagerModel: ObservableObject {
 
     private let settingsStore: SettingsStore
     private let homeDirectory: String
-    /// Reloaded with each full summary reload, so a model AntiGravity ships
-    /// after launch names itself without a relaunch. One small JSON file.
-    private var antigravityModelLabels: AntigravityModelLabelStore
+    /// Refreshed off the main actor with each full summary reload, so a
+    /// model AntiGravity ships after launch names itself without a relaunch
+    /// and no filter change waits on a disk read.
+    @Published private(set) var antigravityModelLabels = AntigravityModelLabelStore()
     private let registry: SessionProviderRegistry
     private let deleter: SessionDeleter
     private let index: SharedSessionIndex
@@ -349,7 +350,21 @@ final class SessionManagerModel: ObservableObject {
         self.deleter = SessionDeleter(homeDirectory: homeDirectory)
         self.index = index
         self.isIndexAvailable = index.store != nil
-        self.antigravityModelLabels = AntigravityModelLabelStore.load(homeDirectory: homeDirectory)
+        refreshAntigravityModelLabels()
+    }
+
+    /// Off the actor: this is a file read, and every filter change asks for
+    /// it. A row without its labels yet draws no chip, and gets one on the
+    /// next render.
+    private func refreshAntigravityModelLabels() {
+        let home = homeDirectory
+        Task.detached(priority: .utility) {
+            let store = AntigravityModelLabelStore.load(homeDirectory: home)
+            await MainActor.run { [weak self] in
+                guard let self, self.antigravityModelLabels != store else { return }
+                self.antigravityModelLabels = store
+            }
+        }
     }
 
     /// The name AntiGravity's own status endpoint gives a model id, or nil
@@ -496,9 +511,7 @@ final class SessionManagerModel: ObservableObject {
 
     private func reloadSummaryPage(reset: Bool) {
         guard let service else { return }
-        if reset {
-            antigravityModelLabels = AntigravityModelLabelStore.load(homeDirectory: homeDirectory)
-        }
+        if reset { refreshAntigravityModelLabels() }
         summaryGeneration &+= 1
         let generation = summaryGeneration
         // No harness selected queries nothing. Asking the index for an empty

--- a/Sources/VibeBarApp/Controllers/SessionManagerModel.swift
+++ b/Sources/VibeBarApp/Controllers/SessionManagerModel.swift
@@ -258,6 +258,9 @@ final class SessionManagerModel: ObservableObject {
 
     private let settingsStore: SettingsStore
     private let homeDirectory: String
+    /// Reloaded with each full summary reload, so a model AntiGravity ships
+    /// after launch names itself without a relaunch. One small JSON file.
+    private var antigravityModelLabels: AntigravityModelLabelStore
     private let registry: SessionProviderRegistry
     private let deleter: SessionDeleter
     private let index: SharedSessionIndex
@@ -346,6 +349,21 @@ final class SessionManagerModel: ObservableObject {
         self.deleter = SessionDeleter(homeDirectory: homeDirectory)
         self.index = index
         self.isIndexAvailable = index.store != nil
+        self.antigravityModelLabels = AntigravityModelLabelStore.load(homeDirectory: homeDirectory)
+    }
+
+    /// The name AntiGravity's own status endpoint gives a model id, or nil
+    /// when the id is still one of its internal enums and says nothing a
+    /// reader can use.
+    ///
+    /// AntiGravity writes `MODEL_PLACEHOLDER_M318` into its transcripts and
+    /// keeps the label — "Gemini 3.8 Flash (High)" — in the status response
+    /// the quota adapter already harvests into
+    /// `~/.vibebar/antigravity_model_labels.json`. The cost scanner has
+    /// resolved through that file for as long as it has existed; the session
+    /// list was reading the raw id and hiding the chip instead.
+    func displayModel(for summary: SessionSummary) -> String? {
+        UsageModelNaming.sessionChipLabel(model: summary.model, labels: antigravityModelLabels)
     }
 
     // MARK: - Lifecycle
@@ -478,6 +496,9 @@ final class SessionManagerModel: ObservableObject {
 
     private func reloadSummaryPage(reset: Bool) {
         guard let service else { return }
+        if reset {
+            antigravityModelLabels = AntigravityModelLabelStore.load(homeDirectory: homeDirectory)
+        }
         summaryGeneration &+= 1
         let generation = summaryGeneration
         // No harness selected queries nothing. Asking the index for an empty

--- a/Sources/VibeBarApp/Controllers/SessionManagerModel.swift
+++ b/Sources/VibeBarApp/Controllers/SessionManagerModel.swift
@@ -356,13 +356,23 @@ final class SessionManagerModel: ObservableObject {
     /// Off the actor: this is a file read, and every filter change asks for
     /// it. A row without its labels yet draws no chip, and gets one on the
     /// next render.
+    ///
+    /// Merged rather than assigned, so two reads that straddle a quota
+    /// refresh cannot end with the older one winning and a chip that was
+    /// already named going blank again. The file only ever gains entries —
+    /// `AntigravityQuotaAdapter` merges into it — so a union is the same
+    /// answer as the newest read, whichever order they land in.
     private func refreshAntigravityModelLabels() {
         let home = homeDirectory
         Task.detached(priority: .utility) {
             let store = AntigravityModelLabelStore.load(homeDirectory: home)
+            guard !store.labels.isEmpty else { return }
             await MainActor.run { [weak self] in
-                guard let self, self.antigravityModelLabels != store else { return }
-                self.antigravityModelLabels = store
+                guard let self else { return }
+                var merged = self.antigravityModelLabels
+                merged.labels.merge(store.labels) { _, new in new }
+                guard merged != self.antigravityModelLabels else { return }
+                self.antigravityModelLabels = merged
             }
         }
     }

--- a/Sources/VibeBarApp/Controllers/SessionManagerModel.swift
+++ b/Sources/VibeBarApp/Controllers/SessionManagerModel.swift
@@ -262,9 +262,12 @@ final class SessionManagerModel: ObservableObject {
     /// model AntiGravity ships after launch names itself without a relaunch
     /// and no filter change waits on a disk read.
     @Published private(set) var antigravityModelLabels = AntigravityModelLabelStore()
-    /// Orders the label reads above: issued, and last one applied.
-    private var labelsRefresh = 0
-    private var appliedLabelsRefresh = 0
+    /// When the label file the published labels came from was last written.
+    /// Ordering by the snapshot rather than by the read that asked for it:
+    /// two detached reads can finish either way round, and can even read
+    /// either way round, but the file's own timestamp says which of them
+    /// saw the newer file.
+    private var appliedLabelsWrittenAt: Date?
     private let registry: SessionProviderRegistry
     private let deleter: SessionDeleter
     private let index: SharedSessionIndex
@@ -360,20 +363,22 @@ final class SessionManagerModel: ObservableObject {
     /// it. A row without its labels yet draws no chip, and gets one on the
     /// next render.
     ///
-    /// Numbered, because two reads can straddle a quota refresh that
-    /// rewrites the file — `AntigravityQuotaAdapter` replaces a label whose
-    /// value changed, so the file is not append-only — and the one that
-    /// started first could otherwise land last and put an older answer back.
-    /// A read whose number is not the newest is dropped.
+    /// Two reads can straddle a quota refresh that rewrites the file —
+    /// `AntigravityQuotaAdapter` replaces a label whose value changed, so
+    /// the file is not append-only — and neither the order they were asked
+    /// for nor the order they finish in says which one read the newer file.
+    /// Its modification date does, so each read carries it and an older
+    /// snapshot is dropped.
     private func refreshAntigravityModelLabels() {
-        labelsRefresh &+= 1
-        let refresh = labelsRefresh
         let home = homeDirectory
         Task.detached(priority: .utility) {
+            let url = AntigravityModelLabelStore.fileURL(homeDirectory: home)
             let store = AntigravityModelLabelStore.load(homeDirectory: home)
+            let writtenAt = (try? FileManager.default.attributesOfItem(atPath: url.path))?[.modificationDate] as? Date
             await MainActor.run { [weak self] in
-                guard let self, refresh > self.appliedLabelsRefresh else { return }
-                self.appliedLabelsRefresh = refresh
+                guard let self else { return }
+                if let writtenAt, let applied = self.appliedLabelsWrittenAt, writtenAt < applied { return }
+                self.appliedLabelsWrittenAt = writtenAt ?? self.appliedLabelsWrittenAt
                 guard self.antigravityModelLabels != store else { return }
                 self.antigravityModelLabels = store
             }

--- a/Sources/VibeBarApp/Controllers/SessionManagerModel.swift
+++ b/Sources/VibeBarApp/Controllers/SessionManagerModel.swift
@@ -262,6 +262,9 @@ final class SessionManagerModel: ObservableObject {
     /// model AntiGravity ships after launch names itself without a relaunch
     /// and no filter change waits on a disk read.
     @Published private(set) var antigravityModelLabels = AntigravityModelLabelStore()
+    /// Orders the label reads above: issued, and last one applied.
+    private var labelsRefresh = 0
+    private var appliedLabelsRefresh = 0
     private let registry: SessionProviderRegistry
     private let deleter: SessionDeleter
     private let index: SharedSessionIndex
@@ -357,22 +360,22 @@ final class SessionManagerModel: ObservableObject {
     /// it. A row without its labels yet draws no chip, and gets one on the
     /// next render.
     ///
-    /// Merged rather than assigned, so two reads that straddle a quota
-    /// refresh cannot end with the older one winning and a chip that was
-    /// already named going blank again. The file only ever gains entries —
-    /// `AntigravityQuotaAdapter` merges into it — so a union is the same
-    /// answer as the newest read, whichever order they land in.
+    /// Numbered, because two reads can straddle a quota refresh that
+    /// rewrites the file — `AntigravityQuotaAdapter` replaces a label whose
+    /// value changed, so the file is not append-only — and the one that
+    /// started first could otherwise land last and put an older answer back.
+    /// A read whose number is not the newest is dropped.
     private func refreshAntigravityModelLabels() {
+        labelsRefresh &+= 1
+        let refresh = labelsRefresh
         let home = homeDirectory
         Task.detached(priority: .utility) {
             let store = AntigravityModelLabelStore.load(homeDirectory: home)
-            guard !store.labels.isEmpty else { return }
             await MainActor.run { [weak self] in
-                guard let self else { return }
-                var merged = self.antigravityModelLabels
-                merged.labels.merge(store.labels) { _, new in new }
-                guard merged != self.antigravityModelLabels else { return }
-                self.antigravityModelLabels = merged
+                guard let self, refresh > self.appliedLabelsRefresh else { return }
+                self.appliedLabelsRefresh = refresh
+                guard self.antigravityModelLabels != store else { return }
+                self.antigravityModelLabels = store
             }
         }
     }

--- a/Sources/VibeBarApp/Views/Workbench/SessionListView.swift
+++ b/Sources/VibeBarApp/Views/Workbench/SessionListView.swift
@@ -73,6 +73,7 @@ struct SessionListView: View {
         SessionRow(
             density: density,
             row: row,
+            modelLabel: model.displayModel(for: row.summary),
             isSelected: model.selection?.id == row.id,
             isDeleteMode: model.isDeleteMode,
             isChecked: model.checkedIDs.contains(row.id),
@@ -176,6 +177,9 @@ struct SessionListView: View {
 private struct SessionRow: View {
     let density: Theme.Density
     let row: SessionManagerModel.Row
+    /// Resolved by the model, not here: it holds the labels AntiGravity
+    /// learned, and a row must not read a file to draw a chip.
+    let modelLabel: String?
     let isSelected: Bool
     let isDeleteMode: Bool
     let isChecked: Bool
@@ -293,15 +297,16 @@ private struct SessionRow: View {
             Text(summary.effectiveHarness.displayName)
                 .fontWeight(.medium)
                 .lineLimit(1)
-            // An unlearned AntiGravity model enum says nothing a reader can
-            // use; the row is better off without the chip.
-            if let model = summary.model, !model.isEmpty, !UsageModelNaming.isUnlabelledModelEnum(model) {
-                Text(UsageModelNaming.canonicalDisplayName(model))
+            // An AntiGravity model id that is still an internal enum says
+            // nothing a reader can use; the row is better off without the
+            // chip than with `MODEL_PLACEHOLDER_M318` on it.
+            if let modelLabel {
+                Text(modelLabel)
                     .lineLimit(1)
                     .padding(.horizontal, 5)
                     .frame(minHeight: 14)
                     .background(Capsule().fill(Color.primary.opacity(0.07)))
-                    .help(model)
+                    .help(summary.model ?? modelLabel)
             }
         }
         .font(.system(size: max(10, density.resetCountdownFontSize - 1)))

--- a/Sources/VibeBarCore/Utilities/UsageModelNaming.swift
+++ b/Sources/VibeBarCore/Utilities/UsageModelNaming.swift
@@ -9,6 +9,25 @@ public enum UsageModelNaming {
     /// `MODEL_PLACEHOLDER_M318` and the like — for which no human label has
     /// been learned. It is an identifier for the pricing side to key on,
     /// not a name anyone should read.
+    /// The model name a session row should wear, or nil when the log named
+    /// no model a reader could use.
+    ///
+    /// AntiGravity writes that internal enum into its own transcripts and
+    /// keeps the human label — "Gemini 3.8 Flash (High)" — in the status
+    /// response the quota adapter harvests into
+    /// `AntigravityModelLabelStore`. Resolving through it here is what lets
+    /// a Sessions row name the model at all; the cost scanner has resolved
+    /// through the same file since the store existed.
+    public static func sessionChipLabel(
+        model: String?,
+        labels: AntigravityModelLabelStore
+    ) -> String? {
+        guard let model, !model.isEmpty else { return nil }
+        let resolved = labels.resolve(model)
+        guard !isUnlabelledModelEnum(resolved) else { return nil }
+        return canonicalDisplayName(resolved)
+    }
+
     public static func isUnlabelledModelEnum(_ raw: String) -> Bool {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard trimmed.hasPrefix("MODEL_"), trimmed.count > 6 else { return false }

--- a/Tests/VibeBarCoreTests/UsageModelNamingTests.swift
+++ b/Tests/VibeBarCoreTests/UsageModelNamingTests.swift
@@ -57,3 +57,38 @@ final class UsageModelNamingTests: XCTestCase {
         XCTAssertEqual(UsageModelNaming.canonicalDisplayName("MODEL_PLACEHOLDER_M318"), "Unlabelled model")
     }
 }
+
+extension UsageModelNamingTests {
+    /// A Sessions row names an AntiGravity model by resolving the internal
+    /// enum through the labels AntiGravity's own status endpoint taught us —
+    /// the same file the cost scanner has always priced through. Before
+    /// this, the row read the raw id, decided it was unreadable, and drew no
+    /// chip at all.
+    func testSessionChipResolvesAnAntigravityEnumThroughTheLearnedLabels() {
+        let labels = AntigravityModelLabelStore(labels: [
+            "MODEL_PLACEHOLDER_M318": "Gemini 3.8 Flash (High)",
+            "MODEL_OPENAI_GPT_OSS_120B_MEDIUM": "GPT-OSS 120B (Medium)"
+        ])
+        XCTAssertEqual(
+            UsageModelNaming.sessionChipLabel(model: "MODEL_PLACEHOLDER_M318", labels: labels),
+            UsageModelNaming.canonicalDisplayName("Gemini 3.8 Flash (High)")
+        )
+        XCTAssertEqual(
+            UsageModelNaming.sessionChipLabel(model: "MODEL_OPENAI_GPT_OSS_120B_MEDIUM", labels: labels),
+            UsageModelNaming.canonicalDisplayName("GPT-OSS 120B (Medium)")
+        )
+        // An enum with no label learned yet still says nothing worth drawing.
+        XCTAssertNil(UsageModelNaming.sessionChipLabel(model: "MODEL_PLACEHOLDER_M999", labels: labels))
+        XCTAssertNil(UsageModelNaming.sessionChipLabel(model: nil, labels: labels))
+        XCTAssertNil(UsageModelNaming.sessionChipLabel(model: "", labels: labels))
+        // Every other provider's model names are untouched by the lookup.
+        XCTAssertEqual(
+            UsageModelNaming.sessionChipLabel(model: "claude-fable-5-1", labels: labels),
+            UsageModelNaming.canonicalDisplayName("claude-fable-5-1")
+        )
+        XCTAssertEqual(
+            UsageModelNaming.sessionChipLabel(model: "gemini-3.8-flash", labels: AntigravityModelLabelStore()),
+            UsageModelNaming.canonicalDisplayName("gemini-3.8-flash")
+        )
+    }
+}


### PR DESCRIPTION
AntiGravity sessions show no model at all in the Sessions list.

AntiGravity writes an internal enum into its own transcripts — `MODEL_PLACEHOLDER_M318` — and keeps the human label in the `GetUserStatus` response, which the quota adapter already harvests into `~/.vibebar/antigravity_model_labels.json` (22 entries on the maintainer's Mac, including `MODEL_PLACEHOLDER_M318 -> Gemini 3.8 Flash (High)`). The cost scanner has priced through that file since it existed. The Sessions row read the raw id, correctly decided it was unreadable, and drew no chip.

It now resolves through the same labels first, so those rows say "Gemini 3.8 Flash (High)" — retroactively, with no re-index, because the resolution happens at render rather than at index time. An id with no label learned yet still draws nothing.

The lookup is `UsageModelNaming.sessionChipLabel`, and the labels are loaded by `SessionManagerModel` on each full reload rather than by the row: a row must not read a file to draw a chip (CLAUDE.md rule 0).

## Verification

- `swift build`; `swift test`: 2364 tests, 3 skipped, 0 failures; `./Scripts/build_app.sh release`.
- New test covers the enum→label resolution, an unlearned enum still drawing nothing, and every other provider's model names passing through untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)