### PR TITLE
Keep Overview grouping controls in Layout settings

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -26,7 +26,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.6.4</string>
 	<key>CFBundleVersion</key>
-	<string>79</string>
+	<string>80</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>

--- a/Sources/VibeBarApp/Views/PopoverRoot.swift
+++ b/Sources/VibeBarApp/Views/PopoverRoot.swift
@@ -27,7 +27,6 @@ struct PopoverRoot: View {
         let contentDensity = activeDensity
         let shellContentWidth = max(0, width - shellDensity.popoverPaddingH * 2)
         VStack(alignment: .leading, spacing: 0) {
-            VStack(alignment: .trailing, spacing: 4) {
             HeaderView(
                 title: headerTitle,
                 subtitle: headerSubtitle,
@@ -44,10 +43,6 @@ struct PopoverRoot: View {
             )
             .frame(height: shellDensity.headerHeight, alignment: .center)
             .padding(.bottom, max(4, shellDensity.interSectionSpacing * 0.45))
-            if overviewPage == .overview {
-                OverviewQuotaGranularityPicker().font(.caption)
-            }
-            }
             .onGeometryChange(for: CGFloat.self) { $0.frame(in: .named(SurfaceCoordinates.space)).maxY } action: {
                 onHeaderHeightChange?($0)
             }


### PR DESCRIPTION
Keep the Overview card granularity control in Settings → Layout. Remove the duplicate control and its extra header row from the Overview popover, while retaining the existing settings binding and all three grouping choices.

Prepare `1.6.4` build `80` for the Dev release.

Validation: `swift build`, full `swift test`, release packaging, and strict code-signature verification with empty entitlements.

Co-Authored-By: Codex <noreply@openai.com>
