### PR TITLE
Keep canvas groups atomic and localize percentages

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -26,7 +26,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.6.4</string>
 	<key>CFBundleVersion</key>
-	<string>77</string>
+	<string>78</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>

--- a/Sources/VibeBarApp/Views/MiniCanvasInspector.swift
+++ b/Sources/VibeBarApp/Views/MiniCanvasInspector.swift
@@ -174,20 +174,14 @@ struct MiniCanvasInspector: View {
                 Button(L10n.MenuBar.Composer.Group.bind) { layout.group(selection) }.disabled(selection.count < 2)
                 Button(L10n.MenuBar.Composer.Group.unbind) { layout.ungroup(selection) }
             }
-            if let selected {
+            if let layer = layers.first(where: { Set($0.elements.map(\.id)) == selection }),
+               let element = layer.elements.first {
                 HStack {
-                    Button(L10n.Settings.MiniCanvas.back) { reorder(selected.id, delta: -1) }
-                    Button(L10n.Settings.MiniCanvas.front) { reorder(selected.id, delta: 1) }
+                    Button(L10n.Settings.MiniCanvas.back) { layout.reorder(element.id, by: -1) }
+                    Button(L10n.Settings.MiniCanvas.front) { layout.reorder(element.id, by: 1) }
                 }
             }
         }
-    }
-
-    private func reorder(_ id: UUID, delta: Int) {
-        guard let i = layout.elements.firstIndex(where: { $0.id == id }) else { return }
-        let target = i + delta
-        guard layout.elements.indices.contains(target) else { return }
-        layout.elements.swapAt(i, target)
     }
 
     private func canvasNumber(_ key: WritableKeyPath<MiniCanvasLayout, Double>, divisor: Double = 1) -> Binding<Double> {

--- a/Sources/VibeBarApp/Views/MiniCanvasView.swift
+++ b/Sources/VibeBarApp/Views/MiniCanvasView.swift
@@ -109,7 +109,7 @@ struct MiniCanvasView: View {
         .accessibilityLabel(element.kind == .text
                             ? text(element, label: label, percent: percent, bucket: bucket, now: now)
                             : "\(element.kind.title) · \(label)")
-        .accessibilityValue(percent.map { String(format: "%.0f%%", $0) } ?? L10n.Settings.MiniCanvas.unavailable)
+        .accessibilityValue(percent.map { L10n.Common.percent(value: Int($0.rounded())) } ?? L10n.Settings.MiniCanvas.unavailable)
         .help(label)
     }
 
@@ -117,7 +117,7 @@ struct MiniCanvasView: View {
         switch element.textContent {
         case .custom: return element.text
         case .label: return label
-        case .percent: return percent.map { String(format: "%.0f%%", $0) } ?? "—"
+        case .percent: return percent.map { L10n.Common.percent(value: Int($0.rounded())) } ?? "—"
         case .countdown: return ResetCountdownFormatter.string(from: bucket?.resetAt, now: now) ?? "—"
         }
     }

--- a/Sources/VibeBarCore/Models/MiniCanvasLayout.swift
+++ b/Sources/VibeBarCore/Models/MiniCanvasLayout.swift
@@ -144,6 +144,24 @@ public struct MiniCanvasLayout: Codable, Equatable, Sendable {
         for i in elements.indices where ids.contains(elements[i].id) { elements[i].groupID = nil }
     }
 
+    /// Z-order is a list of complete layers. Crossing a group must never put
+    /// an unrelated element between its children.
+    public mutating func reorder(_ id: UUID, by delta: Int) {
+        guard delta != 0, let element = elements.first(where: { $0.id == id }) else { return }
+        var layers: [[MiniCanvasElement]] = []
+        var indices: [UUID: Int] = [:]
+        for child in elements {
+            let layer = child.groupID ?? child.id
+            if let index = indices[layer] { layers[index].append(child) }
+            else { indices[layer] = layers.count; layers.append([child]) }
+        }
+        guard let source = indices[element.groupID ?? element.id] else { return }
+        let target = source + (delta < 0 ? -1 : 1)
+        guard layers.indices.contains(target) else { return }
+        layers.swapAt(source, target)
+        elements = layers.flatMap { $0 }
+    }
+
     static func bound(_ value: Double, _ range: ClosedRange<Double>, fallback: Double) -> Double {
         value.isFinite ? min(range.upperBound, max(range.lowerBound, value)) : fallback
     }

--- a/Tests/VibeBarCoreTests/MiniCanvasLayoutTests.swift
+++ b/Tests/VibeBarCoreTests/MiniCanvasLayoutTests.swift
@@ -119,6 +119,35 @@ final class MiniCanvasLayoutTests: XCTestCase {
         }
     }
 
+    func testReorderingALoneElementCrossesAnEntireGroup() {
+        var canvas = MiniCanvasLayout()
+        let a = canvas.add(.ring, fieldID: nil)
+        let b = canvas.add(.text, fieldID: nil)
+        let c = canvas.add(.sector, fieldID: nil)
+        canvas.group([a, b])
+        let before = canvas
+        canvas.reorder(c, by: -1)
+        XCTAssertEqual(canvas.elements.map(\.id), [c, a, b])
+        XCTAssertEqual(canvas.elements[1].groupID, canvas.elements[2].groupID)
+        canvas.reorder(c, by: 1)
+        XCTAssertEqual(canvas, before)
+    }
+
+    func testReorderingAGroupMovesAllChildrenAndStopsAtTheEnds() {
+        var canvas = MiniCanvasLayout()
+        let a = canvas.add(.ring, fieldID: nil)
+        let b = canvas.add(.text, fieldID: nil)
+        let c = canvas.add(.sector, fieldID: nil)
+        canvas.group([a, b])
+        canvas.reorder(b, by: 1)
+        XCTAssertEqual(canvas.elements.map(\.id), [c, a, b])
+        let atFront = canvas
+        canvas.reorder(a, by: 1)
+        XCTAssertEqual(canvas, atFront)
+        canvas.reorder(a, by: -1)
+        XCTAssertEqual(canvas.elements.map(\.id), [a, b, c])
+    }
+
     @MainActor
     func testCanvasSurvivesRealSettingsSaveReloadAndAnExternalWindowEdit() throws {
         let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)


### PR DESCRIPTION
Moving an element backward across grouped `[A, B]` could produce `[A, C, B]`, splitting an atomic layer. Reorder complete layers instead, and expose the same controls when a whole group is selected. Visible and accessibility percentages now use the shared localized formatter.

Adds regression coverage for crossing a group and moving a group to the stack boundary. Advances the Dev build to 78; the already-created v1.6.4-dev.77 tag is unchanged and its release remains an unpublished superseded draft.

Validation: `swift build`, full `swift test` (2384 tests, 3 skipped, 0 failures), release packaging, empty entitlements, strict deep codesign and packaged-resource launch smoke all passed.

Addresses the two late review findings on #369.

Co-Authored-By: Codex <noreply@openai.com>
