### PR TITLE
Bump the version to 1.7.0 (build 81) for a Dev release

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -24,9 +24,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.4</string>
+	<string>1.7.0</string>
 	<key>CFBundleVersion</key>
-	<string>80</string>
+	<string>81</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
Version-only bump for the next Dev-channel release: `Resources/Info.plist` moves `CFBundleShortVersionString` to `1.7.0` and `CFBundleVersion` to `81`. The minor bump reflects the new E-ink Displays feature that landed on `main` since build 80 — bundled e-ink preview fonts (#373), the Core render pipeline and Dot. device client (#374), the panel sync engine plus the Displays settings section and preview (#375), the sync follow-ups and feature documentation (#376), and custom e-ink slide editing in the Layout Studio (#377). Nothing else changes in this PR; validated locally with `swift build`, `swift test`, `./Scripts/build_app.sh release`, an empty `<dict/>` entitlements dump, and `codesign --verify --deep --strict`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)