### PR TITLE
Bump the version to 1.6.4 (build 76) for a Dev release

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -24,9 +24,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.3</string>
+	<string>1.6.4</string>
 	<key>CFBundleVersion</key>
-	<string>75</string>
+	<string>76</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
Dev build 76 carries, on top of 1.6.3:

- **#364** — every ChatGPT Chat bucket has a group, a window row and a reset, so the Pro lanes pace and forecast like every other quota row.
- **#365** — an AntiGravity session row names its model instead of hiding an internal enum.
- **#366** — dates, relative times and numbers follow the app's language rather than the Mac's.
- **#367** — agent-session-kit 0.8.1, plus a one-shot reparse so conversations already in the index pick up their new titles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)