### PR TITLE
Format dates and numbers in the app's language, not the Mac's

### DIFF
--- a/Sources/VibeBarApp/Controllers/LayoutStudioWindowController.swift
+++ b/Sources/VibeBarApp/Controllers/LayoutStudioWindowController.swift
@@ -47,6 +47,7 @@ final class LayoutStudioWindowController: NSObject {
 
         let hosting = NSHostingController(
             rootView: LayoutStudioView(model: model)
+                .appLanguageLocale()
                 .environmentObject(environment)
                 .environmentObject(environment.accountStore)
                 .environmentObject(environment.settingsStore)

--- a/Sources/VibeBarApp/Controllers/OnboardingWindowController.swift
+++ b/Sources/VibeBarApp/Controllers/OnboardingWindowController.swift
@@ -46,6 +46,7 @@ final class OnboardingWindowController: NSObject {
 
         let hosting = NSHostingController(
             rootView: OnboardingView(navigation: navigation)
+                .appLanguageLocale()
                 .vibeBarNoInitialFocus()
                 .environmentObject(environment)
                 .environmentObject(environment.accountStore)

--- a/Sources/VibeBarApp/Controllers/WorkbenchWindowController.swift
+++ b/Sources/VibeBarApp/Controllers/WorkbenchWindowController.swift
@@ -42,6 +42,7 @@ final class WorkbenchWindowController: NSObject {
 
         let hosting = NSHostingController(
             rootView: WorkbenchRootView(initialPage: page, navigation: navigation)
+                .appLanguageLocale()
                 .vibeBarNoInitialFocus()
                 .environmentObject(environment)
                 .environmentObject(environment.accountStore)

--- a/Sources/VibeBarApp/MiniQuotaWindowController.swift
+++ b/Sources/VibeBarApp/MiniQuotaWindowController.swift
@@ -263,6 +263,7 @@ final class MiniQuotaWindowController: NSObject, NSWindowDelegate {
                 onClose: { [weak self] in self?.close(configID: configID) },
                 onToggleDisplayMode: { [weak self] in self?.cycleDisplayMode(configID: configID) }
             )
+                .appLanguageLocale()
                 .environmentObject(environment)
                 .environmentObject(environment.settingsStore)
                 .environmentObject(environment.quotaService)

--- a/Sources/VibeBarApp/StatusItemController.swift
+++ b/Sources/VibeBarApp/StatusItemController.swift
@@ -261,6 +261,7 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
                 onToggleMiniWindow: { [weak controller] in controller?.toggleMiniWindow() },
                 initialPage: controller.popoverInitialPage
             )
+                .appLanguageLocale()
                 .vibeBarNoInitialFocus()
                 // While a shrink waits out its settle window the hosting view
                 // is briefly taller than the content; without an explicit top

--- a/Sources/VibeBarApp/Views/AppLanguageLocale.swift
+++ b/Sources/VibeBarApp/Views/AppLanguageLocale.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+import VibeBarCore
+
+/// Puts the app's own language into the SwiftUI environment.
+///
+/// Every string Vibe Bar authors goes through `L10n`, which follows
+/// `AppSettings.language`. Everything SwiftUI and Foundation format
+/// themselves — `Text(date, style: .relative)`, a `DatePicker`'s month
+/// names, a chart axis's dates, `.percent` and `.number` styles — resolve
+/// their locale from the environment instead, and the environment's default
+/// is `Locale.current`: the language macOS is set to.
+///
+/// So on a Chinese Mac those fields render Chinese whatever the app's
+/// language is. They look right while the app is Chinese and read as
+/// "stuck in Chinese" the moment it is switched back to English — which is
+/// exactly what a user sees. `UsageTrendChartView` already passed
+/// `AppLocale.current` by hand for its axis; this does it once, for every
+/// surface, so the next `Text(_, style:)` written does not have to remember.
+///
+/// It reads the settings store so the value is re-derived when the language
+/// changes: the modifier's body re-runs on the same publish that re-renders
+/// the rest of the window. Apply it *innermost*, before the
+/// `environmentObject` chain, so the store is already in the environment.
+private struct AppLanguageLocaleModifier: ViewModifier {
+    @EnvironmentObject private var settingsStore: SettingsStore
+
+    func body(content: Content) -> some View {
+        content.environment(\.locale, AppLocale.current)
+    }
+}
+
+extension View {
+    /// See `AppLanguageLocaleModifier`. Every window and popover root wears
+    /// this; a surface without it formats dates in the system's language.
+    func appLanguageLocale() -> some View {
+        modifier(AppLanguageLocaleModifier())
+    }
+}

--- a/Sources/VibeBarApp/Views/CostHistoryView.swift
+++ b/Sources/VibeBarApp/Views/CostHistoryView.swift
@@ -1441,15 +1441,19 @@ struct CostHistoryView: View {
         _ granularity: CostChartGranularity,
         span: TimeInterval
     ) -> Date.FormatStyle {
-        switch granularity {
-        case .hour: .dateTime.hour()
+        // `.locale` on every branch: a format style carries its own locale
+        // and defaults to the system's, so an axis would spell its months in
+        // the language macOS is set to rather than the one the user picked.
+        let locale = AppLocale.current
+        return switch granularity {
+        case .hour: .dateTime.hour().locale(locale)
         case .day, .week:
             span > Self.multiYearSpan
-                ? .dateTime.month(.abbreviated).year(.twoDigits)
-                : .dateTime.day().month(.abbreviated)
+                ? .dateTime.month(.abbreviated).year(.twoDigits).locale(locale)
+                : .dateTime.day().month(.abbreviated).locale(locale)
         // Monthly bars only appear on spans where the day of the month is
         // noise, so the label goes straight to month-and-year.
-        case .month: .dateTime.month(.abbreviated).year(.twoDigits)
+        case .month: .dateTime.month(.abbreviated).year(.twoDigits).locale(locale)
         }
     }
 


### PR DESCRIPTION
Switch the app to Chinese and back to English and some fields stay Chinese.

They are the ones Vibe Bar never wrote. Every string it authors goes through `L10n`, which follows `AppSettings.language`; a relative time, a chart axis' months, a `DatePicker`'s weekday headers and a percent format themselves, and resolve their locale from the SwiftUI environment — whose default is `Locale.current`, the language macOS is set to. On a Chinese Mac they are Chinese in both app languages, so they only look wrong once the app is English around them. `.environment(\.locale, …)` was injected nowhere in the tree; `UsageTrendChartView` had already hit this and passed `AppLocale.current` by hand for its own axis.

Every window and popover root now wears `appLanguageLocale()`, which reads the settings store so the value is re-derived on the same publish that re-renders the window. The cost-history axis also names its own locale: a `Date.FormatStyle` carries one and defaults to the system's whatever the environment says.

Surfaces this reaches: the cost-history and quota-history axes, the Overview quota chart, the cost card and detail-popover "updated" times, the route-health check time, the usage filter bar's date pickers, and the percent and number styles in the usage mix card and the pricing editor.

## Verification

- `swift build`; `swift test`: 2363 tests, 3 skipped, 0 failures; `./Scripts/build_app.sh release`; localization lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)