### PR TITLE
Pin agent-session-kit 0.8.1 and re-read what it now reads better

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -916,6 +916,10 @@ asked for. `SessionIndexReparse` drops the affected provider's rows from
 files; it never touches `sessions` or `session_messages`, so nothing
 disappears from the Workbench meanwhile. Bump `currentVersion` and list the
 providers when a kit upgrade changes what already-indexed rows should say.
+It runs behind `SessionIndexMaintenanceGate` and stamps only after every
+delete reports `SQLITE_DONE`, so a pass that is already walking those files
+cannot skip one on a cursor being deleted, and a refusal is retried on the
+next launch rather than recorded as done.
 
 ### 7.1 Provider and harness naming
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -906,6 +906,17 @@ Three rules keep the browser-cookie importers (the four core providers'
   `BrowserCookieImportPreference.available()` — installed browsers with a
   cookie store — and ticking every browser back on clears the choice.
 
+### 7.0.1 A parser fix and an index that already read the file
+
+`SessionIndexService` skips a file whose size and mtime have not moved,
+which is what makes a refresh cheap — and what makes a *parser* upgrade
+invisible: nothing about the file changed, so the better reading is never
+asked for. `SessionIndexReparse` drops the affected provider's rows from
+`session_files` once per version at launch, so the next pass re-reads those
+files; it never touches `sessions` or `session_messages`, so nothing
+disappears from the Workbench meanwhile. Bump `currentVersion` and list the
+providers when a kit upgrade changes what already-indexed rows should say.
+
 ### 7.1 Provider and harness naming
 
 Vibe Bar names a provider along **two orthogonal axes**. A surface picks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,7 +171,7 @@ there, not in the package.
 
 **Where it comes from.** `Package.swift` pins the package to an exact
 tag on GitHub (`.package(url: "https://github.com/AstroQore/agent-session-kit.git",
-exact: "0.7.0")`), so a plain clone builds and a release build resolves the
+exact: "0.8.1")`), so a plain clone builds and a release build resolves the
 same package the developer built against — `Package.resolved` is
 gitignored here, and the exact pin is what stands in for it.
 

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         // from a clean checkout with no Package.resolved (it is gitignored),
         // so the pin is the only thing that makes two builds of the same
         // Vibe Bar commit contain the same package. Bump it deliberately.
-        .package(url: "https://github.com/AstroQore/agent-session-kit.git", exact: "0.7.0"),
+        .package(url: "https://github.com/AstroQore/agent-session-kit.git", exact: "0.8.1"),
         // SweetCookieKit encapsulates Chromium cookie + localStorage parsing,
         // "Chrome Safe Storage" Keychain decryption, and Safari
         // binarycookies / Firefox SQLite reads used by misc providers.

--- a/Sources/VibeBarApp/AppDelegate.swift
+++ b/Sources/VibeBarApp/AppDelegate.swift
@@ -73,6 +73,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // MCP-only day, so launch is the trigger that always exists. The
         // compactor throttles itself to one completed pass per day.
         Task.detached(priority: .utility) {
+            // Before the compactor, and before anything reads the index: a
+            // parser upgrade only reaches files the index has already
+            // fingerprinted if their cursors are dropped first.
+            SessionIndexReparse.runIfNeeded()
             try? await Task.sleep(for: .seconds(60))
             await SessionIndexCompactor.standard.compactIfDue()
         }

--- a/Sources/VibeBarApp/AppDelegate.swift
+++ b/Sources/VibeBarApp/AppDelegate.swift
@@ -75,8 +75,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         Task.detached(priority: .utility) {
             // Before the compactor, and before anything reads the index: a
             // parser upgrade only reaches files the index has already
-            // fingerprinted if their cursors are dropped first.
-            SessionIndexReparse.runIfNeeded()
+            // fingerprinted if their cursors are dropped first. Behind the
+            // maintenance gate, so a refresh that is already walking those
+            // files cannot skip one on the cursor this deletes.
+            await SessionIndexReparse.runIfNeededBehindGate()
             try? await Task.sleep(for: .seconds(60))
             await SessionIndexCompactor.standard.compactIfDue()
         }

--- a/Sources/VibeBarCore/Services/SessionIndexReparse.swift
+++ b/Sources/VibeBarCore/Services/SessionIndexReparse.swift
@@ -35,6 +35,27 @@ public enum SessionIndexReparse {
         var version: Int
     }
 
+    /// Behind the maintenance gate, which is what keeps this off an
+    /// indexing pass already walking the same files: that pass can skip a
+    /// file on the cursor this is about to delete and finish just after,
+    /// leaving the conversation on the old reading until the next refresh.
+    /// A gate that cannot be claimed leaves the stamp alone, so the next
+    /// launch tries again.
+    @discardableResult
+    public static func runIfNeededBehindGate(
+        databaseURL: URL = VibeBarLocalStore.sessionIndexURL,
+        stampURL: URL = VibeBarLocalStore.sessionIndexReparseStampURL,
+        version: Int = SessionIndexReparse.currentVersion,
+        providers: [String] = SessionIndexReparse.providers,
+        gate: SessionIndexMaintenanceGate = .shared
+    ) async -> Outcome? {
+        do { try await gate.acquire() } catch { return nil }
+        let outcome = runIfNeeded(databaseURL: databaseURL, stampURL: stampURL,
+                                  version: version, providers: providers)
+        await gate.release()
+        return outcome
+    }
+
     /// Run once per version. Returns what it did, or nil when the stamp is
     /// current, the index does not exist yet, or the database refused — and
     /// a refusal leaves the stamp alone, so the next launch tries again.

--- a/Sources/VibeBarCore/Services/SessionIndexReparse.swift
+++ b/Sources/VibeBarCore/Services/SessionIndexReparse.swift
@@ -1,0 +1,82 @@
+import Foundation
+import SQLite3
+
+/// Re-reads one provider's session files after a parser upgrade.
+///
+/// The index skips a file whose size and modification time have not moved,
+/// which is what makes a refresh cheap and what makes a *parser* fix
+/// invisible: nothing about the file changed, so a better reading of it is
+/// never asked for. Deleting the provider's rows from `session_files` drops
+/// only those cursors, and the next indexing pass reads those files again
+/// and rewrites what they say.
+///
+/// The kit's index is derived data whose path this app chose, so trimming it
+/// is the host's business — the same licence `SessionIndexCompactor` works
+/// under. This deletes cursors, never sessions or messages, so nothing
+/// disappears from the Workbench in the meantime.
+public enum SessionIndexReparse {
+    /// Bump when a kit upgrade changes what a provider's already-indexed
+    /// rows should say.
+    ///
+    /// v1, with kit 0.8.1: an AntiGravity session takes its title from the
+    /// user's own first prompt instead of falling back to the file's name,
+    /// and its user steps became user messages. Every conversation already
+    /// on disk was indexed under the old reading.
+    public static let currentVersion = 1
+    /// Providers to re-read, as `SessionSummary.provider` spells them.
+    public static let providers = ["antigravity"]
+
+    public struct Outcome: Equatable, Sendable {
+        public let version: Int
+        public let cursorsDropped: Int
+    }
+
+    private struct Stamp: Codable {
+        var version: Int
+    }
+
+    /// Run once per version. Returns what it did, or nil when the stamp is
+    /// current, the index does not exist yet, or the database refused.
+    @discardableResult
+    public static func runIfNeeded(
+        databaseURL: URL = VibeBarLocalStore.sessionIndexURL,
+        stampURL: URL = VibeBarLocalStore.sessionIndexReparseStampURL,
+        version: Int = SessionIndexReparse.currentVersion,
+        providers: [String] = SessionIndexReparse.providers
+    ) -> Outcome? {
+        let applied = (try? VibeBarLocalStore.readJSON(Stamp.self, from: stampURL))?.version ?? 0
+        guard applied < version else { return nil }
+        // No index yet is the good case: whatever is scanned next is scanned
+        // by the new parser. Stamp it so this never runs on that database.
+        guard FileManager.default.fileExists(atPath: databaseURL.path) else {
+            try? VibeBarLocalStore.writeJSON(Stamp(version: version), to: stampURL)
+            return nil
+        }
+        var handle: OpaquePointer?
+        guard sqlite3_open_v2(databaseURL.path, &handle,
+                              SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX, nil) == SQLITE_OK,
+              let database = handle
+        else {
+            if handle != nil { sqlite3_close_v2(handle) }
+            return nil
+        }
+        defer { sqlite3_close_v2(database) }
+        sqlite3_busy_timeout(database, 5_000)
+        let before = sqlite3_total_changes64(database)
+        for provider in providers {
+            var statement: OpaquePointer?
+            guard sqlite3_prepare_v2(database, "DELETE FROM session_files WHERE provider = ?1", -1,
+                                     &statement, nil) == SQLITE_OK, let statement else { continue }
+            sqlite3_bind_text(statement, 1, provider, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+            _ = sqlite3_step(statement)
+            sqlite3_finalize(statement)
+        }
+        let dropped = Int(sqlite3_total_changes64(database) - before)
+        // Stamped whatever the count: a provider with nothing indexed is
+        // done, and a failed delete will not succeed on the next launch
+        // either. Only a database this could not open is left for later.
+        try? VibeBarLocalStore.writeJSON(Stamp(version: version), to: stampURL)
+        SafeLog.info("Session index reparse v\(version): dropped \(dropped) cursor(s) for \(providers.joined(separator: ", "))")
+        return Outcome(version: version, cursorsDropped: dropped)
+    }
+}

--- a/Sources/VibeBarCore/Services/SessionIndexReparse.swift
+++ b/Sources/VibeBarCore/Services/SessionIndexReparse.swift
@@ -36,7 +36,8 @@ public enum SessionIndexReparse {
     }
 
     /// Run once per version. Returns what it did, or nil when the stamp is
-    /// current, the index does not exist yet, or the database refused.
+    /// current, the index does not exist yet, or the database refused — and
+    /// a refusal leaves the stamp alone, so the next launch tries again.
     @discardableResult
     public static func runIfNeeded(
         databaseURL: URL = VibeBarLocalStore.sessionIndexURL,
@@ -66,15 +67,22 @@ public enum SessionIndexReparse {
         for provider in providers {
             var statement: OpaquePointer?
             guard sqlite3_prepare_v2(database, "DELETE FROM session_files WHERE provider = ?1", -1,
-                                     &statement, nil) == SQLITE_OK, let statement else { continue }
+                                     &statement, nil) == SQLITE_OK, let statement else { return nil }
             sqlite3_bind_text(statement, 1, provider, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
-            _ = sqlite3_step(statement)
+            let step = sqlite3_step(statement)
             sqlite3_finalize(statement)
+            // A busy database is the ordinary case — an index refresh is
+            // running — and it is why this must not stamp: a stamp written
+            // over a delete that never happened leaves those files under the
+            // old parser for good. Leave it for the next launch.
+            guard step == SQLITE_DONE else {
+                SafeLog.info("Session index reparse v\(version) deferred: \(provider) delete returned \(step)")
+                return nil
+            }
         }
         let dropped = Int(sqlite3_total_changes64(database) - before)
-        // Stamped whatever the count: a provider with nothing indexed is
-        // done, and a failed delete will not succeed on the next launch
-        // either. Only a database this could not open is left for later.
+        // Every delete ran, so the stamp is earned. A provider with nothing
+        // indexed drops nothing and is equally done.
         try? VibeBarLocalStore.writeJSON(Stamp(version: version), to: stampURL)
         SafeLog.info("Session index reparse v\(version): dropped \(dropped) cursor(s) for \(providers.joined(separator: ", "))")
         return Outcome(version: version, cursorsDropped: dropped)

--- a/Sources/VibeBarCore/Storage/VibeBarLocalStore.swift
+++ b/Sources/VibeBarCore/Storage/VibeBarLocalStore.swift
@@ -153,6 +153,11 @@ public enum VibeBarLocalStore {
     /// pass over `session_index.sqlite3` completed and under which
     /// `SessionIndexExcerptPolicy.version`. Its own file so maintenance
     /// never rewrites the settings blob.
+    /// Which `SessionIndexReparse` version has run against this index.
+    public static var sessionIndexReparseStampURL: URL {
+        baseDirectory.appendingPathComponent("session_index_reparse.json")
+    }
+
     public static var sessionIndexMaintenanceStampURL: URL {
         baseDirectory.appendingPathComponent("session_index_maintenance.json")
     }

--- a/Tests/VibeBarCoreTests/SessionIndexCompactorTests.swift
+++ b/Tests/VibeBarCoreTests/SessionIndexCompactorTests.swift
@@ -205,6 +205,44 @@ final class SessionIndexCompactorTests: XCTestCase {
 }
 
 extension SessionIndexCompactorTests {
+    /// The gate is what keeps the reparse off an indexing pass already
+    /// walking the same files.
+    func testAReparseWaitsForTheMaintenanceGate() async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let databaseURL = directory.appendingPathComponent("index.sqlite3")
+        var handle: OpaquePointer?
+        XCTAssertEqual(sqlite3_open_v2(databaseURL.path, &handle,
+                                       SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nil), SQLITE_OK)
+        let database = try XCTUnwrap(handle)
+        defer { sqlite3_close_v2(database) }
+        XCTAssertEqual(sqlite3_exec(database, """
+            CREATE TABLE session_files (path_hash TEXT PRIMARY KEY, path TEXT NOT NULL, provider TEXT NOT NULL);
+            INSERT INTO session_files VALUES ('a', '/a.db', 'antigravity');
+            """, nil, nil, nil), SQLITE_OK)
+
+        let gate = SessionIndexMaintenanceGate()
+        try await gate.acquire()
+        let held = Task {
+            await SessionIndexReparse.runIfNeededBehindGate(
+                databaseURL: databaseURL,
+                stampURL: directory.appendingPathComponent("stamp.json"),
+                version: 1, gate: gate
+            )
+        }
+        // Still held: the reparse is waiting rather than deleting.
+        try await Task.sleep(for: .milliseconds(120))
+        XCTAssertFalse(held.isCancelled)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: directory.appendingPathComponent("stamp.json").path))
+        await gate.release()
+        let outcome = await held.value
+        XCTAssertEqual(outcome?.cursorsDropped, 1)
+        // And it handed the gate back.
+        let reclaimed = await gate.tryAcquire()
+        XCTAssertTrue(reclaimed)
+    }
+
     /// A parser fix reaches files the index already read only if their
     /// cursors go. The rows themselves stay, so nothing vanishes from the
     /// Workbench while the next pass re-reads them.

--- a/Tests/VibeBarCoreTests/SessionIndexCompactorTests.swift
+++ b/Tests/VibeBarCoreTests/SessionIndexCompactorTests.swift
@@ -251,6 +251,33 @@ extension SessionIndexCompactorTests {
         XCTAssertTrue(remaining().isEmpty)
         sqlite3_close_v2(database)
 
+        // A database that refuses the delete is left for the next launch:
+        // stamping over a delete that never ran would strand those files
+        // under the old parser for good.
+        let locked = directory.appendingPathComponent("locked.sqlite3")
+        let lockedStamp = directory.appendingPathComponent("locked-stamp.json")
+        var lockedHandle: OpaquePointer?
+        XCTAssertEqual(sqlite3_open_v2(locked.path, &lockedHandle,
+                                       SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nil), SQLITE_OK)
+        let lockedDatabase = try XCTUnwrap(lockedHandle)
+        XCTAssertEqual(sqlite3_exec(lockedDatabase, """
+            CREATE TABLE session_files (path_hash TEXT PRIMARY KEY, path TEXT NOT NULL, provider TEXT NOT NULL);
+            INSERT INTO session_files VALUES ('a', '/a.db', 'antigravity');
+            """, nil, nil, nil), SQLITE_OK)
+        // An exclusive lock another connection holds is exactly what a
+        // running index refresh looks like.
+        XCTAssertEqual(sqlite3_exec(lockedDatabase, "BEGIN EXCLUSIVE", nil, nil, nil), SQLITE_OK)
+        XCTAssertNil(SessionIndexReparse.runIfNeeded(databaseURL: locked, stampURL: lockedStamp, version: 1))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: lockedStamp.path),
+                       "a delete that never ran must not be stamped as done")
+        XCTAssertEqual(sqlite3_exec(lockedDatabase, "COMMIT", nil, nil, nil), SQLITE_OK)
+        XCTAssertEqual(
+            SessionIndexReparse.runIfNeeded(databaseURL: locked, stampURL: lockedStamp, version: 1)?.cursorsDropped,
+            1,
+            "and the next launch does it"
+        )
+        sqlite3_close_v2(lockedDatabase)
+
         // No index yet: nothing to do, and stamped so it never runs on the
         // database the next scan creates.
         let fresh = directory.appendingPathComponent("fresh.json")

--- a/Tests/VibeBarCoreTests/SessionIndexCompactorTests.swift
+++ b/Tests/VibeBarCoreTests/SessionIndexCompactorTests.swift
@@ -203,3 +203,60 @@ final class SessionIndexCompactorTests: XCTestCase {
         XCTAssertNil(try? fileManager.destinationOfSymbolicLink(atPath: plantedLink.path))
     }
 }
+
+extension SessionIndexCompactorTests {
+    /// A parser fix reaches files the index already read only if their
+    /// cursors go. The rows themselves stay, so nothing vanishes from the
+    /// Workbench while the next pass re-reads them.
+    func testAReparseDropsOnlyTheNamedProvidersCursorsAndRunsOnce() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let databaseURL = directory.appendingPathComponent("session_index.sqlite3")
+        let stampURL = directory.appendingPathComponent("reparse.json")
+
+        var handle: OpaquePointer?
+        XCTAssertEqual(sqlite3_open_v2(databaseURL.path, &handle,
+                                       SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nil), SQLITE_OK)
+        let database = try XCTUnwrap(handle)
+        XCTAssertEqual(sqlite3_exec(database, """
+            CREATE TABLE session_files (path_hash TEXT PRIMARY KEY, path TEXT NOT NULL, provider TEXT NOT NULL);
+            INSERT INTO session_files VALUES ('a', '/a.db', 'antigravity'), ('b', '/b.db', 'antigravity'),
+                                             ('c', '/c.jsonl', 'claude');
+            """, nil, nil, nil), SQLITE_OK)
+        func remaining() -> [String] {
+            var statement: OpaquePointer?
+            guard sqlite3_prepare_v2(database, "SELECT provider FROM session_files ORDER BY path_hash", -1,
+                                     &statement, nil) == SQLITE_OK else { return [] }
+            defer { sqlite3_finalize(statement) }
+            var out: [String] = []
+            while sqlite3_step(statement) == SQLITE_ROW {
+                out.append(String(cString: sqlite3_column_text(statement, 0)))
+            }
+            return out
+        }
+
+        let first = SessionIndexReparse.runIfNeeded(databaseURL: databaseURL, stampURL: stampURL, version: 1)
+        XCTAssertEqual(first?.cursorsDropped, 2)
+        XCTAssertEqual(remaining(), ["claude"], "another provider's cursors are not this fix's business")
+
+        // Stamped, so a relaunch does not pay for the same re-scan again.
+        XCTAssertNil(SessionIndexReparse.runIfNeeded(databaseURL: databaseURL, stampURL: stampURL, version: 1))
+        // A later version runs again.
+        XCTAssertEqual(
+            SessionIndexReparse.runIfNeeded(databaseURL: databaseURL, stampURL: stampURL, version: 2,
+                                            providers: ["claude"])?.cursorsDropped,
+            1
+        )
+        XCTAssertTrue(remaining().isEmpty)
+        sqlite3_close_v2(database)
+
+        // No index yet: nothing to do, and stamped so it never runs on the
+        // database the next scan creates.
+        let fresh = directory.appendingPathComponent("fresh.json")
+        XCTAssertNil(SessionIndexReparse.runIfNeeded(
+            databaseURL: directory.appendingPathComponent("missing.sqlite3"), stampURL: fresh, version: 1
+        ))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: fresh.path))
+    }
+}


### PR DESCRIPTION
[agent-session-kit 0.8.1](https://github.com/AstroQore/agent-session-kit/releases/tag/0.8.1) titles an AntiGravity session with the user's own first prompt and makes its user steps user messages. Before it, every AntiGravity row read "Conversation 8ae5c3ce…" — the name the file already had — and its transcripts showed no user messages at all.

Neither reaches a conversation the index has already fingerprinted: `SessionIndexService` skips a file whose size and mtime have not moved, which is what makes a refresh cheap and what makes a parser fix invisible. `SessionIndexReparse` drops the provider's rows from `session_files` once per version at launch, so the next pass re-reads those files. Cursors only — no session or message row is deleted, so the Workbench keeps showing what it has while they refresh. On this Mac that is 534 AntiGravity conversations, 500 of them on the CLI surface, none of which would otherwise ever be re-read.

## Verification

- `swift build`; `swift test`: 2366 tests, 3 skipped, 0 failures; `./Scripts/build_app.sh release`.
- New test covers the cursor delete being scoped to the named provider, the stamp making it run once, a later version running again, and a missing index being stamped rather than re-checked forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)