### PR TITLE
Name e-ink slots in full and make every slide composable

### DIFF
--- a/Sources/VibeBarApp/AppEnvironment.swift
+++ b/Sources/VibeBarApp/AppEnvironment.swift
@@ -417,8 +417,10 @@ final class AppEnvironment: ObservableObject {
         // of anything. It stays idle until the settings say otherwise.
         let eink = EInkSyncService(snapshotProvider: { [weak self] request in
             guard let self else { throw CancellationError() }
-            return await self.einkAssembler(selectedFieldIDs: request.quotaFieldIDs)
-                .assemble(includeUsage: request.includesUsage)
+            return await self.einkAssembler(
+                selectedFieldIDs: request.quotaFieldIDs,
+                customLabels: request.customLabels
+            ).assemble(includeUsage: request.includesUsage)
         })
         self.einkSyncService = eink
         eink.apply(settings: settings.settings.einkSync, layouts: settings.settings.einkCanvasLayouts)
@@ -602,7 +604,10 @@ final class AppEnvironment: ObservableObject {
     /// Rebuilt per pass rather than stored, because it captures the ledger and
     /// the cost service as they are *now* — a stored assembler would keep a
     /// snapshot source alive across a settings change that replaced it.
-    func einkAssembler(selectedFieldIDs: [String] = []) -> EInkDataAssembler {
+    func einkAssembler(
+        selectedFieldIDs: [String] = [],
+        customLabels: [String: String] = [:]
+    ) -> EInkDataAssembler {
         let usage: any EInkUsageQuerying = usageLedger.map {
             EInkLedgerUsageSource(ledger: $0)
         } ?? EInkEmptyUsageSource()
@@ -617,6 +622,27 @@ final class AppEnvironment: ObservableObject {
                     return ToolType.allCases.compactMap { self.costService.snapshot(for: $0) }
                 }
             },
+            forecastLookup: { [weak self] tool, bucket in
+                await MainActor.run {
+                    guard let self, let account = self.account(for: tool) else { return nil }
+                    let snapshot = self.costService.snapshot(for: tool)
+                    return self.quotaService.paceForecast(
+                        accountId: account.id,
+                        bucket: bucket,
+                        activityHeatmap: snapshot?.heatmap,
+                        dailyActivity: snapshot?.dailyHistory ?? [],
+                        allowsPostResetGrace: true
+                    )
+                }
+            },
+            serviceStatus: { [weak self] in
+                await MainActor.run {
+                    guard let self else { return [] }
+                    return Array(self.serviceStatus.snapshotByTool.values)
+                }
+            },
+            registry: quotaService.fieldRegistry,
+            customLabels: customLabels,
             quotaPriority: EInkDataAssembler.priority(includingSelected: selectedFieldIDs)
         )
     }

--- a/Sources/VibeBarApp/AppEnvironment.swift
+++ b/Sources/VibeBarApp/AppEnvironment.swift
@@ -417,10 +417,8 @@ final class AppEnvironment: ObservableObject {
         // of anything. It stays idle until the settings say otherwise.
         let eink = EInkSyncService(snapshotProvider: { [weak self] request in
             guard let self else { throw CancellationError() }
-            return await self.einkAssembler(
-                selectedFieldIDs: request.quotaFieldIDs,
-                customLabels: request.customLabels
-            ).assemble(includeUsage: request.includesUsage)
+            return await self.einkAssembler(selectedFieldIDs: request.quotaFieldIDs)
+                .assemble(includeUsage: request.includesUsage)
         })
         self.einkSyncService = eink
         eink.apply(settings: settings.settings.einkSync, layouts: settings.settings.einkCanvasLayouts)
@@ -604,10 +602,7 @@ final class AppEnvironment: ObservableObject {
     /// Rebuilt per pass rather than stored, because it captures the ledger and
     /// the cost service as they are *now* — a stored assembler would keep a
     /// snapshot source alive across a settings change that replaced it.
-    func einkAssembler(
-        selectedFieldIDs: [String] = [],
-        customLabels: [String: String] = [:]
-    ) -> EInkDataAssembler {
+    func einkAssembler(selectedFieldIDs: [String] = []) -> EInkDataAssembler {
         let usage: any EInkUsageQuerying = usageLedger.map {
             EInkLedgerUsageSource(ledger: $0)
         } ?? EInkEmptyUsageSource()
@@ -642,7 +637,6 @@ final class AppEnvironment: ObservableObject {
                 }
             },
             registry: quotaService.fieldRegistry,
-            customLabels: customLabels,
             quotaPriority: EInkDataAssembler.priority(includingSelected: selectedFieldIDs)
         )
     }

--- a/Sources/VibeBarApp/Views/EInkStudioInspector.swift
+++ b/Sources/VibeBarApp/Views/EInkStudioInspector.swift
@@ -182,6 +182,9 @@ struct EInkStudioInspector: View {
                 DebouncedSettingsTextField(prompt: L10n.MenuBar.Composer.Block.text, value: value(e, \.text))
                     .id("text-\(e.id)")
             }
+        case .clock, .date:
+            // Both draw the assembly time; there is nothing else to choose.
+            EmptyView()
         }
     }
 
@@ -517,6 +520,9 @@ enum EInkNaming {
         case .usageTable: L10n.Settings.Eink.Preset.table
         case .usageDual: L10n.Settings.Eink.Preset.dual
         case .usageTrend: L10n.Settings.Eink.Preset.trend
+        // Round 2's layouts keep their English identifiers until the round 2
+        // settings redesign gives them localized names.
+        case .briefing, .forecast, .resets, .heatmap, .topModels, .alert: preset.identifierName
         }
     }
 

--- a/Sources/VibeBarCore/Models/EInkCanvasLayout.swift
+++ b/Sources/VibeBarCore/Models/EInkCanvasLayout.swift
@@ -58,6 +58,7 @@ public struct EInkCanvasLayout: Codable, Equatable, Hashable, Sendable {
             e.percentOverride = e.percentOverride.map { Self.bound($0, 0...100, fallback: 0).rounded() }
             e.text = Self.panelText(e.text)
             e.subText = Self.panelText(e.subText)
+            e.imageSource = Self.imageSource(e.imageSource)
             var seenFields = Set<String>()
             e.fieldIDs = e.fieldIDs.filter { !$0.isEmpty && seenFields.insert($0).inserted }
             var seenPeriods = Set<EInkUsagePeriod>()
@@ -221,6 +222,12 @@ public struct EInkCanvasLayout: Codable, Equatable, Hashable, Sendable {
         return text.count > maximumTextLength ? String(text.prefix(maximumTextLength)) : text
     }
 
+    /// Only a data URI for a raster image is ever kept: an element pointing at
+    /// a URL would make the panel fetch from a host nobody vetted.
+    static func imageSource(_ value: String) -> String {
+        value.hasPrefix("data:image/") ? value : ""
+    }
+
     static func bound(_ value: Double, _ range: ClosedRange<Double>, fallback: Double) -> Double {
         value.isFinite ? min(range.upperBound, max(range.lowerBound, value)) : fallback
     }
@@ -332,8 +339,21 @@ public enum EInkTextAlignment: String, Codable, CaseIterable, Hashable, Sendable
 public struct EInkCanvasElement: Codable, Equatable, Hashable, Identifiable, Sendable {
     public enum Kind: String, Codable, CaseIterable, Hashable, Sendable {
         case text, ring, horizontalBar, verticalBar, statTile, divider
+        /// A solid black rectangle at the author's exact frame.
+        ///
+        /// `divider` is a one-pixel rule whatever its handle says, which a
+        /// preset's own rules are — but a preset also paints solid blocks
+        /// (a bar's fill, a rule down a column), and exploding one into a
+        /// divider would lose its height. This is the kind that survives a
+        /// round trip.
+        case fill
+        /// A 1-bit PNG data URI, in `imageSource`. Not in the Studio palette
+        /// — an author cannot draw one — but an exploded Heatmap carries its
+        /// grid this way instead of losing it.
+        case image
         case quotaLedger, quotaRings, quotaRail
         case usageTiles, usageSplit, usageTable, usageDual, usageTrend
+        case briefing, forecast, resets, heatmap, topModels
 
         /// Whole-preset blocks the Studio can drop in and scale, the E-ink
         /// counterpart of `MiniCanvasElement.Kind.presetMode`.
@@ -347,6 +367,11 @@ public struct EInkCanvasElement: Codable, Equatable, Hashable, Identifiable, Sen
             case .usageTable: .usageTable
             case .usageDual: .usageDual
             case .usageTrend: .usageTrend
+            case .briefing: .briefing
+            case .forecast: .forecast
+            case .resets: .resets
+            case .heatmap: .heatmap
+            case .topModels: .topModels
             default: nil
             }
         }
@@ -355,6 +380,10 @@ public struct EInkCanvasElement: Codable, Equatable, Hashable, Identifiable, Sen
     /// What a `text` element is bound to.
     public enum TextBinding: String, Codable, CaseIterable, Hashable, Sendable {
         case percent, label, countdown, usageMetric, custom
+        /// `HH:mm` / `MM-dd` at assembly time — what a header bar set to
+        /// "Clock" or "Date" prints, and what the exploder gives those nodes
+        /// so a header stays a clock after it is exploded.
+        case clock, date
     }
 
     /// Which number a `usageMetric` text (or a `statTile`) reads.
@@ -383,6 +412,13 @@ public struct EInkCanvasElement: Codable, Equatable, Hashable, Identifiable, Sen
     /// A stat tile's bottom line. Empty draws the binding's own second
     /// figure — a quota countdown, or the tokens behind a cost.
     public var subText = ""
+    /// A `data:image/png;base64,…` source for an `image` element.
+    ///
+    /// Its own field rather than `text` because `text` is capped at 512
+    /// characters — a label that long is not a label — and a 1-bit PNG is
+    /// tens of kilobytes. The encoder's own `windowData` limit is what bounds
+    /// this one.
+    public var imageSource = ""
     /// Whether the drawn box is measured from the text (`true`) or kept at
     /// the author's `width`, clipping anything longer (`false`).
     ///
@@ -391,6 +427,12 @@ public struct EInkCanvasElement: Codable, Equatable, Hashable, Identifiable, Sen
     /// the Studio losing characters. Fixing the width is the deliberate act —
     /// it is what a column needs, and the Studio says so.
     public var autoWidth = true
+    /// Whether a fixed-width text element clips what does not fit.
+    ///
+    /// A column clips; a header that was laid out flexed does not. Only read
+    /// when `autoWidth` is false — a measured box is never wrong about its
+    /// own text.
+    public var clipsOverflow = true
     public var usagePeriod: EInkUsagePeriod = .today
     public var usageMetric: UsageMetric = .cost
     /// Ring / bar stroke in device pixels.
@@ -398,6 +440,11 @@ public struct EInkCanvasElement: Codable, Equatable, Hashable, Identifiable, Sen
     /// Studio preview value when no live field is bound yet.
     public var percentOverride: Double?
     public var groupID: UUID?
+    /// Which preset module this element was exploded out of ("header",
+    /// "slot:claude.weekly", "footer"). Kept so the Studio can say what a
+    /// group is, and so "Re-layout" can tell an exploded module from an
+    /// element the author drew.
+    public var moduleID: String?
 
     public init(kind: Kind, fieldID: String? = nil) {
         self.kind = kind
@@ -409,7 +456,10 @@ public struct EInkCanvasElement: Codable, Equatable, Hashable, Identifiable, Sen
         case .verticalBar: width = 22; height = 60
         case .statTile: width = 96; height = 48; font = .sans(size: 18, bold: true)
         case .divider: width = 96; height = 1
-        case .quotaLedger, .quotaRail, .usageTiles, .usageSplit, .usageTable, .usageDual, .usageTrend:
+        case .fill: width = 96; height = 4
+        case .image: width = 96; height = 48
+        case .quotaLedger, .quotaRail, .usageTiles, .usageSplit, .usageTable, .usageDual, .usageTrend,
+             .briefing, .forecast, .resets, .heatmap, .topModels:
             width = 284; height = 140
         case .quotaRings:
             width = 284; height = 140
@@ -418,7 +468,8 @@ public struct EInkCanvasElement: Codable, Equatable, Hashable, Identifiable, Sen
 
     private enum CodingKeys: String, CodingKey {
         case id, kind, fieldID, fieldIDs, periods, x, y, width, height, font, alignment
-        case textBinding, text, subText, autoWidth, usagePeriod, usageMetric, thickness, percentOverride, groupID
+        case textBinding, text, subText, imageSource, autoWidth, clipsOverflow, usagePeriod, usageMetric
+        case thickness, percentOverride, groupID, moduleID
     }
 
     public init(from decoder: Decoder) throws {
@@ -436,7 +487,10 @@ public struct EInkCanvasElement: Codable, Equatable, Hashable, Identifiable, Sen
         textBinding = c.lenient(TextBinding.self, .textBinding, .percent)
         text = c.lenient(String.self, .text, "")
         subText = c.lenient(String.self, .subText, "")
+        imageSource = c.lenient(String.self, .imageSource, "")
         autoWidth = c.lenient(Bool.self, .autoWidth, true)
+        clipsOverflow = c.lenient(Bool.self, .clipsOverflow, true)
+        moduleID = c.lenientOptional(String.self, .moduleID)
         usagePeriod = c.lenient(EInkUsagePeriod.self, .usagePeriod, .today)
         usageMetric = c.lenient(UsageMetric.self, .usageMetric, .cost)
         thickness = c.lenient(Double.self, .thickness, thickness)
@@ -460,7 +514,10 @@ public struct EInkCanvasElement: Codable, Equatable, Hashable, Identifiable, Sen
         try c.encode(textBinding, forKey: .textBinding)
         try c.encode(text, forKey: .text)
         try c.encode(subText, forKey: .subText)
+        try c.encode(imageSource, forKey: .imageSource)
         try c.encode(autoWidth, forKey: .autoWidth)
+        try c.encode(clipsOverflow, forKey: .clipsOverflow)
+        try c.encodeIfPresent(moduleID, forKey: .moduleID)
         try c.encode(usagePeriod, forKey: .usagePeriod)
         try c.encode(usageMetric, forKey: .usageMetric)
         try c.encode(thickness, forKey: .thickness)

--- a/Sources/VibeBarCore/Models/EInkDataSnapshot.swift
+++ b/Sources/VibeBarCore/Models/EInkDataSnapshot.swift
@@ -113,6 +113,23 @@ public struct EInkQuotaRow: Sendable, Equatable {
     public var slotLabel: String {
         windowTitle.isEmpty ? providerDisplayName : "\(providerDisplayName) · \(windowTitle)"
     }
+
+    /// This row wearing one slide's own name for it.
+    ///
+    /// The assembler already resolves a default (and honours the merged
+    /// override map, which is what the shared snapshot can carry), but two
+    /// slides may name the same bucket differently — a wide landscape ledger
+    /// and a 140 px portrait rail want different lengths. The slide's own
+    /// label therefore wins at draw time, split on the same separator so the
+    /// two-line slots still break where the name reads.
+    public func relabeled(with options: EInkSlideOptions) -> EInkQuotaRow {
+        guard let label = options.customLabel(for: fieldID) else { return self }
+        var copy = self
+        let parts = label.components(separatedBy: EInkSlotLabel.separator)
+        copy.providerDisplayName = parts.first ?? label
+        copy.windowTitle = parts.dropFirst().joined(separator: EInkSlotLabel.separator)
+        return copy
+    }
 }
 
 /// The pace verdict for one bucket, reduced to what the panel prints.

--- a/Sources/VibeBarCore/Models/EInkDataSnapshot.swift
+++ b/Sources/VibeBarCore/Models/EInkDataSnapshot.swift
@@ -16,6 +16,17 @@ public struct EInkDataSnapshot: Sendable, Equatable {
     public var usage: EInkUsageSet
     /// Seven daily points, oldest first.
     public var trend: [EInkTrendPoint]
+    /// `HH:mm` at assembly time, for a header or footer bound to the clock.
+    public var clockLabel: String
+    /// `MM-dd` at assembly time.
+    public var dateLabel: String
+    /// The 7 × 24 activity grid, summed over every provider.
+    public var heatmap: EInkHeatmap
+    /// Today's heaviest models by spend, heaviest first.
+    public var topModels: [EInkModelRow]
+    /// One line about provider health: "Anthropic: degraded" or
+    /// "All providers operational". Empty when nothing was read.
+    public var providerStatusLine: String
 
     public init(
         generatedAt: Date,
@@ -23,7 +34,12 @@ public struct EInkDataSnapshot: Sendable, Equatable {
         generatedAtISO: String,
         quota: [EInkQuotaRow],
         usage: EInkUsageSet,
-        trend: [EInkTrendPoint]
+        trend: [EInkTrendPoint],
+        clockLabel: String = "",
+        dateLabel: String = "",
+        heatmap: EInkHeatmap = .empty,
+        topModels: [EInkModelRow] = [],
+        providerStatusLine: String = ""
     ) {
         self.generatedAt = generatedAt
         self.generatedAtLabel = generatedAtLabel
@@ -31,6 +47,11 @@ public struct EInkDataSnapshot: Sendable, Equatable {
         self.quota = quota
         self.usage = usage
         self.trend = trend
+        self.clockLabel = clockLabel
+        self.dateLabel = dateLabel
+        self.heatmap = heatmap
+        self.topModels = topModels
+        self.providerStatusLine = providerStatusLine
     }
 
     public func quotaRows(fieldIDs: [String], limit: Int) -> [EInkQuotaRow] {
@@ -59,6 +80,9 @@ public struct EInkQuotaRow: Sendable, Equatable {
     /// `EInkFormat.countdown(resetAt, now)`, e.g. "5d 23h".
     public var countdown: String
     public var plan: String
+    /// What the pace model says about this bucket, when there is enough
+    /// history for one.
+    public var forecast: EInkQuotaForecast?
 
     public init(
         fieldID: String,
@@ -67,7 +91,8 @@ public struct EInkQuotaRow: Sendable, Equatable {
         remainingPercent: Int,
         resetAt: Date? = nil,
         countdown: String = "",
-        plan: String = ""
+        plan: String = "",
+        forecast: EInkQuotaForecast? = nil
     ) {
         self.fieldID = fieldID
         self.providerDisplayName = providerDisplayName
@@ -76,7 +101,130 @@ public struct EInkQuotaRow: Sendable, Equatable {
         self.resetAt = resetAt
         self.countdown = countdown
         self.plan = plan
+        self.forecast = forecast
     }
+
+    /// The slot's label as the panel prints it: SubProvider, quota group and
+    /// window, already resolved by `EInkSlotLabel`.
+    ///
+    /// `providerDisplayName` is the first tier only, and every preset that
+    /// names a bucket should print this instead — that is the whole point of
+    /// the round 2 naming change.
+    public var slotLabel: String {
+        windowTitle.isEmpty ? providerDisplayName : "\(providerDisplayName) · \(windowTitle)"
+    }
+}
+
+/// The pace verdict for one bucket, reduced to what the panel prints.
+public struct EInkQuotaForecast: Sendable, Equatable {
+    public var verdict: QuotaPaceForecast.Verdict
+    /// Median projected demand at reset; may exceed 100.
+    public var projectedUsedPercent: Double
+    public var runOutAt: Date?
+
+    public init(verdict: QuotaPaceForecast.Verdict, projectedUsedPercent: Double, runOutAt: Date? = nil) {
+        self.verdict = verdict
+        self.projectedUsedPercent = projectedUsedPercent
+        self.runOutAt = runOutAt
+    }
+
+    public init(_ forecast: QuotaPaceForecast) {
+        self.init(
+            verdict: forecast.verdict,
+            projectedUsedPercent: forecast.projectedUsedPercent,
+            runOutAt: forecast.runOutAt
+        )
+    }
+
+    /// The verdict in English, in full. Never `Verdict.label`: that one is
+    /// localized, and the panel is English by contract.
+    public var word: String {
+        switch verdict {
+        case .surplus: "SURPLUS"
+        case .enough: "ENOUGH"
+        case .watch: "WATCH"
+        case .atRisk: "AT RISK"
+        case .learning: "LEARNING"
+        }
+    }
+
+    /// Projected use at reset, clamped to a bar percentage.
+    public var projectedTickPercent: Int {
+        max(0, min(100, Int(projectedUsedPercent.rounded())))
+    }
+}
+
+/// One model's share of today's spend.
+public struct EInkModelRow: Sendable, Equatable {
+    public var model: String
+    public var costUSD: Double
+    public var tokens: Int64
+    public var requests: Int
+
+    public init(model: String, costUSD: Double, tokens: Int64, requests: Int) {
+        self.model = model
+        self.costUSD = costUSD
+        self.tokens = tokens
+        self.requests = requests
+    }
+}
+
+/// The 7 × 24 activity grid the heatmap preset draws, summed over providers.
+public struct EInkHeatmap: Sendable, Equatable {
+    /// `[weekday 0 = Sunday][hour 0...23]` token counts.
+    public var cells: [[Int]]
+    public var totalTokens: Int
+
+    public init(cells: [[Int]], totalTokens: Int) {
+        let normalized = (0..<7).map { row -> [Int] in
+            let source = row < cells.count ? cells[row] : []
+            return (0..<24).map { column in column < source.count ? max(0, source[column]) : 0 }
+        }
+        self.cells = normalized
+        self.totalTokens = max(0, totalTokens)
+    }
+
+    public static let empty = EInkHeatmap(cells: [], totalTokens: 0)
+
+    public var isEmpty: Bool { totalTokens == 0 || cells.allSatisfy { $0.allSatisfy { $0 == 0 } } }
+
+    /// Sum of every provider's grid, so the panel shows when *this Mac* works
+    /// rather than when one vendor does.
+    public static func summing(_ maps: [UsageHeatmap]) -> EInkHeatmap {
+        var cells = Array(repeating: Array(repeating: 0, count: 24), count: 7)
+        var total = 0
+        for map in maps {
+            for (row, hours) in map.cells.enumerated() where row < 7 {
+                for (hour, value) in hours.enumerated() where hour < 24 {
+                    cells[row][hour] += max(0, value)
+                    total += max(0, value)
+                }
+            }
+        }
+        return EInkHeatmap(cells: cells, totalTokens: total)
+    }
+
+    /// `(weekday, hour)` of the heaviest cell, or `nil` when the grid is flat
+    /// empty — a busiest hour claimed over no data is a lie on a panel.
+    public var busiest: (weekday: Int, hour: Int)? {
+        var best: (weekday: Int, hour: Int, value: Int)?
+        for (row, hours) in cells.enumerated() {
+            for (hour, value) in hours.enumerated() where value > 0 {
+                if best == nil || value > best!.value { best = (row, hour, value) }
+            }
+        }
+        guard let best else { return nil }
+        return (best.weekday, best.hour)
+    }
+
+    /// "busiest Tue 21:00", written out. Empty when there is no busiest hour.
+    public var busiestLabel: String {
+        guard let busiest else { return "" }
+        return "busiest \(Self.weekdayNames[busiest.weekday]) \(String(format: "%02d:00", busiest.hour))"
+    }
+
+    /// Sunday first, matching `UsageHeatmap.cells`.
+    public static let weekdayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
 }
 
 public struct EInkUsageTotals: Sendable, Equatable {
@@ -230,6 +378,25 @@ public enum EInkFormat {
         return "\(minutes)m"
     }
 
+    /// `HH:mm` in the given calendar's time zone.
+    public static func clockLabel(_ date: Date, calendar: Calendar) -> String {
+        formatted(date, calendar: calendar, format: "HH:mm")
+    }
+
+    /// `MM-dd` in the given calendar's time zone.
+    public static func dateLabel(_ date: Date, calendar: Calendar) -> String {
+        formatted(date, calendar: calendar, format: "MM-dd")
+    }
+
+    static func formatted(_ date: Date, calendar: Calendar, format: String) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.calendar = calendar
+        formatter.timeZone = calendar.timeZone
+        formatter.dateFormat = format
+        return formatter.string(from: date)
+    }
+
     /// `MM-dd HH:mm` in the given calendar's time zone.
     public static func timestampLabel(_ date: Date, calendar: Calendar) -> String {
         let formatter = DateFormatter()
@@ -238,5 +405,33 @@ public enum EInkFormat {
         formatter.timeZone = calendar.timeZone
         formatter.dateFormat = "MM-dd HH:mm"
         return formatter.string(from: date)
+    }
+}
+
+
+/// The one-line provider health summary a header can carry.
+///
+/// English and unabbreviated like everything else the panel prints, and
+/// deliberately *not* `StatusIndicator.summaryDescription`, which is copy and
+/// is translated. The worst provider is named because that is the one the
+/// reader can do something about; a clean board says so in one phrase.
+public enum EInkProviderStatusLine {
+    public static func compose(_ snapshots: [ServiceStatusSnapshot]) -> String {
+        guard !snapshots.isEmpty else { return "" }
+        let worst = snapshots
+            .filter { $0.effectiveIndicator != .none }
+            .max { $0.effectiveIndicator.severity < $1.effectiveIndicator.severity }
+        guard let worst else { return "All providers operational" }
+        return "\(worst.tool.vendorName): \(word(for: worst.effectiveIndicator))"
+    }
+
+    static func word(for indicator: StatusIndicator) -> String {
+        switch indicator {
+        case .none: "operational"
+        case .maintenance: "under maintenance"
+        case .minor: "degraded"
+        case .major: "partial outage"
+        case .critical: "major outage"
+        }
     }
 }

--- a/Sources/VibeBarCore/Models/EInkNodeBinding.swift
+++ b/Sources/VibeBarCore/Models/EInkNodeBinding.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// What a preset node draws, in the same vocabulary a Studio element uses.
+///
+/// The two have to agree: `EInkPresetExploder` turns a preset's nodes into
+/// canvas elements, and a binding that did not map onto one would come out the
+/// far side as frozen text — a panel that stopped following the data without
+/// saying so.
+public struct EInkNodeBinding: Equatable, Hashable, Sendable {
+    public var kind: EInkCanvasElement.TextBinding
+    /// `MenuBarFieldCatalog` field id, for the quota bindings.
+    public var fieldID: String?
+    public var usagePeriod: EInkUsagePeriod
+    public var usageMetric: EInkCanvasElement.UsageMetric
+
+    public init(
+        kind: EInkCanvasElement.TextBinding,
+        fieldID: String? = nil,
+        usagePeriod: EInkUsagePeriod = .today,
+        usageMetric: EInkCanvasElement.UsageMetric = .cost
+    ) {
+        self.kind = kind
+        self.fieldID = fieldID
+        self.usagePeriod = usagePeriod
+        self.usageMetric = usageMetric
+    }
+
+    public static func quota(_ fieldID: String, _ kind: EInkCanvasElement.TextBinding) -> EInkNodeBinding {
+        EInkNodeBinding(kind: kind, fieldID: fieldID)
+    }
+
+    public static func usage(
+        _ period: EInkUsagePeriod,
+        _ metric: EInkCanvasElement.UsageMetric
+    ) -> EInkNodeBinding {
+        EInkNodeBinding(kind: .usageMetric, usagePeriod: period, usageMetric: metric)
+    }
+
+    public static let clock = EInkNodeBinding(kind: .clock)
+    public static let date = EInkNodeBinding(kind: .date)
+    /// Fixed text: the element keeps the string the preset printed.
+    public static let staticText = EInkNodeBinding(kind: .custom)
+
+    /// Applies this binding to an element, so the exploded element reads the
+    /// same value the preset node did.
+    public func apply(to element: inout EInkCanvasElement) {
+        element.textBinding = kind
+        element.fieldID = fieldID
+        element.usagePeriod = usagePeriod
+        element.usageMetric = usageMetric
+    }
+}

--- a/Sources/VibeBarCore/Models/EInkPreset.swift
+++ b/Sources/VibeBarCore/Models/EInkPreset.swift
@@ -1,7 +1,13 @@
 import Foundation
 
-/// The eight layouts ported from the verified Dot. demo. Each one draws in
-/// both a landscape (296 × 152) and a portrait (152 × 296) arrangement.
+/// The layouts the panel can draw. Each one draws in both a landscape
+/// (296 × 152) and a portrait (152 × 296) arrangement.
+///
+/// The first eight are the verified Dot. demo ports; the five after them come
+/// from the owner's round 2 review, which asked for content that answers a
+/// question rather than restating a number ("am I on pace", "when does
+/// anything reset", "when do I actually work"). `alert` is the engine's own
+/// and is never offered in the picker — see `userSelectable`.
 public enum EInkPreset: String, Codable, CaseIterable, Sendable {
     case quotaLedger
     case quotaRings
@@ -11,6 +17,14 @@ public enum EInkPreset: String, Codable, CaseIterable, Sendable {
     case usageTable
     case usageDual
     case usageTrend
+    case briefing
+    case forecast
+    case resets
+    case heatmap
+    case topModels
+    /// Pushed by the sync engine when a bucket crosses its alert threshold,
+    /// with `border: 1`. Not a layout the user places on a slide.
+    case alert
 
     /// Which list the slide's selection applies to.
     public enum SelectionAxis: String, Sendable {
@@ -27,9 +41,13 @@ public enum EInkPreset: String, Codable, CaseIterable, Sendable {
 
     public var selectionAxis: SelectionAxis {
         switch self {
-        case .quotaLedger, .quotaRings, .quotaRail: .quotaFields
+        case .quotaLedger, .quotaRings, .quotaRail, .briefing, .forecast, .resets: .quotaFields
         case .usageTiles, .usageSplit: .usagePeriods
         case .usageTable, .usageDual: .harnessRows
+        // A heatmap is the whole week, the top models are the top models, and
+        // the alert names the one bucket that tripped it. None of the three
+        // has a subset worth picking.
+        case .heatmap, .topModels, .alert: SelectionAxis.none
         // Trend draws today plus the last seven days, always. There is no
         // meaningful subset of that — a "trend" of one bucket is a number —
         // so the slide's period selection does not apply to it.
@@ -50,6 +68,10 @@ public enum EInkPreset: String, Codable, CaseIterable, Sendable {
         case .usageTable: return 5
         case .usageDual: return portrait ? 5 : 4
         case .usageTrend: return 1
+        case .briefing: return portrait ? 8 : 6
+        case .forecast: return portrait ? 6 : 4
+        case .resets: return portrait ? 7 : 5
+        case .heatmap, .topModels, .alert: return 1
         }
     }
 
@@ -65,13 +87,43 @@ public enum EInkPreset: String, Codable, CaseIterable, Sendable {
         case .usageTable: "Usage · Table"
         case .usageDual: "Usage · Dual Bars"
         case .usageTrend: "Usage · Trend"
+        case .briefing: "Briefing"
+        case .forecast: "Forecast"
+        case .resets: "Resets"
+        case .heatmap: "Heatmap"
+        case .topModels: "Top Models"
+        case .alert: "Alert"
         }
     }
 
     public var isQuotaPreset: Bool { selectionAxis == .quotaFields }
 
+    /// Everything a slide may be set to. `alert` is the engine's and appears
+    /// in no picker: it names one bucket that just tripped a threshold, which
+    /// is not something a user can place in advance.
+    public static var userSelectable: [EInkPreset] { allCases.filter { $0 != .alert } }
+
+    /// How many rows the layout prints when nothing is selectable — the
+    /// heatmap's weekdays, the top model list.
+    public func rowCount(for orientation: EInkOrientation) -> Int {
+        switch self {
+        case .topModels: orientation.isPortrait ? 7 : 5
+        default: capacity(for: orientation)
+        }
+    }
+
     /// Whether drawing this layout needs the usage ledger at all. The three
     /// quota layouts do not, which is what lets a quota-only device keep
     /// pushing when the ledger is unreadable.
-    public var needsUsageData: Bool { !isQuotaPreset }
+    public var needsUsageData: Bool {
+        switch self {
+        // Briefing prints today's and the week's spend under its quota lines,
+        // and the heatmap and the model table are nothing else.
+        case .briefing, .heatmap, .topModels: return true
+        // Forecast, resets and the alert are quota only, so a device showing
+        // them keeps pushing when the ledger will not open.
+        case .forecast, .resets, .alert: return false
+        default: return !isQuotaPreset
+        }
+    }
 }

--- a/Sources/VibeBarCore/Models/EInkSlideOptions.swift
+++ b/Sources/VibeBarCore/Models/EInkSlideOptions.swift
@@ -1,0 +1,249 @@
+import Foundation
+
+/// What one side of a header bar prints.
+///
+/// `presetDefault` is the important case: it means "whatever this preset has
+/// always printed here", which is how a slide that nobody has configured
+/// reproduces the shipped layout byte for byte. Everything else is a
+/// deliberate choice the slide editor made.
+public enum EInkBarContent: Codable, Equatable, Hashable, Sendable {
+    case presetDefault
+    case none
+    case text(String)
+    /// `HH:mm` at assembly time.
+    case clock
+    /// `MM-dd` at assembly time.
+    case date
+    /// `MM-dd HH:mm`, the label every shipped header carries.
+    case dateClock
+    /// One line from `ServiceStatusClient`: "Anthropic: degraded" or
+    /// "All providers operational".
+    case providerStatus
+
+    private enum Tag: String, Codable {
+        case presetDefault, none, text, clock, date, dateClock, providerStatus
+    }
+
+    private enum CodingKeys: String, CodingKey { case kind, text }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        switch c.lenient(Tag.self, .kind, .presetDefault) {
+        case .presetDefault: self = .presetDefault
+        case .none: self = .none
+        case .text: self = .text(EInkCanvasLayout.panelText(c.lenient(String.self, .text, "")))
+        case .clock: self = .clock
+        case .date: self = .date
+        case .dateClock: self = .dateClock
+        case .providerStatus: self = .providerStatus
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .presetDefault: try c.encode(Tag.presetDefault, forKey: .kind)
+        case .none: try c.encode(Tag.none, forKey: .kind)
+        case let .text(value):
+            try c.encode(Tag.text, forKey: .kind)
+            try c.encode(EInkCanvasLayout.panelText(value), forKey: .text)
+        case .clock: try c.encode(Tag.clock, forKey: .kind)
+        case .date: try c.encode(Tag.date, forKey: .kind)
+        case .dateClock: try c.encode(Tag.dateClock, forKey: .kind)
+        case .providerStatus: try c.encode(Tag.providerStatus, forKey: .kind)
+        }
+    }
+}
+
+/// The optional bar at the top (or bottom) of every preset.
+public struct EInkBarConfig: Codable, Equatable, Hashable, Sendable {
+    public enum Position: String, Codable, CaseIterable, Sendable {
+        case top
+        case bottom
+    }
+
+    public var position: Position
+    public var left: EInkBarContent
+    public var right: EInkBarContent
+
+    public init(
+        position: Position = .top,
+        left: EInkBarContent = .presetDefault,
+        right: EInkBarContent = .presetDefault
+    ) {
+        self.position = position
+        self.left = left
+        self.right = right
+    }
+
+    private enum CodingKeys: String, CodingKey { case position, left, right }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            position: c.lenient(Position.self, .position, .top),
+            left: c.lenient(EInkBarContent.self, .left, .presetDefault),
+            right: c.lenient(EInkBarContent.self, .right, .presetDefault)
+        )
+    }
+}
+
+/// What the optional footer prints.
+public enum EInkFooterContent: Codable, Equatable, Hashable, Sendable {
+    case presetDefault
+    case usageSummary(periods: [EInkUsagePeriod])
+    case clock
+    case text(String)
+
+    private enum Tag: String, Codable { case presetDefault, usageSummary, clock, text }
+    private enum CodingKeys: String, CodingKey { case kind, periods, text }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        switch c.lenient(Tag.self, .kind, .presetDefault) {
+        case .presetDefault:
+            self = .presetDefault
+        case .usageSummary:
+            let raw = c.lenient([String].self, .periods, [])
+            let periods = raw.compactMap(EInkUsagePeriod.init(rawValue:))
+            self = .usageSummary(periods: periods.isEmpty ? [.today, .week] : periods)
+        case .clock:
+            self = .clock
+        case .text:
+            self = .text(EInkCanvasLayout.panelText(c.lenient(String.self, .text, "")))
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .presetDefault:
+            try c.encode(Tag.presetDefault, forKey: .kind)
+        case let .usageSummary(periods):
+            try c.encode(Tag.usageSummary, forKey: .kind)
+            try c.encode(periods.map(\.rawValue), forKey: .periods)
+        case .clock:
+            try c.encode(Tag.clock, forKey: .kind)
+        case let .text(value):
+            try c.encode(Tag.text, forKey: .kind)
+            try c.encode(EInkCanvasLayout.panelText(value), forKey: .text)
+        }
+    }
+}
+
+public struct EInkFooterConfig: Codable, Equatable, Hashable, Sendable {
+    public var content: EInkFooterContent
+
+    public init(content: EInkFooterContent = .presetDefault) {
+        self.content = content
+    }
+
+    private enum CodingKeys: String, CodingKey { case content }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(content: c.lenient(EInkFooterContent.self, .content, .presetDefault))
+    }
+}
+
+/// How one slide composes the preset it draws.
+///
+/// Every field has a default that means "unchanged", so a slide written by
+/// round 1 decodes into options that reproduce its old panel exactly — the
+/// property `EInkPresetGoldenTests` asserts rather than assumes.
+public struct EInkSlideOptions: Codable, Equatable, Hashable, Sendable {
+    /// `nil` draws no header bar at all and hands the height to the body.
+    public var header: EInkBarConfig?
+    /// `nil` draws no footer.
+    public var footer: EInkFooterConfig?
+    /// Field ids / period raw values in display order. Empty keeps the
+    /// slide's own order.
+    public var slotOrder: [String]
+    /// Field id → the label this slide prints for that slot. Empty string or
+    /// missing key means `EInkSlotLabel.default`.
+    public var customLabels: [String: String]
+    /// Tighter rows so a slide with no header and no footer fills the panel.
+    public var compact: Bool
+
+    public init(
+        header: EInkBarConfig? = EInkBarConfig(),
+        footer: EInkFooterConfig? = EInkFooterConfig(),
+        slotOrder: [String] = [],
+        customLabels: [String: String] = [:],
+        compact: Bool = false
+    ) {
+        self.header = header
+        self.footer = footer
+        self.slotOrder = slotOrder
+        self.customLabels = customLabels
+        self.compact = compact
+    }
+
+    /// Exactly what round 1 drew: a top header and the preset's own footer.
+    public static let `default` = EInkSlideOptions()
+
+    public var sanitized: EInkSlideOptions {
+        var copy = self
+        var seen = Set<String>()
+        copy.slotOrder = slotOrder.filter { !$0.isEmpty && seen.insert($0).inserted }
+        copy.customLabels = customLabels.reduce(into: [:]) { result, entry in
+            let trimmed = entry.value.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !entry.key.isEmpty, !trimmed.isEmpty else { return }
+            result[entry.key] = EInkCanvasLayout.panelText(String(trimmed.prefix(96)))
+        }
+        return copy
+    }
+
+    /// The label this slide prints for a slot, or `nil` for the default.
+    public func customLabel(for fieldID: String) -> String? {
+        guard let raw = customLabels[fieldID] else { return nil }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    /// `ids` in the slide's configured order: everything `slotOrder` names
+    /// that is actually present, then whatever `slotOrder` did not mention.
+    ///
+    /// Reordering must never *drop* a slot: a saved order predates the
+    /// bucket the user ticked a moment ago, and silently hiding it would read
+    /// as the picker not working.
+    public func ordered(_ ids: [String]) -> [String] {
+        guard !slotOrder.isEmpty else { return ids }
+        let available = Set(ids)
+        var seen = Set<String>()
+        var result = slotOrder.filter { available.contains($0) && seen.insert($0).inserted }
+        result += ids.filter { seen.insert($0).inserted }
+        return result
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case header, footer, hasHeader, hasFooter, slotOrder, customLabels, compact
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        // `hasHeader` is written beside the config so "off" survives a
+        // round trip: an absent `header` key is also what a round 1 file
+        // looks like, and those must decode as "on".
+        let hasHeader = c.lenient(Bool.self, .hasHeader, true)
+        let hasFooter = c.lenient(Bool.self, .hasFooter, true)
+        self.init(
+            header: hasHeader ? c.lenient(EInkBarConfig.self, .header, EInkBarConfig()) : nil,
+            footer: hasFooter ? c.lenient(EInkFooterConfig.self, .footer, EInkFooterConfig()) : nil,
+            slotOrder: c.lenient([String].self, .slotOrder, []),
+            customLabels: c.lenient([String: String].self, .customLabels, [:]),
+            compact: c.lenient(Bool.self, .compact, false)
+        )
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(header != nil, forKey: .hasHeader)
+        try c.encodeIfPresent(header, forKey: .header)
+        try c.encode(footer != nil, forKey: .hasFooter)
+        try c.encodeIfPresent(footer, forKey: .footer)
+        try c.encode(slotOrder, forKey: .slotOrder)
+        try c.encode(customLabels, forKey: .customLabels)
+        try c.encode(compact, forKey: .compact)
+    }
+}

--- a/Sources/VibeBarCore/Models/EInkSlotLabel.swift
+++ b/Sources/VibeBarCore/Models/EInkSlotLabel.swift
@@ -1,0 +1,151 @@
+import Foundation
+
+/// How the panel names one quota slot.
+///
+/// Round 1 shipped a short per-provider table ("Claude", "Codex") and the
+/// owner's review killed it: on a panel showing two Claude rows and two Codex
+/// rows, "Claude · Weekly" does not say *which* weekly bucket it is, and the
+/// one surface that already answers that question — the mini window — spells
+/// it out in three tiers. This resolves the same three tiers, in English and
+/// unabbreviated, because a panel read across a desk has no tooltip.
+///
+/// The tiers, joined by `" · "`:
+///
+/// 1. **SubProvider** — `ToolType.quotaSubProviderName(bucketID:)`: "Claude",
+///    "ChatGPT Agentic", "AntiGravity", "Grok Bot".
+/// 2. **Quota group** — only for a *branch* bucket, i.e. one whose
+///    `MenuBarFieldCatalog.namingGroupKey` is not the SubProvider's own
+///    `<tool>.all-models` catch-all. "Fable", "GPT-5.3 Codex Spark",
+///    "Claude and GPT Models". Taken from the contract title rather than
+///    from `MiniWindowGroupLabelCatalog.defaultLabel`, whose short forms
+///    ("Claude + GPT") are exactly the abbreviations the panel may not print.
+/// 3. **Window** — "Weekly", "5 Hours", "Daily", "Monthly".
+///
+/// A part equal to one already emitted is dropped, so Grok Bot's single
+/// weekly reads "Grok Bot · Weekly" rather than naming itself twice.
+public enum EInkSlotLabel {
+    public static let separator = " · "
+
+    /// The default label for one quota field.
+    ///
+    /// `bucket` is the live bucket when the assembler has one: a provider that
+    /// renamed a window, or a bucket the static catalog has never heard of,
+    /// is named by what it actually returned.
+    public static func `default`(
+        for fieldID: String,
+        registry: QuotaFieldRegistry = .empty,
+        bucket: QuotaBucket? = nil
+    ) -> String {
+        parts(for: fieldID, registry: registry, bucket: bucket).joined(separator: separator)
+    }
+
+    /// The label a slide prints for a slot: its own override, else the
+    /// default.
+    public static func resolved(
+        for fieldID: String,
+        options: EInkSlideOptions,
+        registry: QuotaFieldRegistry = .empty,
+        bucket: QuotaBucket? = nil
+    ) -> String {
+        options.customLabel(for: fieldID)
+            ?? `default`(for: fieldID, registry: registry, bucket: bucket)
+    }
+
+    /// The tiers, already de-duplicated and with empties dropped.
+    public static func parts(
+        for fieldID: String,
+        registry: QuotaFieldRegistry = .empty,
+        bucket: QuotaBucket? = nil
+    ) -> [String] {
+        guard let selector = EInkDataAssembler.selector(fieldID: fieldID) else {
+            return [fieldID]
+        }
+        let field = MenuBarFieldCatalog.field(id: fieldID, registry: registry)
+        var raw: [String] = [selector.tool.quotaSubProviderName(bucketID: selector.bucketID)]
+        if let group = groupTitle(selector: selector, field: field, bucket: bucket) {
+            raw.append(group)
+        }
+        if let window = windowTitle(field: field, bucket: bucket) {
+            raw.append(window)
+        }
+        var seen = Set<String>()
+        var kept: [String] = []
+        for part in raw.map({ $0.trimmingCharacters(in: .whitespacesAndNewlines) }) {
+            guard !part.isEmpty, seen.insert(part.lowercased()).inserted else { continue }
+            // "Cursor · Cursor Models · Monthly" names its SubProvider twice.
+            // A tier that merely restates an earlier one, with or without a
+            // trailing noun, is dropped rather than printed on a 296 px panel.
+            if kept.contains(where: { part.lowercased().hasPrefix($0.lowercased() + " ") }) { continue }
+            kept.append(part)
+        }
+        return kept
+    }
+
+    /// Two lines for a slot too narrow for one: the SubProvider on top, the
+    /// rest underneath.
+    ///
+    /// Rings and the rail always draw this form (centred); the ledger and the
+    /// table only fall back to it when the label outruns a grown column.
+    public static func twoLines(_ label: String) -> (first: String, second: String) {
+        let parts = label.components(separatedBy: separator)
+        guard parts.count > 1 else { return (label, "") }
+        return (parts[0], parts.dropFirst().joined(separator: separator))
+    }
+
+    /// Whether `label` needs the two-line form in a column this wide, at the
+    /// device's pixel font.
+    public static func needsTwoLines(_ label: String, columnWidth: Int, font: EInkFont = .pixel12(bold: false)) -> Bool {
+        EInkTextMetrics.width(label, font: font) > columnWidth
+    }
+
+    /// The widest label in `labels`, in device pixels.
+    public static func widestWidth(_ labels: [String], font: EInkFont = .pixel12(bold: false)) -> Int {
+        labels.map { EInkTextMetrics.width($0, font: font) }.max() ?? 0
+    }
+
+    // MARK: - Tiers
+
+    /// The L3 quota group, or `nil` when the bucket sits directly under its
+    /// SubProvider.
+    static func groupTitle(
+        selector: EInkDataAssembler.QuotaSelector,
+        field: MenuBarFieldOption?,
+        bucket: QuotaBucket?
+    ) -> String? {
+        // A bucket whose own group title is just its SubProvider (Grok Bot)
+        // adds nothing: the first tier already said it.
+        let subProvider = selector.tool.quotaSubProviderName(bucketID: selector.bucketID)
+        if let live = bucket?.groupTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !live.isEmpty,
+           live.caseInsensitiveCompare(subProvider) != .orderedSame,
+           !isCatchAll(live)
+        {
+            return live
+        }
+        guard let field else { return nil }
+        // The catch-all lane ("All Models") is not a name, it is the absence
+        // of one: "Claude · All Models · Weekly" reads as three tiers where
+        // there are two.
+        guard let key = MenuBarFieldCatalog.namingGroupKey(for: field),
+              key != MenuBarFieldCatalog.allModelsGroupKey(for: field.tool)
+        else { return nil }
+        let parts = field.title.components(separatedBy: separator)
+        guard parts.count > 1 else { return nil }
+        let group = parts.dropLast().joined(separator: separator)
+        return isCatchAll(group) ? nil : group
+    }
+
+    /// The window word, written out.
+    static func windowTitle(field: MenuBarFieldOption?, bucket: QuotaBucket?) -> String? {
+        if let bucket {
+            let title = bucket.title.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !title.isEmpty { return title }
+        }
+        guard let field else { return nil }
+        return field.title.components(separatedBy: separator).last
+    }
+
+    static func isCatchAll(_ value: String) -> Bool {
+        value.caseInsensitiveCompare("All Models") == .orderedSame
+    }
+}

--- a/Sources/VibeBarCore/Models/EInkSyncSettings.swift
+++ b/Sources/VibeBarCore/Models/EInkSyncSettings.swift
@@ -60,20 +60,6 @@ public struct EInkSyncSettings: Codable, Equatable, Sendable {
         return result
     }
 
-    /// Every slide's per-slot label overrides, merged in device then slide
-    /// order.
-    public var customSlotLabels: [String: String] {
-        var result: [String: String] = [:]
-        for device in devices {
-            for slide in device.slides {
-                for (fieldID, label) in slide.options.sanitized.customLabels where result[fieldID] == nil {
-                    result[fieldID] = label
-                }
-            }
-        }
-        return result
-    }
-
     public func device(id: String) -> EInkDeviceConfig? {
         devices.first { $0.deviceID == id }
     }

--- a/Sources/VibeBarCore/Models/EInkSyncSettings.swift
+++ b/Sources/VibeBarCore/Models/EInkSyncSettings.swift
@@ -60,6 +60,20 @@ public struct EInkSyncSettings: Codable, Equatable, Sendable {
         return result
     }
 
+    /// Every slide's per-slot label overrides, merged in device then slide
+    /// order.
+    public var customSlotLabels: [String: String] {
+        var result: [String: String] = [:]
+        for device in devices {
+            for slide in device.slides {
+                for (fieldID, label) in slide.options.sanitized.customLabels where result[fieldID] == nil {
+                    result[fieldID] = label
+                }
+            }
+        }
+        return result
+    }
+
     public func device(id: String) -> EInkDeviceConfig? {
         devices.first { $0.deviceID == id }
     }
@@ -187,7 +201,10 @@ public enum EInkPlayback: Codable, Equatable, Sendable {
         case appTimer
     }
 
-    public static let minimumSecondsPerSlide = 30
+    /// The device used to floor this at 30 s. The owner asked for a wider,
+    /// typeable range, and the floor was never a device limit — it was a
+    /// guess about how often a panel should flash.
+    public static let minimumSecondsPerSlide = 10
     public static let maximumSecondsPerSlide = 24 * 60 * 60
     public static let `default` = EInkPlayback.single(slideID: "")
 
@@ -241,6 +258,162 @@ public enum EInkPlayback: Codable, Equatable, Sendable {
     }
 }
 
+// MARK: - Playback mode
+
+/// The three ways a device moves between slides, as one flat choice.
+///
+/// Split out of `EInkPlayback` because the owner's review found the bug the
+/// old shape guaranteed: "seconds per slide" lived *inside* the carousel case,
+/// so switching to One slide and back threw the number away and put 300 back.
+/// The mode and the cadence are independent settings and are now stored that
+/// way.
+public enum EInkPlaybackMode: String, Codable, CaseIterable, Sendable {
+    case single
+    case deviceLoop
+    case appTimer
+}
+
+// MARK: - Alerts, tap link, quiet hours
+
+/// When the engine replaces the panel with the alert slide.
+public struct EInkAlertConfig: Codable, Equatable, Sendable {
+    public var enabled: Bool
+    /// A bucket at or below this much quota left alerts. `atRisk` alerts
+    /// whatever this says.
+    public var thresholdPercent: Int
+
+    public static let minimumThresholdPercent = 1
+    public static let maximumThresholdPercent = 99
+    public static let defaultThresholdPercent = 10
+
+    public init(enabled: Bool = true, thresholdPercent: Int = EInkAlertConfig.defaultThresholdPercent) {
+        self.enabled = enabled
+        self.thresholdPercent = thresholdPercent
+    }
+
+    public var sanitized: EInkAlertConfig {
+        EInkAlertConfig(
+            enabled: enabled,
+            thresholdPercent: min(Self.maximumThresholdPercent, max(Self.minimumThresholdPercent, thresholdPercent))
+        )
+    }
+
+    private enum CodingKeys: String, CodingKey { case enabled, thresholdPercent }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            enabled: c.lenient(Bool.self, .enabled, true),
+            thresholdPercent: c.lenient(Int.self, .thresholdPercent, Self.defaultThresholdPercent)
+        )
+    }
+}
+
+/// What the panel opens when it is tapped (the Quote/0 is NFC-tappable, and
+/// the phone follows the payload's `link`).
+public enum EInkTapLink: Codable, Equatable, Sendable {
+    case none
+    /// The Vibe Bar remote dashboard, resolved at push time and omitted when
+    /// Remote is not configured on this Mac.
+    case remoteDashboard
+    case custom(String)
+
+    /// The URL to send, or `nil` for no link at all.
+    ///
+    /// HTTPS only, and never a URL with credentials in it: the value is
+    /// user-entered and ends up on a phone that taps the panel.
+    public func url(remoteDashboard: URL?) -> URL? {
+        switch self {
+        case .none:
+            return nil
+        case .remoteDashboard:
+            return remoteDashboard.flatMap(Self.allowed)
+        case let .custom(raw):
+            return URL(string: raw.trimmingCharacters(in: .whitespacesAndNewlines)).flatMap(Self.allowed)
+        }
+    }
+
+    static func allowed(_ url: URL) -> URL? {
+        guard url.scheme?.lowercased() == "https",
+              let host = url.host, !host.isEmpty,
+              url.user == nil, url.password == nil
+        else { return nil }
+        return url
+    }
+
+    private enum Tag: String, Codable { case none, remoteDashboard, custom }
+    private enum CodingKeys: String, CodingKey { case kind, url }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        switch c.lenient(Tag.self, .kind, .none) {
+        case .none: self = .none
+        case .remoteDashboard: self = .remoteDashboard
+        case .custom: self = .custom(c.lenient(String.self, .url, ""))
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .none: try c.encode(Tag.none, forKey: .kind)
+        case .remoteDashboard: try c.encode(Tag.remoteDashboard, forKey: .kind)
+        case let .custom(raw):
+            try c.encode(Tag.custom, forKey: .kind)
+            try c.encode(raw, forKey: .url)
+        }
+    }
+}
+
+/// The device's own sleep window, written through `POST /settings`.
+public struct EInkQuietHours: Codable, Equatable, Sendable {
+    public var enabled: Bool
+    /// `HH:mm`, the device's own format.
+    public var start: String
+    public var end: String
+
+    public init(enabled: Bool = false, start: String = "23:00", end: String = "07:00") {
+        self.enabled = enabled
+        self.start = start
+        self.end = end
+    }
+
+    /// A device-acceptable window, or `nil` when either end is unreadable.
+    public var window: (start: String, end: String)? {
+        guard let start = Self.normalized(start), let end = Self.normalized(end) else { return nil }
+        return (start, end)
+    }
+
+    /// `HH:mm` with both parts in range, or `nil`.
+    public static func normalized(_ raw: String) -> String? {
+        let parts = raw.trimmingCharacters(in: .whitespaces).components(separatedBy: ":")
+        guard parts.count == 2,
+              let hour = Int(parts[0]), let minute = Int(parts[1]),
+              (0...23).contains(hour), (0...59).contains(minute)
+        else { return nil }
+        return String(format: "%02d:%02d", hour, minute)
+    }
+
+    public var sanitized: EInkQuietHours {
+        EInkQuietHours(
+            enabled: enabled,
+            start: Self.normalized(start) ?? "23:00",
+            end: Self.normalized(end) ?? "07:00"
+        )
+    }
+
+    private enum CodingKeys: String, CodingKey { case enabled, start, end }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            enabled: c.lenient(Bool.self, .enabled, false),
+            start: c.lenient(String.self, .start, "23:00"),
+            end: c.lenient(String.self, .end, "07:00")
+        )
+    }
+}
+
 // MARK: - Device
 
 public struct EInkDeviceConfig: Codable, Equatable, Identifiable, Sendable {
@@ -249,7 +422,16 @@ public struct EInkDeviceConfig: Codable, Equatable, Identifiable, Sendable {
     public var profile: EInkDeviceProfile
     public var enabled: Bool
     public var orientation: EInkOrientation
-    public var playback: EInkPlayback
+    /// How the device moves between slides.
+    public var playbackMode: EInkPlaybackMode
+    /// Kept whatever the mode is — see `EInkPlaybackMode`.
+    public var secondsPerSlide: Int
+    /// The slide `single` shows. Kept across a switch to a carousel and back
+    /// for the same reason `secondsPerSlide` is.
+    public var singleSlideID: String
+    public var alerts: EInkAlertConfig
+    public var tapLink: EInkTapLink
+    public var quietHours: EInkQuietHours
     /// How often the data behind every slide is re-assembled and re-pushed.
     public var dataRefreshMinutes: Int
     /// Battery / Wi-Fi read-back cadence; far cheaper than a push, but it
@@ -264,8 +446,11 @@ public struct EInkDeviceConfig: Codable, Equatable, Identifiable, Sendable {
 
     public static let defaultDataRefreshMinutes = 15
     public static let minimumDataRefreshMinutes = 1
+    public static let maximumDataRefreshMinutes = 1440
     public static let defaultBatteryRefreshMinutes = 60
     public static let minimumBatteryRefreshMinutes = 1
+    public static let maximumBatteryRefreshMinutes = 1440
+    public static let defaultSecondsPerSlide = 300
 
     public init(
         deviceID: String,
@@ -273,7 +458,12 @@ public struct EInkDeviceConfig: Codable, Equatable, Identifiable, Sendable {
         profile: EInkDeviceProfile = .quote0,
         enabled: Bool = false,
         orientation: EInkOrientation = .degrees0,
-        playback: EInkPlayback = .single(slideID: ""),
+        playbackMode: EInkPlaybackMode = .single,
+        secondsPerSlide: Int = EInkDeviceConfig.defaultSecondsPerSlide,
+        singleSlideID: String = "",
+        alerts: EInkAlertConfig = EInkAlertConfig(),
+        tapLink: EInkTapLink = .none,
+        quietHours: EInkQuietHours = EInkQuietHours(),
         dataRefreshMinutes: Int = EInkDeviceConfig.defaultDataRefreshMinutes,
         batteryRefreshMinutes: Int = EInkDeviceConfig.defaultBatteryRefreshMinutes,
         taskKeys: [String] = [],
@@ -284,38 +474,108 @@ public struct EInkDeviceConfig: Codable, Equatable, Identifiable, Sendable {
         self.profile = profile
         self.enabled = enabled
         self.orientation = orientation
-        self.playback = playback
+        self.playbackMode = playbackMode
+        self.secondsPerSlide = secondsPerSlide
+        self.singleSlideID = singleSlideID
+        self.alerts = alerts
+        self.tapLink = tapLink
+        self.quietHours = quietHours
         self.dataRefreshMinutes = dataRefreshMinutes
         self.batteryRefreshMinutes = batteryRefreshMinutes
         self.taskKeys = taskKeys
         self.slides = slides
     }
 
+    /// Convenience initializer keeping the round 1 call shape, so callers
+    /// that think in `EInkPlayback` do not have to be rewritten.
+    public init(
+        deviceID: String,
+        alias: String = "",
+        profile: EInkDeviceProfile = .quote0,
+        enabled: Bool = false,
+        orientation: EInkOrientation = .degrees0,
+        playback: EInkPlayback,
+        dataRefreshMinutes: Int = EInkDeviceConfig.defaultDataRefreshMinutes,
+        batteryRefreshMinutes: Int = EInkDeviceConfig.defaultBatteryRefreshMinutes,
+        taskKeys: [String] = [],
+        slides: [EInkSlide] = []
+    ) {
+        self.init(
+            deviceID: deviceID,
+            alias: alias,
+            profile: profile,
+            enabled: enabled,
+            orientation: orientation,
+            dataRefreshMinutes: dataRefreshMinutes,
+            batteryRefreshMinutes: batteryRefreshMinutes,
+            taskKeys: taskKeys,
+            slides: slides
+        )
+        self.playback = playback
+    }
+
+    /// The mode and the cadence read as one value, for the push planner and
+    /// the carousel loop that only ever ask "which slide, how often".
+    ///
+    /// Writing it back never loses the other half: setting `.single` keeps
+    /// `secondsPerSlide`, and setting a carousel keeps `singleSlideID`.
+    public var playback: EInkPlayback {
+        get {
+            switch playbackMode {
+            case .single: return .single(slideID: singleSlideID)
+            case .deviceLoop: return .carousel(driver: .deviceLoop, secondsPerSlide: secondsPerSlide)
+            case .appTimer: return .carousel(driver: .appTimer, secondsPerSlide: secondsPerSlide)
+            }
+        }
+        set {
+            switch newValue {
+            case let .single(slideID):
+                playbackMode = .single
+                singleSlideID = slideID
+            case let .carousel(driver, seconds):
+                playbackMode = driver == .appTimer ? .appTimer : .deviceLoop
+                secondsPerSlide = seconds
+            }
+        }
+    }
+
     public func slide(id: String) -> EInkSlide? { slides.first { $0.id == id } }
 
     /// The slide a single-display device shows: the named one, else the first.
     public var resolvedSingleSlide: EInkSlide? {
-        if case let .single(slideID) = playback, let match = slide(id: slideID) { return match }
+        if playbackMode == .single, let match = slide(id: singleSlideID) { return match }
         return slides.first
     }
 
     public var sanitized: EInkDeviceConfig {
         var copy = self
         copy.profile = profile.sanitized
-        copy.dataRefreshMinutes = max(Self.minimumDataRefreshMinutes, min(24 * 60, dataRefreshMinutes))
-        copy.batteryRefreshMinutes = max(Self.minimumBatteryRefreshMinutes, min(24 * 60, batteryRefreshMinutes))
+        copy.dataRefreshMinutes = max(
+            Self.minimumDataRefreshMinutes,
+            min(Self.maximumDataRefreshMinutes, dataRefreshMinutes)
+        )
+        copy.batteryRefreshMinutes = max(
+            Self.minimumBatteryRefreshMinutes,
+            min(Self.maximumBatteryRefreshMinutes, batteryRefreshMinutes)
+        )
+        copy.secondsPerSlide = max(
+            EInkPlayback.minimumSecondsPerSlide,
+            min(EInkPlayback.maximumSecondsPerSlide, secondsPerSlide)
+        )
+        copy.alerts = alerts.sanitized
+        copy.quietHours = quietHours.sanitized
         var seenTasks = Set<String>()
         copy.taskKeys = taskKeys.filter { !$0.isEmpty && seenTasks.insert($0).inserted }
         var seenSlides = Set<String>()
         copy.slides = slides
             .filter { !$0.id.isEmpty && seenSlides.insert($0.id).inserted }
             .map { $0.sanitized.fitted(to: copy.orientation) }
-        copy.playback = playback.sanitized
         return copy
     }
 
     private enum CodingKeys: String, CodingKey {
         case deviceID, alias, profile, enabled, orientation, playback
+        case playbackMode, secondsPerSlide, singleSlideID, alerts, tapLink, quietHours
         case dataRefreshMinutes, batteryRefreshMinutes, taskKeys, slides
     }
 
@@ -328,11 +588,33 @@ public struct EInkDeviceConfig: Codable, Equatable, Identifiable, Sendable {
             profile: c.lenient(EInkDeviceProfile.self, .profile, .quote0),
             enabled: c.lenient(Bool.self, .enabled, false),
             orientation: orientationRaw.flatMap(EInkOrientation.init(rawValue:)) ?? .degrees0,
-            playback: c.lenient(EInkPlayback.self, .playback, .single(slideID: "")),
+            alerts: c.lenient(EInkAlertConfig.self, .alerts, EInkAlertConfig()),
+            tapLink: c.lenient(EInkTapLink.self, .tapLink, .none),
+            quietHours: c.lenient(EInkQuietHours.self, .quietHours, EInkQuietHours()),
             dataRefreshMinutes: c.lenient(Int.self, .dataRefreshMinutes, Self.defaultDataRefreshMinutes),
             batteryRefreshMinutes: c.lenient(Int.self, .batteryRefreshMinutes, Self.defaultBatteryRefreshMinutes),
             taskKeys: c.lenient([String].self, .taskKeys, []),
             slides: c.lenient([EInkSlide].self, .slides, [])
+        )
+        // Round 1 wrote one `playback` object; round 2 writes three fields.
+        // Seeding from the old value first and then letting the new keys win
+        // is what makes a file written by either build read correctly, and
+        // what stops a downgrade-then-upgrade from losing the cadence.
+        if let legacy = c.lenientOptional(EInkPlayback.self, .playback) {
+            playback = legacy.sanitized
+        }
+        if let mode = c.lenientOptional(EInkPlaybackMode.self, .playbackMode) {
+            playbackMode = mode
+        }
+        if let seconds = c.lenientOptional(Int.self, .secondsPerSlide) {
+            secondsPerSlide = seconds
+        }
+        if let slideID = c.lenientOptional(String.self, .singleSlideID) {
+            singleSlideID = slideID
+        }
+        secondsPerSlide = max(
+            EInkPlayback.minimumSecondsPerSlide,
+            min(EInkPlayback.maximumSecondsPerSlide, secondsPerSlide)
         )
     }
 
@@ -343,7 +625,14 @@ public struct EInkDeviceConfig: Codable, Equatable, Identifiable, Sendable {
         try c.encode(profile, forKey: .profile)
         try c.encode(enabled, forKey: .enabled)
         try c.encode(orientation.rawValue, forKey: .orientation)
+        // Both shapes: an older build reads `playback` and keeps working.
         try c.encode(playback, forKey: .playback)
+        try c.encode(playbackMode, forKey: .playbackMode)
+        try c.encode(secondsPerSlide, forKey: .secondsPerSlide)
+        try c.encode(singleSlideID, forKey: .singleSlideID)
+        try c.encode(alerts, forKey: .alerts)
+        try c.encode(tapLink, forKey: .tapLink)
+        try c.encode(quietHours, forKey: .quietHours)
         try c.encode(dataRefreshMinutes, forKey: .dataRefreshMinutes)
         try c.encode(batteryRefreshMinutes, forKey: .batteryRefreshMinutes)
         try c.encode(taskKeys, forKey: .taskKeys)
@@ -403,19 +692,40 @@ public struct EInkSlide: Codable, Equatable, Identifiable, Sendable {
     /// `MenuBarFieldCatalog` field IDs ("claude.weekly"), in display order.
     public var quotaFieldIDs: [String]
     public var usagePeriods: [EInkUsagePeriod]
+    /// Header / footer / slot order / per-slot labels. `.default` reproduces
+    /// the round 1 panel exactly.
+    public var options: EInkSlideOptions
 
     public init(
         id: String = UUID().uuidString,
         title: String = "",
         kind: Kind = .preset(.quotaLedger),
         quotaFieldIDs: [String] = [],
-        usagePeriods: [EInkUsagePeriod] = EInkUsagePeriod.allCases
+        usagePeriods: [EInkUsagePeriod] = EInkUsagePeriod.allCases,
+        options: EInkSlideOptions = .default
     ) {
         self.id = id
         self.title = title
         self.kind = kind
         self.quotaFieldIDs = quotaFieldIDs
         self.usagePeriods = usagePeriods
+        self.options = options
+    }
+
+    /// Per-slot label overrides. Stored inside `options` so one struct carries
+    /// everything the slide editor writes.
+    public var customLabels: [String: String] {
+        get { options.customLabels }
+        set { options.customLabels = newValue }
+    }
+
+    /// The quota buckets this slide draws, in the order the editor put them.
+    public var orderedQuotaFieldIDs: [String] { options.ordered(quotaFieldIDs) }
+
+    /// The usage windows this slide draws, in the order the editor put them.
+    public func orderedUsagePeriods(_ periods: [EInkUsagePeriod]) -> [EInkUsagePeriod] {
+        let ordered = options.ordered(periods.map(\.rawValue))
+        return ordered.compactMap(EInkUsagePeriod.init(rawValue:))
     }
 
     public var sanitized: EInkSlide {
@@ -424,6 +734,7 @@ public struct EInkSlide: Codable, Equatable, Identifiable, Sendable {
         copy.quotaFieldIDs = quotaFieldIDs.filter { !$0.isEmpty && seenFields.insert($0).inserted }
         var seenPeriods = Set<EInkUsagePeriod>()
         copy.usagePeriods = usagePeriods.filter { seenPeriods.insert($0).inserted }
+        copy.options = options.sanitized
         return copy
     }
 
@@ -492,7 +803,9 @@ public struct EInkSlide: Codable, Equatable, Identifiable, Sendable {
         return copy
     }
 
-    private enum CodingKeys: String, CodingKey { case id, title, kind, quotaFieldIDs, usagePeriods }
+    private enum CodingKeys: String, CodingKey {
+        case id, title, kind, quotaFieldIDs, usagePeriods, options
+    }
 
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
@@ -502,7 +815,8 @@ public struct EInkSlide: Codable, Equatable, Identifiable, Sendable {
             title: c.lenient(String.self, .title, ""),
             kind: c.lenient(Kind.self, .kind, .preset(.quotaLedger)),
             quotaFieldIDs: c.lenient([String].self, .quotaFieldIDs, []),
-            usagePeriods: rawPeriods.map { $0.compactMap(EInkUsagePeriod.init(rawValue:)) } ?? EInkUsagePeriod.allCases
+            usagePeriods: rawPeriods.map { $0.compactMap(EInkUsagePeriod.init(rawValue:)) } ?? EInkUsagePeriod.allCases,
+            options: c.lenient(EInkSlideOptions.self, .options, .default)
         )
     }
 
@@ -513,6 +827,7 @@ public struct EInkSlide: Codable, Equatable, Identifiable, Sendable {
         try c.encode(kind, forKey: .kind)
         try c.encode(quotaFieldIDs, forKey: .quotaFieldIDs)
         try c.encode(usagePeriods.map(\.rawValue), forKey: .usagePeriods)
+        try c.encode(options, forKey: .options)
     }
 }
 

--- a/Sources/VibeBarCore/Models/EInkSyncState.swift
+++ b/Sources/VibeBarCore/Models/EInkSyncState.swift
@@ -71,6 +71,20 @@ public struct EInkDeviceSyncState: Codable, Equatable, Sendable {
     /// Tasks in the loop that no slide claims, as of the last pass.
     public var surplusTaskCount: Int
     public var lastStatusAt: Date?
+    /// The bucket whose alert is currently on screen, or `nil`.
+    ///
+    /// Persisted for one reason: an alert is an *edge*. Relaunching the app
+    /// with the same bucket still under its threshold must not push the panel
+    /// again — the reader has already seen it, and an e-ink refresh at every
+    /// launch is exactly the noise that makes people turn a feature off.
+    public var alertingFieldID: String?
+    /// The soonest bucket reset this device knows about. When the clock passes
+    /// it, the next pass redraws immediately instead of waiting out the
+    /// cadence: the numbers behind the panel have just jumped.
+    public var nextResetAt: Date?
+    /// `enabled|start|end` of the sleep window last written to the device, so
+    /// a window that has not changed is not written every refresh.
+    public var quietHoursSignature: String?
 
     public init(
         deviceID: String,
@@ -88,7 +102,10 @@ public struct EInkDeviceSyncState: Codable, Equatable, Sendable {
         slideIndex: Int = 0,
         canvasTaskCount: Int? = nil,
         surplusTaskCount: Int = 0,
-        lastStatusAt: Date? = nil
+        lastStatusAt: Date? = nil,
+        alertingFieldID: String? = nil,
+        nextResetAt: Date? = nil,
+        quietHoursSignature: String? = nil
     ) {
         self.deviceID = deviceID
         self.pushedDigests = pushedDigests
@@ -106,6 +123,9 @@ public struct EInkDeviceSyncState: Codable, Equatable, Sendable {
         self.canvasTaskCount = canvasTaskCount
         self.surplusTaskCount = surplusTaskCount
         self.lastStatusAt = lastStatusAt
+        self.alertingFieldID = alertingFieldID
+        self.nextResetAt = nextResetAt
+        self.quietHoursSignature = quietHoursSignature
     }
 
     /// The read-back thumbnail, only when the service handed us one of its own
@@ -137,6 +157,7 @@ public struct EInkDeviceSyncState: Codable, Equatable, Sendable {
         case deviceID, pushedDigests, lastPushAt, lastAttemptAt, lastError, lastFailure
         case renderImageURL, onBattery, powerLabel, batteryLabel, wifiLabel
         case nextRefreshAt, slideIndex, canvasTaskCount, surplusTaskCount, lastStatusAt
+        case alertingFieldID, nextResetAt, quietHoursSignature
     }
 
     public init(from decoder: Decoder) throws {
@@ -157,7 +178,10 @@ public struct EInkDeviceSyncState: Codable, Equatable, Sendable {
             slideIndex: max(0, c.lenient(Int.self, .slideIndex, 0)),
             canvasTaskCount: c.lenientOptional(Int.self, .canvasTaskCount),
             surplusTaskCount: max(0, c.lenient(Int.self, .surplusTaskCount, 0)),
-            lastStatusAt: c.lenientOptional(Date.self, .lastStatusAt)
+            lastStatusAt: c.lenientOptional(Date.self, .lastStatusAt),
+            alertingFieldID: c.lenientOptional(String.self, .alertingFieldID),
+            nextResetAt: c.lenientOptional(Date.self, .nextResetAt),
+            quietHoursSignature: c.lenientOptional(String.self, .quietHoursSignature)
         )
     }
 }

--- a/Sources/VibeBarCore/Services/DotDeviceClient.swift
+++ b/Sources/VibeBarCore/Services/DotDeviceClient.swift
@@ -162,6 +162,39 @@ public struct DotDeviceClient: Sendable {
         return DotResponseParser.message(data)
     }
 
+    /// The device's own sleep window. `start` and `end` are local `HH:mm` in
+    /// the *device's* timezone, and an end earlier than the start means the
+    /// next day — which is what a night-time quiet window always is.
+    ///
+    /// The API rejects a window whose two ends are the same time, so that one
+    /// is refused here rather than sent and reported as a server error.
+    @discardableResult
+    public func updateSleep(
+        deviceID: String,
+        enabled: Bool,
+        start: String,
+        end: String,
+        apiKey: String
+    ) async throws -> String {
+        guard let start = EInkQuietHours.normalized(start),
+              let end = EInkQuietHours.normalized(end),
+              start != end
+        else { throw DotDeviceError.decoding("sleep window is not a pair of distinct HH:mm times") }
+        let body = try? JSONSerialization.data(
+            withJSONObject: ["sleep": ["enabled": enabled, "start": start, "end": end]],
+            options: [.sortedKeys]
+        )
+        guard let body else { throw DotDeviceError.decoding("sleep encoding failed") }
+        let data = try await send(
+            method: "POST",
+            path: "/api/authV2/open/device/\(encoded(deviceID))/settings",
+            apiKey: apiKey,
+            body: body,
+            notFound: .deviceNotFound(deviceID: deviceID)
+        )
+        return DotResponseParser.message(data)
+    }
+
     static func roundedInterval(_ milliseconds: Int) -> Int {
         let minute = 60_000
         let clamped = min(43_200_000, max(minute, milliseconds))
@@ -273,6 +306,18 @@ public protocol DotDeviceClienting: Sendable {
     @discardableResult
     func sendCanvas(deviceID: String, payload: DotCanvasPayload, apiKey: String) async throws -> String
     func fetchRenderImage(url: URL) async throws -> Data
+    @discardableResult
+    func updateSleep(deviceID: String, enabled: Bool, start: String, end: String, apiKey: String) async throws -> String
+}
+
+public extension DotDeviceClienting {
+    /// Defaulted so a fake in a test that never touches quiet hours does not
+    /// have to answer it. A no-op is the right stand-in: nothing else in the
+    /// engine reads the result.
+    @discardableResult
+    func updateSleep(deviceID: String, enabled: Bool, start: String, end: String, apiKey: String) async throws -> String {
+        ""
+    }
 }
 
 extension DotDeviceClient: DotDeviceClienting {}

--- a/Sources/VibeBarCore/Services/EInkAlertEvaluator.swift
+++ b/Sources/VibeBarCore/Services/EInkAlertEvaluator.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+/// Decides when a panel should drop what it is showing and shout.
+///
+/// Pure, and separate from the sync engine, because it is the part that is
+/// easy to get subtly wrong and impossible to eyeball on a panel across the
+/// room: an alert that re-fires on every refresh is a panel that flashes all
+/// day, and one that never clears is a panel stuck on yesterday's problem.
+public enum EInkAlertEvaluator {
+    /// The bucket this device should be alerting about, or `nil`.
+    ///
+    /// Only buckets the device actually *shows* can trip it. A panel that
+    /// flips to an alert about a bucket it never displays is a panel telling
+    /// the reader about something they did not ask it to watch.
+    public static func offendingFieldID(
+        device: EInkDeviceConfig,
+        snapshot: EInkDataSnapshot
+    ) -> String? {
+        guard device.alerts.enabled else { return nil }
+        let watched = watchedFieldIDs(device)
+        let candidates = snapshot.quota.filter { row in
+            guard watched.isEmpty || watched.contains(row.fieldID) else { return false }
+            return isAlerting(row, threshold: device.alerts.thresholdPercent)
+        }
+        // The worst one. Two buckets in trouble is still one panel, and the
+        // reader wants the one that runs out first.
+        return candidates.min { $0.remainingPercent < $1.remainingPercent }?.fieldID
+    }
+
+    /// A bucket alerts when it is at or below the threshold, or when the pace
+    /// model says it will not make it. The second is the one that catches a
+    /// bucket at 40 % on a Monday that is going to be gone by Wednesday.
+    public static func isAlerting(_ row: EInkQuotaRow, threshold: Int) -> Bool {
+        if row.remainingPercent <= threshold { return true }
+        return row.forecast?.verdict == .atRisk
+    }
+
+    /// Every quota bucket any of this device's slides draws.
+    public static func watchedFieldIDs(_ device: EInkDeviceConfig) -> Set<String> {
+        var result = Set<String>()
+        for slide in device.slides {
+            result.formUnion(slide.quotaFieldIDs)
+        }
+        return result
+    }
+
+    /// The slide the engine pushes while the alert stands.
+    ///
+    /// It is built rather than configured: an alert names the bucket that just
+    /// tripped, and there is nothing about that a user could have chosen in
+    /// advance.
+    public static func alertSlide(fieldID: String) -> EInkSlide {
+        EInkSlide(
+            id: alertSlideID,
+            title: "Alert",
+            kind: .preset(.alert),
+            quotaFieldIDs: [fieldID],
+            usagePeriods: [],
+            // No header choice, no footer, no reordering: the alert is the
+            // engine's own panel and stays the same wherever it appears.
+            options: EInkSlideOptions(header: EInkBarConfig(), footer: nil)
+        )
+    }
+
+    public static let alertSlideID = "vibe-bar-alert"
+
+    /// The soonest reset ahead of `now`, which is when the numbers behind the
+    /// panel will next jump on their own.
+    public static func nextResetAt(_ snapshot: EInkDataSnapshot, after now: Date) -> Date? {
+        snapshot.quota
+            .compactMap(\.resetAt)
+            .filter { $0 > now }
+            .min()
+    }
+
+    /// True when a reset the last pass was waiting for has happened.
+    public static func resetBoundaryPassed(recorded: Date?, now: Date) -> Bool {
+        guard let recorded else { return false }
+        return now >= recorded
+    }
+}
+
+/// Where "Tap link → Vibe Bar remote dashboard" points.
+///
+/// Only when Remote is actually configured on this Mac: a panel whose tap
+/// opens a dashboard nobody has joined is worse than one that does nothing.
+/// The link is the control center's own origin rather than a guessed
+/// per-workspace path — a tap that lands on a 404 is the one outcome a
+/// glanceable surface cannot explain.
+public enum EInkRemoteDashboard {
+    public static let controlCenter = URL(string: "https://vibebar.aqor.io")!
+
+    public static func current() -> URL? {
+        guard (try? RemoteCoreConfigStore.load()) != nil else { return nil }
+        return controlCenter
+    }
+}

--- a/Sources/VibeBarCore/Services/EInkAlertEvaluator.swift
+++ b/Sources/VibeBarCore/Services/EInkAlertEvaluator.swift
@@ -14,12 +14,13 @@ public enum EInkAlertEvaluator {
     /// the reader about something they did not ask it to watch.
     public static func offendingFieldID(
         device: EInkDeviceConfig,
-        snapshot: EInkDataSnapshot
+        snapshot: EInkDataSnapshot,
+        layouts: [String: EInkCanvasLayout] = [:]
     ) -> String? {
         guard device.alerts.enabled else { return nil }
-        let watched = watchedFieldIDs(device)
+        let watched = watchedFieldIDs(device, layouts: layouts)
         let candidates = snapshot.quota.filter { row in
-            guard watched.isEmpty || watched.contains(row.fieldID) else { return false }
+            guard watched.map({ $0.contains(row.fieldID) }) ?? true else { return false }
             return isAlerting(row, threshold: device.alerts.thresholdPercent)
         }
         // The worst one. Two buckets in trouble is still one panel, and the
@@ -35,11 +36,42 @@ public enum EInkAlertEvaluator {
         return row.forecast?.verdict == .atRisk
     }
 
-    /// Every quota bucket any of this device's slides draws.
-    public static func watchedFieldIDs(_ device: EInkDeviceConfig) -> Set<String> {
+    /// Every quota bucket any of this device's slides actually *draws*, or
+    /// `nil` when one of them draws whatever Vibe Bar's own order gives it.
+    ///
+    /// Three answers, not two, and the distinction is the whole point:
+    ///
+    /// - a set: alert only about these.
+    /// - `nil`: a quota slide with no selection of its own draws the default
+    ///   priority order, so every bucket in the snapshot is on screen.
+    /// - the empty set: this device draws no quota at all, so it never alerts.
+    ///   A slide keeps the buckets it had when it was switched to a usage
+    ///   layout — deliberately, so switching back does not lose them — and
+    ///   without this an unseen bucket could replace a Heatmap with news from
+    ///   nowhere.
+    public static func watchedFieldIDs(
+        _ device: EInkDeviceConfig,
+        layouts: [String: EInkCanvasLayout] = [:]
+    ) -> Set<String>? {
         var result = Set<String>()
         for slide in device.slides {
-            result.formUnion(slide.quotaFieldIDs)
+            if let preset = slide.kind.preset {
+                guard preset.isQuotaPreset else { continue }
+                if slide.quotaFieldIDs.isEmpty { return nil }
+                result.formUnion(slide.quotaFieldIDs)
+                continue
+            }
+            for layout in slide.allLayouts(in: layouts) {
+                for element in layout.elements {
+                    result.formUnion(element.quotaFieldIDs)
+                    // A quota block with no selection of its own draws the
+                    // slide's buckets, and a slide with none draws the default
+                    // order.
+                    guard element.kind.preset?.isQuotaPreset == true, element.fieldIDs.isEmpty else { continue }
+                    if slide.quotaFieldIDs.isEmpty { return nil }
+                    result.formUnion(slide.quotaFieldIDs)
+                }
+            }
         }
         return result
     }

--- a/Sources/VibeBarCore/Services/EInkBoxLayout.swift
+++ b/Sources/VibeBarCore/Services/EInkBoxLayout.swift
@@ -137,6 +137,22 @@ public struct EInkNode: Sendable, Equatable {
     /// 6 px margin, which is what makes a preset filling the panel produce
     /// byte-for-byte the boxes the preset slide produces.
     public var clampInset: Int?
+    /// What live value this node draws, when it draws one.
+    ///
+    /// Layout ignores it entirely — it exists so `EInkPresetExploder` can turn
+    /// a preset into a Studio layout whose elements still follow the data,
+    /// instead of a frozen picture of one refresh.
+    public var binding: EInkNodeBinding?
+    /// The module this node belongs to ("header", "slot:claude.weekly",
+    /// "footer"). The exploder turns each one into a group.
+    public var moduleID: String?
+    /// Overrides the "a fixed width clips" rule for one text node.
+    ///
+    /// A preset has three kinds of text box — measured, flexed, and fixed —
+    /// and only the last one clips. An exploded element has to state the
+    /// width it was given *and* whether that width clips, or a flexed header
+    /// would come back from the Studio truncated to its measured width.
+    public var clipsText: Bool?
     public var children: [EInkNode] = []
 
     public init(
@@ -149,6 +165,9 @@ public struct EInkNode: Sendable, Equatable {
         align: EInkCrossAlignment = .stretch,
         origin: EInkPoint? = nil,
         clampInset: Int? = nil,
+        binding: EInkNodeBinding? = nil,
+        moduleID: String? = nil,
+        clipsText: Bool? = nil,
         children: [EInkNode] = []
     ) {
         self.kind = kind
@@ -160,7 +179,24 @@ public struct EInkNode: Sendable, Equatable {
         self.align = align
         self.origin = origin
         self.clampInset = clampInset
+        self.binding = binding
+        self.moduleID = moduleID
+        self.clipsText = clipsText
         self.children = children
+    }
+
+    /// This node tagged with a binding, for the exploder.
+    public func bound(_ binding: EInkNodeBinding?) -> EInkNode {
+        var copy = self
+        copy.binding = binding
+        return copy
+    }
+
+    /// This node and everything under it tagged as one module.
+    public func module(_ id: String) -> EInkNode {
+        var copy = self
+        copy.moduleID = id
+        return copy
     }
 
     var isRow: Bool { if case .row = kind { return true }; return false }
@@ -201,6 +237,43 @@ public struct EInkDrawBox: Sendable, Equatable {
     }
 }
 
+/// One resolved box plus what produced it.
+///
+/// `source` is what lets the exploder put a bar back together: a
+/// `horizontalBar` node emits a track box and a fill box, and turning both
+/// into elements would freeze the fill at the percentage it had when the
+/// preset was exploded.
+public struct EInkPlacedBox: Sendable, Equatable {
+    public enum Source: Sendable, Equatable {
+        case plain
+        /// The outlined track of a bar, with everything needed to rebuild it.
+        case barTrack(percent: Int, vertical: Bool)
+        /// The filled part of the bar above; the exploder skips it.
+        case barFill
+        /// A ring's arc. Its label follows as `ringLabel` and is skipped too,
+        /// because one `ring` element draws both.
+        case ringArc(percent: Int, stroke: Int, labelFont: EInkFont)
+        case ringLabel
+    }
+
+    public var box: EInkDrawBox
+    public var binding: EInkNodeBinding?
+    public var moduleID: String?
+    public var source: Source
+
+    public init(
+        box: EInkDrawBox,
+        binding: EInkNodeBinding? = nil,
+        moduleID: String? = nil,
+        source: Source = .plain
+    ) {
+        self.box = box
+        self.binding = binding
+        self.moduleID = moduleID
+        self.source = source
+    }
+}
+
 /// Resolves an `EInkNode` tree to absolute integer boxes.
 public enum EInkBoxLayout {
     /// `bounds` is the safe area every emitted box is kept inside — the frame
@@ -217,7 +290,17 @@ public enum EInkBoxLayout {
         in frame: EInkRect,
         bounds: EInkRect? = nil
     ) -> [EInkDrawBox] {
-        var boxes: [EInkDrawBox] = []
+        resolveAnnotated(root, in: frame, bounds: bounds).map(\.box)
+    }
+
+    /// The same boxes, each carrying the binding and module of the node it
+    /// came from. `resolve` is this, projected.
+    public static func resolveAnnotated(
+        _ root: EInkNode,
+        in frame: EInkRect,
+        bounds: EInkRect? = nil
+    ) -> [EInkPlacedBox] {
+        var boxes: [EInkPlacedBox] = []
         let safe = bounds ?? frame.inset(by: EInkInsets(all: Int(EInkCanvasLayout.safeMargin)))
         // A root that states its own size keeps it (clamped to the panel), so
         // a preset authored at 152 × 296 lays out at 152 × 296 even when the
@@ -288,53 +371,64 @@ public enum EInkBoxLayout {
         _ node: EInkNode,
         in unclampedRect: EInkRect,
         bounds outerBounds: EInkRect,
-        into boxes: inout [EInkDrawBox]
+        into boxes: inout [EInkPlacedBox],
+        module inheritedModule: String? = nil
     ) {
         let rect = node.isContainer ? unclampedRect : clamp(unclampedRect, to: outerBounds)
         let bounds = node.clampInset.map { rect.inset(by: EInkInsets(all: $0)) } ?? outerBounds
+        let module = node.moduleID ?? inheritedModule
+        let binding = node.binding
+        func emit(_ box: EInkDrawBox, _ source: EInkPlacedBox.Source = .plain) {
+            boxes.append(EInkPlacedBox(box: box, binding: binding, moduleID: module, source: source))
+        }
         switch node.kind {
         case let .text(content, font, alignment):
             if !content.isEmpty {
                 let fixedWidth: Bool
                 if case .points = node.width { fixedWidth = true } else { fixedWidth = false }
-                boxes.append(
+                emit(
                     EInkDrawBox(
                         frame: rect,
                         content: .text(content, font: font, alignment: alignment),
-                        clipsContent: fixedWidth
+                        clipsContent: node.clipsText ?? fixedWidth
                     )
                 )
             }
         case let .image(source):
-            boxes.append(EInkDrawBox(frame: rect, content: .image(source)))
+            emit(EInkDrawBox(frame: rect, content: .image(source)))
         case .fill:
-            boxes.append(EInkDrawBox(frame: rect, content: .fill))
+            emit(EInkDrawBox(frame: rect, content: .fill))
         case let .horizontalBar(percent):
-            boxes.append(EInkDrawBox(frame: rect, content: .outline))
+            emit(EInkDrawBox(frame: rect, content: .outline), .barTrack(percent: percent, vertical: false))
             let inner = EInkRect(x: rect.x + 1, y: rect.y + 1, width: rect.width - 2, height: rect.height - 2)
             let filled = fillLength(inner.width, percent: percent)
             if filled > 0, inner.height > 0 {
-                boxes.append(
+                emit(
                     EInkDrawBox(
                         frame: EInkRect(x: inner.x, y: inner.y, width: filled, height: inner.height),
                         content: .fill
-                    )
+                    ),
+                    .barFill
                 )
             }
         case let .verticalBar(percent):
-            boxes.append(EInkDrawBox(frame: rect, content: .outline))
+            emit(EInkDrawBox(frame: rect, content: .outline), .barTrack(percent: percent, vertical: true))
             let inner = EInkRect(x: rect.x + 1, y: rect.y + 1, width: rect.width - 2, height: rect.height - 2)
             let filled = fillLength(inner.height, percent: percent)
             if filled > 0, inner.width > 0 {
-                boxes.append(
+                emit(
                     EInkDrawBox(
                         frame: EInkRect(x: inner.x, y: inner.maxY - filled, width: inner.width, height: filled),
                         content: .fill
-                    )
+                    ),
+                    .barFill
                 )
             }
         case let .ring(percent, stroke, labelFont):
-            boxes.append(EInkDrawBox(frame: rect, content: .ring(percent: percent, stroke: stroke)))
+            emit(
+                EInkDrawBox(frame: rect, content: .ring(percent: percent, stroke: stroke)),
+                .ringArc(percent: percent, stroke: stroke, labelFont: labelFont)
+            )
             let label = String(percent)
             let labelHeight = min(rect.height, labelFont.lineHeight)
             let labelRect = EInkRect(
@@ -343,13 +437,16 @@ public enum EInkBoxLayout {
                 width: rect.width,
                 height: labelHeight
             )
-            boxes.append(EInkDrawBox(frame: labelRect, content: .text(label, font: labelFont, alignment: .center)))
+            emit(
+                EInkDrawBox(frame: labelRect, content: .text(label, font: labelFont, alignment: .center)),
+                .ringLabel
+            )
         case .row:
-            layoutChildren(node, in: rect, horizontal: true, bounds: bounds, into: &boxes)
+            layoutChildren(node, in: rect, horizontal: true, bounds: bounds, into: &boxes, module: module)
         case .column:
-            layoutChildren(node, in: rect, horizontal: false, bounds: bounds, into: &boxes)
+            layoutChildren(node, in: rect, horizontal: false, bounds: bounds, into: &boxes, module: module)
         case .stack:
-            layoutStack(node, in: rect, bounds: bounds, into: &boxes)
+            layoutStack(node, in: rect, bounds: bounds, into: &boxes, module: module)
         }
     }
 
@@ -360,7 +457,8 @@ public enum EInkBoxLayout {
         _ node: EInkNode,
         in rect: EInkRect,
         bounds: EInkRect,
-        into boxes: inout [EInkDrawBox]
+        into boxes: inout [EInkPlacedBox],
+        module: String?
     ) {
         let content = rect.inset(by: node.padding)
         for child in node.children {
@@ -382,7 +480,8 @@ public enum EInkBoxLayout {
                 child,
                 in: EInkRect(x: content.x + offsetX, y: content.y + offsetY, width: width, height: height),
                 bounds: bounds,
-                into: &boxes
+                into: &boxes,
+                module: module
             )
         }
     }
@@ -400,7 +499,8 @@ public enum EInkBoxLayout {
         in rect: EInkRect,
         horizontal: Bool,
         bounds: EInkRect,
-        into boxes: inout [EInkDrawBox]
+        into boxes: inout [EInkPlacedBox],
+        module: String?
     ) {
         let content = rect.inset(by: node.padding)
         let children = node.children
@@ -480,7 +580,7 @@ public enum EInkBoxLayout {
             let childRect = horizontal
                 ? EInkRect(x: offset, y: crossOffset, width: mainSize, height: crossSize)
                 : EInkRect(x: crossOffset, y: offset, width: crossSize, height: mainSize)
-            place(child, in: childRect, bounds: bounds, into: &boxes)
+            place(child, in: childRect, bounds: bounds, into: &boxes, module: module)
             offset += mainSize + node.gap + extraGap
         }
     }

--- a/Sources/VibeBarCore/Services/EInkCustomLayoutRenderer.swift
+++ b/Sources/VibeBarCore/Services/EInkCustomLayoutRenderer.swift
@@ -364,6 +364,23 @@ public extension EInkCanvasElement {
 }
 
 public extension EInkSlide {
+    /// Every layout this slide has, across orientations.
+    ///
+    /// A custom slide carries up to four, keyed `"<layoutID>/<degrees>"`, and
+    /// a scan that asks only for `layouts[layoutID]` finds none of them. That
+    /// matters for more than tidiness: these scans decide whether the pass
+    /// walks the ledger and which quota buckets it gathers, so missing them
+    /// draws a bound element from data nobody fetched — `$0.00` on a panel, or
+    /// a blank where a percentage should be.
+    func allLayouts(in layouts: [String: EInkCanvasLayout]) -> [EInkCanvasLayout] {
+        guard let layoutID = kind.layoutID, !layoutID.isEmpty else { return [] }
+        let prefix = layoutID + "/"
+        return layouts
+            .filter { $0.key == layoutID || $0.key.hasPrefix(prefix) }
+            .sorted { $0.key < $1.key }
+            .map(\.value)
+    }
+
     /// Whether this slide needs the usage ledger, custom layouts included.
     ///
     /// A custom slide that prints today's spend and is drawn from an empty
@@ -372,8 +389,9 @@ public extension EInkSlide {
     /// layout, not only at the preset.
     func needsUsageData(layouts: [String: EInkCanvasLayout]) -> Bool {
         if let preset = kind.preset { return preset.needsUsageData }
-        guard let layoutID = kind.layoutID, let layout = layouts[layoutID] else { return false }
-        return layout.elements.contains { $0.readsUsage }
+        return allLayouts(in: layouts).contains { layout in
+            layout.elements.contains { $0.readsUsage }
+        }
     }
 }
 
@@ -395,9 +413,10 @@ public extension EInkSyncSettings {
         var result = referencedQuotaFieldIDs
         for device in devices {
             for slide in device.slides {
-                guard let layoutID = slide.kind.layoutID, let layout = layouts[layoutID] else { continue }
-                for element in layout.elements {
-                    result.formUnion(element.quotaFieldIDs)
+                for layout in slide.allLayouts(in: layouts) {
+                    for element in layout.elements {
+                        result.formUnion(element.quotaFieldIDs)
+                    }
                 }
             }
         }
@@ -412,20 +431,21 @@ public extension EInkSyncSettings {
         }
         for device in devices {
             for slide in device.slides {
-                guard let layoutID = slide.kind.layoutID, let layout = layouts[layoutID] else { continue }
-                for element in layout.elements {
-                    for fieldID in element.quotaFieldIDs where seen.insert(fieldID).inserted {
-                        result.append(fieldID)
-                    }
-                    // A quota block with no selection of its own draws the
-                    // slide's buckets, and those are not in
-                    // `selectedQuotaFieldIDs`, which only looks at preset
-                    // slides. Without this, a slide converted from a preset
-                    // keeps buckets the assembler is never asked for and the
-                    // block silently drops those rows.
-                    guard element.kind.preset?.isQuotaPreset == true, element.fieldIDs.isEmpty else { continue }
-                    for fieldID in slide.quotaFieldIDs where seen.insert(fieldID).inserted {
-                        result.append(fieldID)
+                for layout in slide.allLayouts(in: layouts) {
+                    for element in layout.elements {
+                        for fieldID in element.quotaFieldIDs where seen.insert(fieldID).inserted {
+                            result.append(fieldID)
+                        }
+                        // A quota block with no selection of its own draws the
+                        // slide's buckets, and those are not in
+                        // `selectedQuotaFieldIDs`, which only looks at preset
+                        // slides. Without this, a slide converted from a preset
+                        // keeps buckets the assembler is never asked for and the
+                        // block silently drops those rows.
+                        guard element.kind.preset?.isQuotaPreset == true, element.fieldIDs.isEmpty else { continue }
+                        for fieldID in slide.quotaFieldIDs where seen.insert(fieldID).inserted {
+                            result.append(fieldID)
+                        }
                     }
                 }
             }

--- a/Sources/VibeBarCore/Services/EInkCustomLayoutRenderer.swift
+++ b/Sources/VibeBarCore/Services/EInkCustomLayoutRenderer.swift
@@ -82,7 +82,8 @@ public enum EInkCustomLayoutRenderer {
                 .text(content, font: element.font, alignment: element.alignment),
                 width: element.autoWidth ? .auto : .points(width),
                 height: .points(height),
-                origin: origin
+                origin: origin,
+                clipsText: element.autoWidth ? false : element.clipsOverflow
             )
         case .ring:
             guard let percent = percent(for: element, snapshot: snapshot) else { return nil }
@@ -114,6 +115,21 @@ public enum EInkCustomLayoutRenderer {
             )
         case .statTile:
             return statTile(element, snapshot: snapshot, width: width, height: height, origin: origin)
+        case .image:
+            guard !element.imageSource.isEmpty else { return nil }
+            return EInkNode(
+                .image(element.imageSource),
+                width: .points(width),
+                height: .points(height),
+                origin: origin
+            )
+        case .fill:
+            return EInkNode(
+                .fill,
+                width: .points(width),
+                height: .points(height),
+                origin: origin
+            )
         case .divider:
             // One pixel of ink whatever the handle says: the box is the grab
             // target, the rule is the drawing, and it sits in the middle of
@@ -126,7 +142,8 @@ public enum EInkCustomLayoutRenderer {
                 origin: EInkPoint(x: x, y: y + (height - 1) / 2)
             )
         case .quotaLedger, .quotaRings, .quotaRail,
-             .usageTiles, .usageSplit, .usageTable, .usageDual, .usageTrend:
+             .usageTiles, .usageSplit, .usageTable, .usageDual, .usageTrend,
+             .briefing, .forecast, .resets, .heatmap, .topModels:
             return nil  // Handled above.
         }
     }
@@ -190,48 +207,17 @@ public enum EInkCustomLayoutRenderer {
         frame: EInkRect
     ) -> EInkNode {
         let capacity = preset.capacity(for: orientation)
-        let portrait = orientation.isPortrait
-        let fieldIDs = element.fieldIDs.isEmpty ? slide.quotaFieldIDs : element.fieldIDs
-        var node: EInkNode
-        switch preset {
-        case .quotaLedger:
-            let rows = snapshot.quotaRows(fieldIDs: fieldIDs, limit: capacity)
-            node = portrait
-                ? EInkPresets.ledgerPortrait(rows, snapshot, frame: frame)
-                : EInkPresets.ledgerLandscape(rows, snapshot, frame: frame)
-        case .quotaRings:
-            let rows = snapshot.quotaRows(fieldIDs: fieldIDs, limit: capacity)
-            node = portrait
-                ? EInkPresets.ringsPortrait(rows, snapshot, frame: frame)
-                : EInkPresets.ringsLandscape(rows, snapshot, frame: frame)
-        case .quotaRail:
-            let rows = snapshot.quotaRows(fieldIDs: fieldIDs, limit: capacity)
-            node = portrait
-                ? EInkPresets.railPortrait(rows, snapshot, frame: frame)
-                : EInkPresets.railLandscape(rows, snapshot, frame: frame)
-        case .usageTiles:
-            let periods = resolvedPeriods(element: element, slide: slide, capacity: capacity)
-            node = portrait
-                ? EInkPresets.tilesPortrait(periods, snapshot, frame: frame)
-                : EInkPresets.tilesLandscape(periods, snapshot, frame: frame)
-        case .usageSplit:
-            let periods = resolvedPeriods(element: element, slide: slide, capacity: capacity)
-            node = portrait
-                ? EInkPresets.splitPortrait(periods, snapshot, frame: frame)
-                : EInkPresets.splitLandscape(periods, snapshot, frame: frame)
-        case .usageTable:
-            node = portrait
-                ? EInkPresets.tablePortrait(capacity, snapshot, frame: frame)
-                : EInkPresets.tableLandscape(capacity, snapshot, frame: frame)
-        case .usageDual:
-            node = portrait
-                ? EInkPresets.dualPortrait(capacity, snapshot, frame: frame)
-                : EInkPresets.dualLandscape(capacity, snapshot, frame: frame)
-        case .usageTrend:
-            node = portrait
-                ? EInkPresets.trendPortrait(snapshot, frame: frame)
-                : EInkPresets.trendLandscape(snapshot, frame: frame)
-        }
+        // One path through `EInkRenderer.presetTree` for the preset slide, the
+        // whole-preset element and the exploder, so the three cannot drift.
+        var node = EInkRenderer.presetTree(
+            preset,
+            slide: slide,
+            orientation: orientation,
+            snapshot: snapshot,
+            frame: frame,
+            fieldIDs: element.fieldIDs.isEmpty ? slide.orderedQuotaFieldIDs : element.fieldIDs,
+            periods: resolvedPeriods(element: element, slide: slide, capacity: capacity)
+        )
         node.origin = EInkPoint(x: frame.x, y: frame.y)
         node.clampInset = presetMargin
         return node
@@ -280,8 +266,19 @@ public enum EInkCustomLayoutRenderer {
     }
 
     /// `nil` when nothing is bound — the caller then draws nothing at all.
+    ///
+    /// A bar with a bucket behind it reads that bucket, and reads nothing when
+    /// the bucket is missing: a stand-in percentage on a glanceable surface is
+    /// indistinguishable from a reading. An *unbound* bar falls back to its
+    /// author's fixed percentage, which is what the exploded usage layouts
+    /// carry — a "share of the biggest harness" bar is a real number, it is
+    /// just not a quota bucket.
     public static func percent(for element: EInkCanvasElement, snapshot: EInkDataSnapshot) -> Int? {
-        quotaRow(for: element, snapshot: snapshot)?.remainingPercent
+        if let fieldID = element.fieldID, !fieldID.isEmpty {
+            return snapshot.quota.first { $0.fieldID == fieldID }?.remainingPercent
+        }
+        guard let override = element.percentOverride else { return nil }
+        return max(0, min(100, Int(override.rounded())))
     }
 
     /// What one text-carrying element prints. Empty means "draw no box".
@@ -292,15 +289,19 @@ public enum EInkCustomLayoutRenderer {
             return "\(row.remainingPercent)%"
         case .label:
             guard let row = quotaRow(for: element, snapshot: snapshot) else { return "" }
-            // Written out, never abbreviated: "Claude · Weekly", the same two
-            // parts the ledger prints, because a panel read from a metre away
-            // has no tooltip to expand a short form.
-            return "\(row.providerDisplayName) · \(row.windowTitle)"
+            // Written out, never abbreviated: the SubProvider, the quota group
+            // and the window, because a panel read from a metre away has no
+            // tooltip to expand a short form.
+            return row.slotLabel
         case .countdown:
             guard let row = quotaRow(for: element, snapshot: snapshot) else { return "" }
             return row.countdown
         case .usageMetric:
             return usageFigure(element, snapshot: snapshot)
+        case .clock:
+            return snapshot.clockLabel
+        case .date:
+            return snapshot.dateLabel
         case .custom:
             return element.text
         }
@@ -319,7 +320,7 @@ public enum EInkCustomLayoutRenderer {
         switch element.textBinding {
         case .usageMetric:
             return element.usagePeriod.caption
-        case .custom:
+        case .custom, .clock, .date:
             return ""
         case .percent, .label, .countdown:
             return quotaRow(for: element, snapshot: snapshot)?.providerDisplayName ?? ""
@@ -333,7 +334,7 @@ public enum EInkCustomLayoutRenderer {
             return element.usageMetric == .cost
                 ? "\(EInkFormat.tokens(totals.tokens)) tokens"
                 : EInkFormat.money(totals.costUSD)
-        case .custom:
+        case .custom, .clock, .date:
             return ""
         case .percent, .label, .countdown:
             return quotaRow(for: element, snapshot: snapshot)?.countdown ?? ""

--- a/Sources/VibeBarCore/Services/EInkDataAssembler.swift
+++ b/Sources/VibeBarCore/Services/EInkDataAssembler.swift
@@ -9,41 +9,16 @@ public protocol EInkUsageQuerying: Sendable {
     func summary(_ filter: UsageQueryFilter) async throws -> UsageSummaryMetrics
     func harnessStats(_ filter: UsageQueryFilter) async throws -> [UsageHarnessStat]
     func trend(_ filter: UsageQueryFilter, bucket: UsageTrendBucket) async throws -> UsageTrendSeries
+    /// Today's per-model rows, for the Top Models layout.
+    func modelStats(_ filter: UsageQueryFilter) async throws -> [UsageModelStat]
 }
 
-/// Company-axis display names for the quota rows.
-///
-/// Deliberately short and fixed: the panel is 296 px wide and these strings
-/// are measured against the pixel font's metrics by the presets. The quota
-/// axis names companies, never harnesses — see the naming contract.
-/// The single table of provider labels the panel is allowed to print.
-///
-/// These are deliberately **not** `ToolType.hierarchy`'s display names, and
-/// the difference is a product decision rather than an oversight. A Quote/0
-/// panel is 296 px wide; a quota ledger spends about 126 px of that on the
-/// provider column, which is roughly eleven pixel-font characters. The
-/// hierarchy's names are written for a Mac window with room to disambiguate a
-/// vendor from its surfaces — "ChatGPT Agentic" does not fit in that column
-/// at any supported font size, and it is not the name the owner of the device
-/// uses for it either. The short form is what the panel shows and what the
-/// person reading it across a desk expects to see.
-///
-/// Keep this the only place the mapping lives. If a label ever has to change,
-/// it changes here and every preset follows.
-public enum EInkProviderLabel {
-    /// The panel label for a provider. Falls back to a capitalized raw value
-    /// so a tool added upstream still draws something readable.
-    public static func short(for tool: ToolType) -> String {
-        switch tool.rawValue {
-        case "codex": "Codex"
-        case "claude": "Claude"
-        case "grok": "Grok"
-        case "antigravity": "AntiGravity"
-        case "gemini": "Gemini"
-        case "cursor": "Cursor"
-        default: tool.rawValue.capitalized
-        }
-    }
+public extension EInkUsageQuerying {
+    /// Defaulted so a source that predates the Top Models layout — or a test
+    /// that only cares about totals — does not have to answer it. An empty
+    /// list draws no rows, which is the honest answer for a source that has
+    /// none.
+    func modelStats(_ filter: UsageQueryFilter) async throws -> [UsageModelStat] { [] }
 }
 
 /// Builds an `EInkDataSnapshot` from injected sources.
@@ -107,8 +82,19 @@ public struct EInkDataAssembler: Sendable {
 
     public var quotaLookup: @Sendable (ToolType) async -> AccountQuota?
     public var usage: any EInkUsageQuerying
-    /// Per-tool cost snapshots; only their all-time columns are read.
+    /// Per-tool cost snapshots; their all-time columns and their activity
+    /// heatmaps are read.
     public var allTimeCostSnapshots: @Sendable () async -> [CostSnapshot]
+    /// The pace verdict for one bucket, injected like the quota lookup so the
+    /// whole pipeline stays testable without `QuotaService`.
+    public var forecastLookup: @Sendable (ToolType, QuotaBucket) async -> QuotaPaceForecast?
+    /// Provider health, for the header's provider-status option.
+    public var serviceStatus: @Sendable () async -> [ServiceStatusSnapshot]
+    /// Resolves a slot's default name; discovered buckets need the registry.
+    public var registry: QuotaFieldRegistry
+    /// Per-slide label overrides, keyed by field id. The engine merges every
+    /// slide's `customLabels` before assembling.
+    public var customLabels: [String: String]
     public var quotaPriority: [QuotaSelector]
     public var calendar: Calendar
 
@@ -116,12 +102,20 @@ public struct EInkDataAssembler: Sendable {
         quotaLookup: @escaping @Sendable (ToolType) async -> AccountQuota?,
         usage: any EInkUsageQuerying,
         allTimeCostSnapshots: @escaping @Sendable () async -> [CostSnapshot],
+        forecastLookup: @escaping @Sendable (ToolType, QuotaBucket) async -> QuotaPaceForecast? = { _, _ in nil },
+        serviceStatus: @escaping @Sendable () async -> [ServiceStatusSnapshot] = { [] },
+        registry: QuotaFieldRegistry = .empty,
+        customLabels: [String: String] = [:],
         quotaPriority: [QuotaSelector] = EInkDataAssembler.defaultQuotaPriority,
         calendar: Calendar = .current
     ) {
         self.quotaLookup = quotaLookup
         self.usage = usage
         self.allTimeCostSnapshots = allTimeCostSnapshots
+        self.forecastLookup = forecastLookup
+        self.serviceStatus = serviceStatus
+        self.registry = registry
+        self.customLabels = customLabels
         self.quotaPriority = quotaPriority
         self.calendar = calendar
     }
@@ -136,7 +130,12 @@ public struct EInkDataAssembler: Sendable {
             generatedAtISO: Self.iso8601.string(from: now),
             quota: quota,
             usage: usageSet,
-            trend: trend
+            trend: trend,
+            clockLabel: EInkFormat.clockLabel(now, calendar: calendar),
+            dateLabel: EInkFormat.dateLabel(now, calendar: calendar),
+            heatmap: EInkHeatmap.summing(await allTimeCostSnapshots().map(\.heatmap)),
+            topModels: (try? await modelRows(now: now)) ?? [],
+            providerStatusLine: EInkProviderStatusLine.compose(await serviceStatus())
         )
     }
 
@@ -155,14 +154,20 @@ public struct EInkDataAssembler: Sendable {
         let quota = await quotaRows(now: now)
         var usage = EInkUsageSet()
         var trend: [EInkTrendPoint] = []
+        var models: [EInkModelRow] = []
+        var heatmap = EInkHeatmap.empty
         var usageUnavailable = false
         if includeUsage {
             do {
                 usage = try await usageSet(now: now)
                 trend = try await trendPoints(now: now)
+                models = try await modelRows(now: now)
+                heatmap = EInkHeatmap.summing(await allTimeCostSnapshots().map(\.heatmap))
             } catch {
                 usage = EInkUsageSet()
                 trend = []
+                models = []
+                heatmap = .empty
                 usageUnavailable = true
                 SafeLog.warn("eink usage assembly failed: \(SafeLog.sanitize(String(describing: error)))")
             }
@@ -174,7 +179,12 @@ public struct EInkDataAssembler: Sendable {
                 generatedAtISO: Self.iso8601.string(from: now),
                 quota: quota,
                 usage: usage,
-                trend: trend
+                trend: trend,
+                clockLabel: EInkFormat.clockLabel(now, calendar: calendar),
+                dateLabel: EInkFormat.dateLabel(now, calendar: calendar),
+                heatmap: heatmap,
+                topModels: models,
+                providerStatusLine: EInkProviderStatusLine.compose(await serviceStatus())
             ),
             usageUnavailable: usageUnavailable
         )
@@ -195,15 +205,23 @@ public struct EInkDataAssembler: Sendable {
             }
             guard let account, let bucket = account.bucket(id: selector.bucketID) else { continue }
             let remaining = Int((100 - bucket.usedPercent).rounded())
+            let label = customLabels[selector.fieldID]?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let parts = (label?.isEmpty == false)
+                ? label!.components(separatedBy: EInkSlotLabel.separator)
+                : EInkSlotLabel.parts(for: selector.fieldID, registry: registry, bucket: bucket)
             rows.append(
                 EInkQuotaRow(
                     fieldID: selector.fieldID,
-                    providerDisplayName: EInkProviderLabel.short(for: selector.tool),
-                    windowTitle: Self.windowTitle(for: bucket),
+                    // Tier 1 on its own line, tiers 2 and 3 on the next: the
+                    // split every two-line slot needs, and exactly what
+                    // "provider · window" already meant to the one-line ones.
+                    providerDisplayName: parts.first ?? selector.tool.quotaSubProviderName(bucketID: selector.bucketID),
+                    windowTitle: parts.dropFirst().joined(separator: EInkSlotLabel.separator),
                     remainingPercent: remaining,
                     resetAt: bucket.resetAt,
                     countdown: EInkFormat.countdown(bucket.resetAt, now: now),
-                    plan: account.plan ?? ""
+                    plan: account.plan ?? "",
+                    forecast: await forecastLookup(selector.tool, bucket).map(EInkQuotaForecast.init)
                 )
             )
         }
@@ -263,6 +281,24 @@ public struct EInkDataAssembler: Sendable {
             requests: summary.requests,
             rows: harnessRows
         )
+    }
+
+    // MARK: - Models
+
+    func modelRows(now: Date) async throws -> [EInkModelRow] {
+        let midnight = calendar.startOfDay(for: now)
+        let filter = UsageQueryFilter(range: DateInterval(start: midnight, end: max(midnight, now)))
+        return try await usage.modelStats(filter)
+            .sorted { $0.costMicros > $1.costMicros }
+            .prefix(8)
+            .map {
+                EInkModelRow(
+                    model: $0.model,
+                    costUSD: Self.usd($0.costMicros),
+                    tokens: $0.totalTokens,
+                    requests: $0.requests
+                )
+            }
     }
 
     // MARK: - Trend
@@ -325,9 +361,15 @@ public struct EInkSnapshotRequest: Sendable, Equatable {
     public var quotaFieldIDs: [String]
     /// False when no slide on this pass draws usage.
     public var includesUsage: Bool
+    /// Every slide's per-slot label overrides, merged. First writer wins, so
+    /// two slides naming the same bucket differently do not fight over the
+    /// snapshot — the panel that asked for a different name gets it through
+    /// its own slide, not through the shared assembly.
+    public var customLabels: [String: String]
 
-    public init(quotaFieldIDs: [String], includesUsage: Bool) {
+    public init(quotaFieldIDs: [String], includesUsage: Bool, customLabels: [String: String] = [:]) {
         self.quotaFieldIDs = quotaFieldIDs
         self.includesUsage = includesUsage
+        self.customLabels = customLabels
     }
 }

--- a/Sources/VibeBarCore/Services/EInkDataAssembler.swift
+++ b/Sources/VibeBarCore/Services/EInkDataAssembler.swift
@@ -91,10 +91,12 @@ public struct EInkDataAssembler: Sendable {
     /// Provider health, for the header's provider-status option.
     public var serviceStatus: @Sendable () async -> [ServiceStatusSnapshot]
     /// Resolves a slot's default name; discovered buckets need the registry.
+    ///
+    /// The snapshot carries the *default* name and nothing else. A slide's own
+    /// override is applied while that slide draws (`EInkQuotaRow.relabeled`),
+    /// because the snapshot is shared: merging overrides here meant two slides
+    /// naming the same bucket differently both got the first one's name.
     public var registry: QuotaFieldRegistry
-    /// Per-slide label overrides, keyed by field id. The engine merges every
-    /// slide's `customLabels` before assembling.
-    public var customLabels: [String: String]
     public var quotaPriority: [QuotaSelector]
     public var calendar: Calendar
 
@@ -105,7 +107,6 @@ public struct EInkDataAssembler: Sendable {
         forecastLookup: @escaping @Sendable (ToolType, QuotaBucket) async -> QuotaPaceForecast? = { _, _ in nil },
         serviceStatus: @escaping @Sendable () async -> [ServiceStatusSnapshot] = { [] },
         registry: QuotaFieldRegistry = .empty,
-        customLabels: [String: String] = [:],
         quotaPriority: [QuotaSelector] = EInkDataAssembler.defaultQuotaPriority,
         calendar: Calendar = .current
     ) {
@@ -115,7 +116,6 @@ public struct EInkDataAssembler: Sendable {
         self.forecastLookup = forecastLookup
         self.serviceStatus = serviceStatus
         self.registry = registry
-        self.customLabels = customLabels
         self.quotaPriority = quotaPriority
         self.calendar = calendar
     }
@@ -205,10 +205,7 @@ public struct EInkDataAssembler: Sendable {
             }
             guard let account, let bucket = account.bucket(id: selector.bucketID) else { continue }
             let remaining = Int((100 - bucket.usedPercent).rounded())
-            let label = customLabels[selector.fieldID]?.trimmingCharacters(in: .whitespacesAndNewlines)
-            let parts = (label?.isEmpty == false)
-                ? label!.components(separatedBy: EInkSlotLabel.separator)
-                : EInkSlotLabel.parts(for: selector.fieldID, registry: registry, bucket: bucket)
+            let parts = EInkSlotLabel.parts(for: selector.fieldID, registry: registry, bucket: bucket)
             rows.append(
                 EInkQuotaRow(
                     fieldID: selector.fieldID,
@@ -361,15 +358,8 @@ public struct EInkSnapshotRequest: Sendable, Equatable {
     public var quotaFieldIDs: [String]
     /// False when no slide on this pass draws usage.
     public var includesUsage: Bool
-    /// Every slide's per-slot label overrides, merged. First writer wins, so
-    /// two slides naming the same bucket differently do not fight over the
-    /// snapshot — the panel that asked for a different name gets it through
-    /// its own slide, not through the shared assembly.
-    public var customLabels: [String: String]
-
-    public init(quotaFieldIDs: [String], includesUsage: Bool, customLabels: [String: String] = [:]) {
+    public init(quotaFieldIDs: [String], includesUsage: Bool) {
         self.quotaFieldIDs = quotaFieldIDs
         self.includesUsage = includesUsage
-        self.customLabels = customLabels
     }
 }

--- a/Sources/VibeBarCore/Services/EInkLayoutDiagnostics.swift
+++ b/Sources/VibeBarCore/Services/EInkLayoutDiagnostics.swift
@@ -151,11 +151,13 @@ public enum EInkLayoutDiagnostics {
         switch element.kind {
         case .text, .statTile:
             switch element.textBinding {
-            case .usageMetric, .custom: return false
+            case .usageMetric, .custom, .clock, .date: return false
             case .percent, .label, .countdown: break
             }
         case .ring, .horizontalBar, .verticalBar:
-            break
+            // A bar carrying its own percentage is bound to a figure, just not
+            // to a bucket: the exploded usage layouts are full of them.
+            if element.percentOverride != nil { return false }
         default:
             return false
         }

--- a/Sources/VibeBarCore/Services/EInkNewPresets.swift
+++ b/Sources/VibeBarCore/Services/EInkNewPresets.swift
@@ -431,7 +431,11 @@ extension EInkPresets {
     ) -> EInkNode {
         let gap = 3
         let rows = Array(snapshot.topModels.prefix(limit))
-        let total = max(snapshot.topModels.reduce(0) { $0 + $1.costUSD }, 0.000_001)
+        // The whole day, not the models this layout happens to list: the
+        // assembler keeps the top eight, so a busy day's tail would otherwise
+        // be missing from a denominator the footer calls "today's cost".
+        let listed = snapshot.topModels.reduce(0) { $0 + $1.costUSD }
+        let total = max(max(snapshot.usage.today.costUSD, listed), 0.000_001)
         let shareLine: EInkNode? = rows.first.map { top in
             let share = Int((100 * top.costUSD / total).rounded())
             return topRuled(

--- a/Sources/VibeBarCore/Services/EInkNewPresets.swift
+++ b/Sources/VibeBarCore/Services/EInkNewPresets.swift
@@ -1,0 +1,610 @@
+import Foundation
+
+// The round 2 layouts: Briefing, Forecast, Resets, Heatmap, Top Models, and
+// the engine's own Alert.
+//
+// They exist because the owner's review of round 1 said the panel was showing
+// him numbers he already knew. Each one answers a question instead: what is
+// the state of everything (Briefing), am I on pace (Forecast), when does
+// anything come back (Resets), when do I actually work (Heatmap), what is the
+// money going on (Top Models).
+extension EInkPresets {
+    // MARK: - Shared pieces
+
+    /// How much of a slot's figures the row can afford beside its name.
+    ///
+    /// Three widths rather than two: a panel showing six buckets from six
+    /// different SubProviders has names 270 px long, and spending the whole
+    /// row on "on pace 59%" leaves the reader looking at a column of truncated
+    /// names — which is the exact complaint round 2 exists to fix.
+    enum BriefingDetail: CaseIterable {
+        /// "67% left · resets in 5d 03h · on pace 59%"
+        case full
+        /// "67% · 5d 03h · pace 59%"
+        case terse
+        /// "67% · 5d 03h"
+        case figuresOnly
+    }
+
+    static func briefingStats(_ quota: EInkQuotaRow, detail: BriefingDetail) -> String {
+        var parts: [String] = []
+        parts.append(detail == .full ? "\(quota.remainingPercent)% left" : "\(quota.remainingPercent)%")
+        if !quota.countdown.isEmpty {
+            parts.append(detail == .full ? "resets in \(quota.countdown)" : quota.countdown)
+        }
+        if detail != .figuresOnly, let forecast = quota.forecast {
+            let pace = Int(forecast.projectedUsedPercent.rounded())
+            parts.append(detail == .full ? "on pace \(pace)%" : "pace \(pace)%")
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    /// "Today $427 · 538M tokens · 1,848 requests".
+    static func briefingTodayLine(_ snapshot: EInkDataSnapshot) -> String {
+        let today = snapshot.usage.today
+        return "Today \(EInkFormat.money(today.costUSD)) · \(EInkFormat.tokens(today.tokens)) tokens"
+            + " · \(EInkFormat.int(today.requests)) requests"
+    }
+
+    /// "7 days $6,169 · busiest 09-09 $1,486".
+    static func briefingWeekLine(_ snapshot: EInkDataSnapshot) -> String {
+        let week = snapshot.usage.week
+        var line = "7 days \(EInkFormat.money(week.costUSD))"
+        if let busiest = snapshot.trend.max(by: { $0.costUSD < $1.costUSD }), busiest.costUSD > 0 {
+            line += " · busiest \(busiest.dayLabel) \(EInkFormat.money(busiest.costUSD))"
+        }
+        return line
+    }
+
+    // MARK: - Briefing
+
+    static func briefing(
+        _ rows: [EInkQuotaRow],
+        _ snapshot: EInkDataSnapshot,
+        frame: EInkRect,
+        portrait: Bool,
+        options: EInkSlideOptions = .default
+    ) -> EInkNode {
+        let gap = portrait ? 3 : 2
+        let chrome = chrome(
+            options,
+            defaults: ChromeDefaults(
+                right: portrait ? snapshot.generatedAtLabel : "BRIEFING · \(snapshot.generatedAtLabel)"
+            ),
+            snapshot: snapshot,
+            gap: gap
+        )
+        let content = frame.width - 2 * margin
+        var children: [EInkNode] = []
+
+        if portrait {
+            // 140 px cannot hold a name and its figures on one line, so each
+            // slot gets two: the name, then what it is doing.
+            for quota in rows {
+                children.append(
+                    column(
+                        [
+                            text(quota.slotLabel, pixelBold, width: .flex(1), height: .points(12))
+                                .bound(.quota(quota.fieldID, .label)),
+                            text(briefingStats(quota, detail: .terse), pixel, width: .flex(1), height: .points(12))
+                        ],
+                        height: .points(25),
+                        gap: 1
+                    ).module(slotModule(quota.fieldID))
+                )
+            }
+        } else {
+            // One line per slot, with the figures in a column of their own.
+            //
+            // Both halves are *fixed* width on purpose. An auto-width name
+            // beside a right-aligned figure is exactly how the first hardware
+            // push came back with "GPT-5.3 Codex Spark" printed through its
+            // own percentage: the name outran the row and the flexed figure
+            // had nowhere left to start. A three-tier name is long, so the
+            // column that clips is the name — a truncated name still
+            // identifies its row, a truncated figure lies about the number.
+            // Plus slack, and the figures never clip. `EInkTextMetrics` is an
+            // estimate of the device's font, and the first hardware push came
+            // back with "67%" printed as "7%" — a clipped number is a wrong
+            // number, so the column that absorbs a mis-measurement is the
+            // name's, and a figure that outruns its box spills instead.
+            func statsWidth(_ detail: BriefingDetail) -> Int {
+                min(
+                    content - 60,
+                    (rows.map { EInkTextMetrics.width(briefingStats($0, detail: detail), font: pixel) }.max() ?? 0) + 10
+                )
+            }
+            let labelWidths = rows.map { EInkTextMetrics.width($0.slotLabel, font: pixelBold) }
+            // The widest form at least half the names still fit beside. All or
+            // nothing would drop to the terse form over one long name; none at
+            // all would truncate every name to keep a figure nobody can read
+            // the row for.
+            let needed = labelWidths.sorted()[max(0, (labelWidths.count - 1) / 2)]
+            let detail = BriefingDetail.allCases.first { content - statsWidth($0) - 6 >= needed }
+                ?? .figuresOnly
+            let statsColumn = statsWidth(detail)
+            let labelWidth = max(0, content - statsColumn - 6)
+            for quota in rows {
+                children.append(
+                    row(
+                        [
+                            text(quota.slotLabel, pixelBold, width: .points(labelWidth))
+                                .bound(.quota(quota.fieldID, .label)),
+                            text(
+                                briefingStats(quota, detail: detail),
+                                pixel,
+                                width: .points(statsColumn),
+                                align: .trailing,
+                                clips: false
+                            )
+                        ],
+                        height: .points(13),
+                        gap: 6,
+                        align: .center
+                    ).module(slotModule(quota.fieldID))
+                )
+            }
+        }
+
+        children.append(verticalSpacer())
+        children.append(rule())
+        children.append(
+            text(briefingTodayLine(snapshot), pixel, width: .flex(1), height: .points(13))
+                .module(footerModule)
+        )
+        children.append(
+            text(briefingWeekLine(snapshot), pixel, width: .flex(1), height: .points(13))
+                .module(footerModule)
+        )
+        return screen(chrome.compose(children), frame: frame, gap: gap)
+    }
+
+    // MARK: - Forecast
+
+    /// One bar with the projected-use tick standing in it.
+    ///
+    /// The bar shows quota *left*, so the tick sits where the bar is expected
+    /// to end up at reset: `100 − projected`. A hollow marker rather than a
+    /// second fill, because the two numbers are different kinds of thing —
+    /// one is measured, one is a guess.
+    static func forecastBar(_ quota: EInkQuotaRow, width: Int, height: Int) -> EInkNode {
+        var children: [EInkNode] = [
+            EInkNode(
+                .horizontalBar(percent: quota.remainingPercent),
+                width: .points(width),
+                height: .points(height),
+                origin: EInkPoint(x: 0, y: 0),
+                binding: .quota(quota.fieldID, .percent)
+            )
+        ]
+        if let forecast = quota.forecast {
+            let left = max(0, 100 - forecast.projectedTickPercent)
+            let x = min(width - 2, max(1, EInkBoxLayout.fillLength(width - 2, percent: left)))
+            children.append(
+                EInkNode(.fill, width: .points(1), height: .points(height), origin: EInkPoint(x: x, y: 0))
+            )
+        }
+        return EInkNode(.stack, width: .points(width), height: .points(height), children: children)
+    }
+
+    static func forecastRunOutText(_ quota: EInkQuotaRow, calendar: Calendar) -> String {
+        if let runOutAt = quota.forecast?.runOutAt {
+            return "runs out \(EInkFormat.clockLabel(runOutAt, calendar: calendar))"
+        }
+        return quota.countdown.isEmpty ? "" : "resets in \(quota.countdown)"
+    }
+
+    static func forecast(
+        _ rows: [EInkQuotaRow],
+        _ snapshot: EInkDataSnapshot,
+        frame: EInkRect,
+        portrait: Bool,
+        calendar: Calendar,
+        options: EInkSlideOptions = .default
+    ) -> EInkNode {
+        let gap = 4
+        let chrome = chrome(
+            options,
+            defaults: ChromeDefaults(
+                right: portrait ? snapshot.generatedAtLabel : "FORECAST · \(snapshot.generatedAtLabel)"
+            ),
+            snapshot: snapshot,
+            gap: gap
+        )
+        let barWidth = portrait ? 70 : 150
+        let rowHeight = chrome.compact ? 28 : 25
+        let list = rows.map { quota in
+            column(
+                [
+                    row(
+                        [
+                            text(quota.slotLabel, pixelBold).bound(.quota(quota.fieldID, .label)),
+                            text(quota.forecast?.word ?? "LEARNING", pixel, width: .flex(1), align: .trailing)
+                        ],
+                        height: .points(12),
+                        align: .center
+                    ),
+                    row(
+                        [
+                            forecastBar(quota, width: barWidth, height: 10),
+                            text(
+                                forecastRunOutText(quota, calendar: calendar),
+                                pixel,
+                                width: .flex(1),
+                                align: .trailing
+                            )
+                        ],
+                        height: .points(11),
+                        gap: 4,
+                        align: .center
+                    )
+                ],
+                height: .points(rowHeight),
+                gap: 1
+            ).module(slotModule(quota.fieldID))
+        }
+        return screen(chrome.compose(list + [verticalSpacer()]), frame: frame, gap: gap)
+    }
+
+    // MARK: - Resets
+
+    /// A seven-day strip with a tick per bucket.
+    ///
+    /// The strip is one rule and one short mark per reset, drawn at its share
+    /// of the week: three ticks bunched at the left edge say "everything comes
+    /// back today" at a glance, which no list of countdowns does.
+    static func resetTimeline(_ rows: [EInkQuotaRow], now: Date, width: Int) -> EInkNode {
+        let window: TimeInterval = 7 * 86_400
+        var children: [EInkNode] = [
+            EInkNode(.fill, width: .points(width), height: .points(1), origin: EInkPoint(x: 0, y: 6))
+        ]
+        for quota in rows {
+            guard let resetAt = quota.resetAt else { continue }
+            let fraction = max(0, min(1, resetAt.timeIntervalSince(now) / window))
+            let x = min(width - 2, Int((Double(width - 2) * fraction).rounded()))
+            children.append(
+                EInkNode(.fill, width: .points(2), height: .points(7), origin: EInkPoint(x: x, y: 0))
+            )
+        }
+        return EInkNode(.stack, width: .points(width), height: .points(7), children: children)
+    }
+
+    static func resets(
+        _ rows: [EInkQuotaRow],
+        _ snapshot: EInkDataSnapshot,
+        frame: EInkRect,
+        portrait: Bool,
+        options: EInkSlideOptions = .default
+    ) -> EInkNode {
+        let gap = portrait ? 4 : 3
+        let chrome = chrome(
+            options,
+            defaults: ChromeDefaults(
+                right: portrait ? snapshot.generatedAtLabel : "RESETS · \(snapshot.generatedAtLabel)"
+            ),
+            snapshot: snapshot,
+            gap: gap
+        )
+        // Soonest first: the whole point of the layout is what comes back
+        // next. A bucket with no reset time at all sorts last rather than
+        // being dropped, because it is still quota the reader has.
+        let sorted = rows.sorted {
+            ($0.resetAt ?? .distantFuture) < ($1.resetAt ?? .distantFuture)
+        }
+        let content = frame.width - 2 * margin
+        var children: [EInkNode] = [
+            resetTimeline(sorted, now: snapshot.generatedAt, width: content),
+            text("NEXT SEVEN DAYS", pixel, width: .flex(1), height: .points(12))
+        ]
+        let countdownWidth = portrait ? 50 : 62
+        for quota in sorted {
+            children.append(
+                row(
+                    [
+                        text(
+                            quota.countdown.isEmpty ? "unknown" : "in \(quota.countdown)",
+                            pixelBold,
+                            width: .points(countdownWidth)
+                        ).bound(.quota(quota.fieldID, .countdown)),
+                        text(quota.slotLabel, pixel, width: .flex(1))
+                            .bound(.quota(quota.fieldID, .label))
+                    ],
+                    height: .points(portrait ? 14 : 15),
+                    gap: 4,
+                    align: .center
+                ).module(slotModule(quota.fieldID))
+            )
+        }
+        children.append(verticalSpacer())
+        return screen(chrome.compose(children), frame: frame, gap: gap)
+    }
+
+    // MARK: - Heatmap
+
+    static func heatmap(
+        _ snapshot: EInkDataSnapshot,
+        frame: EInkRect,
+        portrait: Bool,
+        options: EInkSlideOptions = .default
+    ) -> EInkNode {
+        let gap = 3
+        let busiest = snapshot.heatmap.busiestLabel
+        let chrome = chrome(
+            options,
+            defaults: ChromeDefaults(
+                right: busiest.isEmpty ? snapshot.generatedAtLabel : busiest
+            ),
+            snapshot: snapshot,
+            gap: gap
+        )
+        let content = frame.width - 2 * margin
+        let labelWidth = 26
+        let cellSize = portrait ? max(3, (content - labelWidth) / 7) : max(3, (content - labelWidth) / 24)
+        let size = EInkHeatmapRasterizer.size(cellSize: cellSize, weekdaysAcross: portrait)
+        let uri = try? EInkHeatmapRasterizer.dataURI(
+            heatmap: snapshot.heatmap,
+            cellSize: cellSize,
+            weekdaysAcross: portrait
+        )
+
+        var children: [EInkNode] = []
+        if let uri {
+            let axis: EInkNode
+            if portrait {
+                // Days across the top, hours down the side.
+                axis = row(
+                    [
+                        column(
+                            (0..<24).map { hour in
+                                text(
+                                    hour % 3 == 0 ? String(format: "%02d", hour) : "",
+                                    pixel,
+                                    width: .points(labelWidth),
+                                    height: .points(cellSize),
+                                    align: .trailing
+                                )
+                            },
+                            width: .points(labelWidth),
+                            height: .points(size.height)
+                        ),
+                        EInkNode(.image(uri), width: .points(size.width), height: .points(size.height))
+                    ],
+                    height: .points(size.height),
+                    gap: 2
+                )
+                children.append(
+                    row(
+                        [text("", pixel, width: .points(labelWidth + 2))]
+                            + EInkHeatmap.weekdayNames.map {
+                                text($0, pixel, width: .points(cellSize), height: .points(12), align: .center)
+                            },
+                        height: .points(12)
+                    )
+                )
+                children.append(axis)
+            } else {
+                axis = row(
+                    [
+                        column(
+                            EInkHeatmap.weekdayNames.map {
+                                text($0, pixel, width: .points(labelWidth), height: .points(cellSize), align: .trailing)
+                            },
+                            width: .points(labelWidth),
+                            height: .points(size.height)
+                        ),
+                        EInkNode(.image(uri), width: .points(size.width), height: .points(size.height))
+                    ],
+                    height: .points(size.height),
+                    gap: 2
+                )
+                children.append(axis)
+                children.append(
+                    row(
+                        [text("", pixel, width: .points(labelWidth + 2))]
+                            + (0..<24).map { hour in
+                                text(
+                                    hour % 6 == 0 ? String(format: "%02d", hour) : "",
+                                    pixel,
+                                    width: .points(cellSize),
+                                    height: .points(12)
+                                )
+                            },
+                        height: .points(12)
+                    )
+                )
+            }
+        } else {
+            children.append(text("ACTIVITY UNAVAILABLE", pixel, width: .flex(1), height: .points(12), align: .center))
+        }
+        children.append(verticalSpacer())
+        return screen(chrome.compose(children), frame: frame, gap: gap)
+    }
+
+    // MARK: - Top models
+
+    static func topModels(
+        _ snapshot: EInkDataSnapshot,
+        frame: EInkRect,
+        portrait: Bool,
+        limit: Int,
+        options: EInkSlideOptions = .default
+    ) -> EInkNode {
+        let gap = 3
+        let rows = Array(snapshot.topModels.prefix(limit))
+        let total = max(snapshot.topModels.reduce(0) { $0 + $1.costUSD }, 0.000_001)
+        let shareLine: EInkNode? = rows.first.map { top in
+            let share = Int((100 * top.costUSD / total).rounded())
+            return topRuled(
+                row(
+                    [
+                        text("TOP MODEL", pixelBold),
+                        text("\(share)% of today's cost", pixel, width: .flex(1), align: .trailing)
+                    ],
+                    height: .points(14),
+                    align: .center
+                )
+            )
+        }
+        let chrome = chrome(
+            options,
+            defaults: ChromeDefaults(
+                right: portrait ? snapshot.generatedAtLabel : "TOP MODELS · TODAY · \(snapshot.generatedAtLabel)",
+                footer: shareLine
+            ),
+            snapshot: snapshot,
+            gap: gap
+        )
+        let costWidth = portrait ? 40 : 52
+        let tokensWidth = portrait ? 34 : 46
+        var children: [EInkNode] = []
+        if portrait {
+            children.append(
+                row(
+                    [
+                        text("MODEL", pixelBold),
+                        text("COST", pixel, width: .flex(1), align: .trailing)
+                    ],
+                    height: .points(12)
+                )
+            )
+        } else {
+            children.append(
+                row(
+                    [
+                        text("MODEL", pixelBold),
+                        text("COST", pixel, width: .points(costWidth), align: .trailing),
+                        text("TOKENS", pixel, width: .points(tokensWidth), align: .trailing),
+                        text("REQUESTS", pixel, width: .points(60), align: .trailing)
+                    ],
+                    height: .points(12),
+                    gap: 4
+                )
+            )
+        }
+        for model in rows {
+            if portrait {
+                children.append(
+                    column(
+                        [
+                            text(model.model, pixel, width: .flex(1), height: .points(12)),
+                            row(
+                                [
+                                    text(EInkFormat.tokens(model.tokens) + " tokens", pixel),
+                                    text(EInkFormat.money(model.costUSD), pixelBold, width: .flex(1), align: .trailing)
+                                ],
+                                height: .points(12)
+                            )
+                        ],
+                        height: .points(25),
+                        gap: 1
+                    )
+                )
+            } else {
+                children.append(
+                    row(
+                        [
+                            text(model.model, pixel, width: .flex(1)),
+                            text(EInkFormat.money(model.costUSD), sans(13), width: .points(costWidth), align: .trailing),
+                            text(EInkFormat.tokens(model.tokens), pixel, width: .points(tokensWidth), align: .trailing),
+                            text(EInkFormat.int(model.requests), pixel, width: .points(60), align: .trailing)
+                        ],
+                        height: .points(15),
+                        gap: 4,
+                        align: .center
+                    )
+                )
+            }
+        }
+        if rows.isEmpty {
+            children.append(text("NO MODEL ACTIVITY TODAY", pixel, width: .flex(1), height: .points(12), align: .center))
+        }
+        children.append(verticalSpacer())
+        return screen(chrome.compose(children), frame: frame, gap: gap)
+    }
+
+    // MARK: - Alert
+
+    /// The panel the engine pushes when a bucket crosses its threshold.
+    ///
+    /// Deliberately loud and deliberately not configurable: it names the one
+    /// bucket that tripped, says when it runs out, and draws the bar. The
+    /// black border comes from the payload (`border: 1`), not from here.
+    static func alert(
+        _ quota: EInkQuotaRow?,
+        _ snapshot: EInkDataSnapshot,
+        frame: EInkRect,
+        portrait: Bool,
+        calendar: Calendar
+    ) -> EInkNode {
+        let content = frame.width - 2 * margin
+        guard let quota else {
+            return screen(
+                [
+                    header("VIBE BAR", "ALERT"),
+                    verticalSpacer(),
+                    text("QUOTA ALERT", sans(portrait ? 18 : 24), width: .flex(1), height: .points(portrait ? 18 : 24), align: .center),
+                    verticalSpacer()
+                ],
+                frame: frame,
+                gap: 6
+            )
+        }
+        // Two centred lines, both clipped to the panel.
+        //
+        // The first hardware push printed a three-tier name straight through
+        // both edges of the black border: a centred `.auto` text wider than
+        // its row spills symmetrically, and on an alert — the one panel that
+        // exists to be read at a glance — that is unreadable. The name splits
+        // where it reads, SubProvider then the rest.
+        let headline = EInkSlotLabel.twoLines(quota.slotLabel)
+        let runOut: String
+        if let runOutAt = quota.forecast?.runOutAt {
+            runOut = "RUNS OUT \(EInkFormat.clockLabel(runOutAt, calendar: calendar))"
+        } else {
+            runOut = "\(quota.remainingPercent)% LEFT"
+        }
+        return screen(
+            [
+                header("VIBE BAR", "ALERT · \(snapshot.generatedAtLabel)"),
+                verticalSpacer(),
+                text(
+                    headline.first.uppercased(),
+                    pixelBold,
+                    width: .points(content),
+                    height: .points(12),
+                    align: .center
+                ),
+                text(
+                    headline.second.uppercased(),
+                    pixelBold,
+                    width: .points(content),
+                    height: .points(headline.second.isEmpty ? 0 : 12),
+                    align: .center
+                ),
+                text(
+                    runOut,
+                    sans(portrait ? 18 : 22),
+                    width: .flex(1),
+                    height: .points(portrait ? 18 : 22),
+                    align: .center
+                ),
+                EInkNode(
+                    .horizontalBar(percent: quota.remainingPercent),
+                    width: .points(content),
+                    height: .points(12),
+                    binding: .quota(quota.fieldID, .percent)
+                ),
+                text(
+                    quota.countdown.isEmpty ? "" : "RESETS IN \(quota.countdown.uppercased())",
+                    pixel,
+                    width: .flex(1),
+                    height: .points(12),
+                    align: .center
+                ).bound(.quota(quota.fieldID, .countdown)),
+                verticalSpacer()
+            ],
+            frame: frame,
+            gap: 5
+        )
+    }
+}

--- a/Sources/VibeBarCore/Services/EInkPresetExploder.swift
+++ b/Sources/VibeBarCore/Services/EInkPresetExploder.swift
@@ -1,0 +1,243 @@
+import Foundation
+
+/// Turns a preset into the Studio layout that draws it.
+///
+/// "Edit in Studio" on a preset slide runs this: the preset's box tree becomes
+/// grouped canvas elements — the header bar one group, each quota slot one,
+/// the footer one — with their bindings preserved, so a slot's percentage
+/// still follows its bucket after the author has moved it. That last part is
+/// the whole point. Exploding into fixed text would hand the user a picture of
+/// one refresh and call it a layout.
+///
+/// The contract `EInkPresetExploderTests` holds it to: for every preset and
+/// every orientation, drawing the exploded layout produces the *same boxes*
+/// the preset produces. Anything else is a layout that silently changed the
+/// panel the moment the user pressed a button.
+public enum EInkPresetExploder {
+    /// The exploded layout for one slide at one orientation.
+    public static func explode(
+        slide: EInkSlide,
+        orientation: EInkOrientation,
+        profile: EInkDeviceProfile = .quote0,
+        snapshot: EInkDataSnapshot,
+        calendar: Calendar = .current
+    ) -> EInkCanvasLayout {
+        let preset = slide.kind.preset ?? .quotaLedger
+        let size = profile.frameSize(for: orientation)
+        let frame = EInkRect(x: 0, y: 0, width: size.width, height: size.height)
+        let tree = EInkRenderer.presetTree(
+            preset,
+            slide: slide,
+            orientation: orientation,
+            snapshot: snapshot,
+            frame: frame,
+            calendar: calendar
+        )
+        return layout(
+            from: EInkBoxLayout.resolveAnnotated(tree, in: frame),
+            profile: profile,
+            orientation: orientation,
+            snapshot: snapshot
+        )
+    }
+
+    /// "Re-layout": the preset's own arrangement again, at this orientation.
+    ///
+    /// Identical to `explode` and named for what the Studio button does, so a
+    /// call site reads as the intent rather than as the mechanism.
+    public static func reflow(
+        slide: EInkSlide,
+        orientation: EInkOrientation,
+        profile: EInkDeviceProfile = .quote0,
+        snapshot: EInkDataSnapshot,
+        calendar: Calendar = .current
+    ) -> EInkCanvasLayout {
+        explode(
+            slide: slide,
+            orientation: orientation,
+            profile: profile,
+            snapshot: snapshot,
+            calendar: calendar
+        )
+    }
+
+    // MARK: - Boxes to elements
+
+    static func layout(
+        from placed: [EInkPlacedBox],
+        profile: EInkDeviceProfile,
+        orientation: EInkOrientation,
+        snapshot: EInkDataSnapshot
+    ) -> EInkCanvasLayout {
+        var layout = EInkCanvasLayout(profile: profile, orientation: orientation)
+        // Single-pixel snapping: the boxes are already whole device pixels and
+        // rounding them onto the 8 px grid would move every one of them.
+        layout.snapToGrid = false
+        var groups: [String: UUID] = [:]
+        var elements: [EInkCanvasElement] = []
+
+        var index = 0
+        while index < placed.count {
+            let entry = placed[index]
+            index += 1
+            switch entry.source {
+            case .barFill, .ringLabel:
+                // Drawn by the element the box before it produced.
+                continue
+            case .plain, .barTrack, .ringArc:
+                break
+            }
+            guard var element = element(for: entry, snapshot: snapshot) else { continue }
+            if let moduleID = entry.moduleID {
+                let group = groups[moduleID] ?? UUID()
+                groups[moduleID] = group
+                element.groupID = group
+                element.moduleID = moduleID
+            }
+            elements.append(element)
+        }
+        layout.elements = elements
+        return layout.normalized()
+    }
+
+    static func element(for placed: EInkPlacedBox, snapshot: EInkDataSnapshot) -> EInkCanvasElement? {
+        let frame = placed.box.frame
+        guard frame.width > 0, frame.height > 0 else { return nil }
+
+        func positioned(_ kind: EInkCanvasElement.Kind) -> EInkCanvasElement {
+            var element = EInkCanvasElement(kind: kind)
+            element.x = Double(frame.x)
+            element.y = Double(frame.y)
+            element.width = Double(frame.width)
+            element.height = Double(frame.height)
+            placed.binding?.apply(to: &element)
+            return element
+        }
+
+        switch placed.source {
+        case let .barTrack(percent, vertical):
+            var element = positioned(vertical ? .verticalBar : .horizontalBar)
+            // A bar with no bucket behind it — the usage layouts' "share of
+            // the biggest harness" — keeps the figure it was drawn with, which
+            // is a real measurement rather than a placeholder.
+            if element.fieldID?.isEmpty ?? true { element.percentOverride = Double(percent) }
+            return element
+        case let .ringArc(percent, stroke, labelFont):
+            var element = positioned(.ring)
+            element.thickness = Double(stroke)
+            element.font = labelFont
+            if element.fieldID?.isEmpty ?? true { element.percentOverride = Double(percent) }
+            return element
+        case .barFill, .ringLabel:
+            return nil
+        case .plain:
+            switch placed.box.content {
+            case let .text(content, font, alignment):
+                var element = positioned(.text)
+                element.font = font
+                element.alignment = alignment
+                // A measured box keeps measuring; a fixed one keeps its width
+                // and says whether that width clips.
+                element.autoWidth = false
+                element.clipsOverflow = placed.box.clipsContent
+                // A binding is only kept when it prints exactly what the
+                // preset printed. Several layouts decorate their value — "in
+                // 3h 00m", a bare "62" beside a bar, an uppercased alert
+                // headline — and a binding there would quietly redraw the cell
+                // as the undecorated figure the moment the layout was edited.
+                // Those become fixed text, which is honest: the author can
+                // rebind them in the inspector and see what they get.
+                let rendered = EInkCustomLayoutRenderer.text(for: element, snapshot: snapshot)
+                if placed.binding == nil || rendered != content {
+                    element.textBinding = .custom
+                    element.fieldID = nil
+                    element.text = content
+                }
+                return element
+            case .fill:
+                return positioned(.fill)
+            case .outline:
+                // Only a bar's track draws an outline, and that arrives as
+                // `barTrack`. An outline with no bar behind it would be a new
+                // primitive nobody can edit, so it is drawn as its own bar at
+                // zero rather than invented.
+                var element = positioned(.horizontalBar)
+                element.percentOverride = 0
+                return element
+            case let .image(source):
+                var element = positioned(.image)
+                element.imageSource = source
+                return element
+            case let .ring(percent, stroke):
+                var element = positioned(.ring)
+                element.thickness = Double(stroke)
+                element.percentOverride = Double(percent)
+                return element
+            }
+        }
+    }
+}
+
+// MARK: - Layout table migration
+
+/// Moves round 1's `einkCanvasLayouts` entries onto the new per-orientation
+/// keys.
+///
+/// A round 1 file has one layout per slide and no orientation anywhere in the
+/// key, so the only honest place to put it is the orientation the device was
+/// actually showing when it was authored. The other three are generated on
+/// demand by "Re-layout", which is what the Studio's button does.
+public enum EInkCanvasLayoutMigration {
+    public static func migrated(
+        _ layouts: [String: EInkCanvasLayout],
+        devices: [EInkDeviceConfig]
+    ) -> [String: EInkCanvasLayout] {
+        var orientationByLayoutID: [String: EInkOrientation] = [:]
+        for device in devices {
+            for slide in device.slides {
+                guard let layoutID = slide.kind.layoutID else { continue }
+                orientationByLayoutID[layoutID] = device.orientation
+            }
+        }
+        var result: [String: EInkCanvasLayout] = [:]
+        for (key, layout) in layouts {
+            guard !key.contains("/") else {
+                result[key] = layout
+                continue
+            }
+            let orientation = orientationByLayoutID[key] ?? .degrees0
+            result[EInkRenderer.layoutKey(key, orientation: orientation)] = layout
+        }
+        return result
+    }
+
+    /// True when anything still sits under a round 1 key.
+    public static func needsMigration(_ layouts: [String: EInkCanvasLayout]) -> Bool {
+        layouts.keys.contains { !$0.contains("/") }
+    }
+}
+
+
+public extension EInkCanvasLayout {
+    /// "Re-layout": this slide's preset, arranged for this orientation.
+    ///
+    /// Spelled on the layout because that is where the Studio's button lives,
+    /// and because it reads as what it replaces: a layout, re-derived. The
+    /// caller decides whether to confirm first — re-laying out discards
+    /// whatever the author moved.
+    static func reflow(
+        from slide: EInkSlide,
+        orientation: EInkOrientation,
+        profile: EInkDeviceProfile = .quote0,
+        snapshot: EInkDataSnapshot,
+        calendar: Calendar = .current
+    ) -> EInkCanvasLayout {
+        EInkPresetExploder.reflow(
+            slide: slide,
+            orientation: orientation,
+            profile: profile,
+            snapshot: snapshot,
+            calendar: calendar
+        )
+    }
+}

--- a/Sources/VibeBarCore/Services/EInkPresets.swift
+++ b/Sources/VibeBarCore/Services/EInkPresets.swift
@@ -26,9 +26,15 @@ public enum EInkPresets {
         _ font: EInkFont = EInkPresets.pixel,
         width: EInkLength = .auto,
         height: EInkLength = .auto,
-        align: EInkTextAlignment = .leading
+        align: EInkTextAlignment = .leading,
+        clips: Bool? = nil
     ) -> EInkNode {
-        EInkNode(.text(content, font: font, alignment: align), width: width, height: height)
+        EInkNode(
+            .text(content, font: font, alignment: align),
+            width: width,
+            height: height,
+            clipsText: clips
+        )
     }
 
     static func row(
@@ -147,9 +153,17 @@ public enum EInkPresets {
 
     // MARK: - Shared rows
 
-    static func header(_ left: String, _ right: String) -> EInkNode {
+    static func header(
+        _ left: String,
+        _ right: String,
+        leftBinding: EInkNodeBinding? = nil,
+        rightBinding: EInkNodeBinding? = nil
+    ) -> EInkNode {
         row(
-            [text(left, pixelBold), text(right, pixel, width: .flex(1), align: .trailing)],
+            [
+                text(left, pixelBold).bound(leftBinding),
+                text(right, pixel, width: .flex(1), align: .trailing).bound(rightBinding)
+            ],
             height: .points(14),
             align: .center
         )
@@ -189,6 +203,141 @@ public enum EInkPresets {
             )
         }
         return topRuled(column(lines, height: .auto, gap: 1), paddingTop: 3)
+    }
+
+    /// The module id one quota slot's nodes carry, so the exploder can group
+    /// them.
+    static func slotModule(_ fieldID: String) -> String { "slot:\(fieldID)" }
+
+    static let headerModule = "header"
+    static let footerModule = "footer"
+
+    // MARK: - Chrome (header / footer composition)
+
+    /// What one preset prints in its bars when the slide has not said
+    /// otherwise. Round 1's strings, exactly.
+    struct ChromeDefaults {
+        var left: String
+        var right: String
+        /// `nil` when this preset never had a footer.
+        var footer: EInkNode?
+
+        init(left: String = "VIBE BAR", right: String, footer: EInkNode? = nil) {
+            self.left = left
+            self.right = right
+            self.footer = footer
+        }
+    }
+
+    /// A slide's resolved header and footer, plus the height they cost the
+    /// body.
+    struct Chrome {
+        var header: EInkNode?
+        var headerAtBottom = false
+        var footer: EInkNode?
+        var reserved = 0
+        var compact = false
+
+        /// `body` between the bars, in the order the slide asked for.
+        func compose(_ body: [EInkNode]) -> [EInkNode] {
+            var children: [EInkNode] = []
+            if let header, !headerAtBottom { children.append(header) }
+            children += body
+            if let footer { children.append(footer) }
+            if let header, headerAtBottom { children.append(header) }
+            return children
+        }
+
+        /// The row height a list should aim for: the preset's own, unless the
+        /// slide asked to fill the panel.
+        func preferredRowHeight(_ preferred: Int) -> Int {
+            compact ? 1_000 : preferred
+        }
+    }
+
+    static func chrome(
+        _ options: EInkSlideOptions,
+        defaults: ChromeDefaults,
+        snapshot: EInkDataSnapshot,
+        gap: Int
+    ) -> Chrome {
+        var result = Chrome(compact: options.compact)
+        if let bar = options.header {
+            let left = barText(bar.left, default: defaults.left, snapshot: snapshot)
+            let right = barText(bar.right, default: defaults.right, snapshot: snapshot)
+            if !left.isEmpty || !right.isEmpty {
+                result.header = header(left, right, leftBinding: binding(for: bar.left), rightBinding: binding(for: bar.right))
+                    .module(headerModule)
+                result.headerAtBottom = bar.position == .bottom
+                result.reserved += 14 + gap
+            }
+        }
+        if let config = options.footer, let node = footerNode(config.content, defaults: defaults, snapshot: snapshot) {
+            result.footer = node.module(footerModule)
+            result.reserved += EInkBoxLayout.intrinsicHeight(node) + gap
+        }
+        return result
+    }
+
+    /// What an exploded header element follows. Only the clock and the date
+    /// move on their own; everything else is a fixed string.
+    static func binding(for content: EInkBarContent) -> EInkNodeBinding? {
+        switch content {
+        case .clock: .clock
+        case .date: .date
+        default: nil
+        }
+    }
+
+    static func barText(_ content: EInkBarContent, default fallback: String, snapshot: EInkDataSnapshot) -> String {
+        switch content {
+        case .presetDefault: return fallback
+        case .none: return ""
+        case let .text(value): return value
+        case .clock: return snapshot.clockLabel
+        case .date: return snapshot.dateLabel
+        case .dateClock: return snapshot.generatedAtLabel
+        case .providerStatus: return snapshot.providerStatusLine
+        }
+    }
+
+    static func footerNode(
+        _ content: EInkFooterContent,
+        defaults: ChromeDefaults,
+        snapshot: EInkDataSnapshot
+    ) -> EInkNode? {
+        switch content {
+        case .presetDefault:
+            return defaults.footer
+        case let .usageSummary(periods):
+            return usageSummaryFooter(periods, snapshot)
+        case .clock:
+            return topRuled(
+                row([text(snapshot.generatedAtLabel, pixel, width: .flex(1), align: .center)], height: .points(14), align: .center)
+            )
+        case let .text(value):
+            guard !value.isEmpty else { return nil }
+            return topRuled(row([text(value, pixel, width: .flex(1))], height: .points(14), align: .center))
+        }
+    }
+
+    /// A footer over the windows the slide picked. One line each, so two
+    /// windows read like the shipped footer and four still fit.
+    static func usageSummaryFooter(_ periods: [EInkUsagePeriod], _ snapshot: EInkDataSnapshot) -> EInkNode? {
+        let chosen = periods.isEmpty ? [EInkUsagePeriod.today, .week] : periods
+        let lines = chosen.map { period -> EInkNode in
+            let totals = snapshot.usage[period]
+            return row(
+                [
+                    text("\(period.caption) \(EInkFormat.money(totals.costUSD))", pixelBold),
+                    text("\(EInkFormat.tokens(totals.tokens)) tokens", pixel, width: .flex(1), align: .trailing)
+                ],
+                height: .points(14),
+                align: .center
+            )
+        }
+        guard !lines.isEmpty else { return nil }
+        return topRuled(column(lines, height: .auto, gap: 1))
     }
 
     // MARK: - Column ordering

--- a/Sources/VibeBarCore/Services/EInkPresets.swift
+++ b/Sources/VibeBarCore/Services/EInkPresets.swift
@@ -312,8 +312,10 @@ public enum EInkPresets {
         case let .usageSummary(periods):
             return usageSummaryFooter(periods, snapshot)
         case .clock:
+            // The clock, not the timestamp: a footer set to Clock that printed
+            // "09-13 01:21" would be the date option under another name.
             return topRuled(
-                row([text(snapshot.generatedAtLabel, pixel, width: .flex(1), align: .center)], height: .points(14), align: .center)
+                row([text(snapshot.clockLabel, pixel, width: .flex(1), align: .center)], height: .points(14), align: .center)
             )
         case let .text(value):
             guard !value.isEmpty else { return nil }

--- a/Sources/VibeBarCore/Services/EInkQuotaPresets.swift
+++ b/Sources/VibeBarCore/Services/EInkQuotaPresets.swift
@@ -1,37 +1,121 @@
 import Foundation
 
-// Quota presets: Ledger, Rings, Rail. Ported from the verified demo.
+// Quota presets: Ledger, Rings, Rail. Ported from the verified demo, then
+// given the round 2 composition options.
 extension EInkPresets {
+    // MARK: - Slot labels
+
+    /// The label column the ledger and the table use.
+    ///
+    /// It grows before anything else gives way: the owner's review found
+    /// "Claude · Weekly" hiding which weekly bucket a row was, and the fix is
+    /// a longer name, which is only worth printing if there is room for it.
+    /// `minimum` is the shipped width, `maximum` what the row can spare.
+    static func labelColumnWidth(_ labels: [String], minimum: Int, maximum: Int) -> Int {
+        let widest = EInkSlotLabel.widestWidth(labels)
+        return max(minimum, min(maximum, widest))
+    }
+
+    /// One slot's name, on one line or two.
+    ///
+    /// Two lines put the SubProvider on top and the rest underneath, which is
+    /// the reading order of the name itself — "Claude", then "Fable · Weekly".
+    static func slotLabel(
+        _ quota: EInkQuotaRow,
+        width: EInkLength,
+        twoLines: Bool,
+        align: EInkTextAlignment = .leading,
+        firstFont: EInkFont = EInkPresets.pixelBold,
+        secondFont: EInkFont = EInkPresets.pixel
+    ) -> EInkNode {
+        guard twoLines else {
+            return text(quota.slotLabel, pixel, width: width, align: align)
+                .bound(.quota(quota.fieldID, .label))
+        }
+        return column(
+            [
+                text(quota.providerDisplayName, firstFont, width: .flex(1), height: .points(12), align: align),
+                text(quota.windowTitle, secondFont, width: .flex(1), height: .points(12), align: align)
+            ],
+            width: width,
+            height: .auto,
+            gap: 0
+        )
+    }
+
     // MARK: - Ledger
 
-    static func ledgerLandscape(_ rows: [EInkQuotaRow], _ snapshot: EInkDataSnapshot, frame: EInkRect) -> EInkNode {
+    static func ledgerLandscape(
+        _ rows: [EInkQuotaRow],
+        _ snapshot: EInkDataSnapshot,
+        frame: EInkRect,
+        options: EInkSlideOptions = .default
+    ) -> EInkNode {
         let gap = 4
-        let footer = usageFooter(snapshot)
-        let available = frame.height - 2 * margin - 14 - 15 - 2 * gap
-        let height = fittedRowHeight(available: available, count: rows.count, gap: gap, preferred: 18)
+        let chrome = chrome(
+            options,
+            defaults: ChromeDefaults(
+                right: "QUOTA LEFT · \(snapshot.generatedAtLabel)",
+                footer: usageFooter(snapshot)
+            ),
+            snapshot: snapshot,
+            gap: gap
+        )
+        let available = frame.height - 2 * margin - chrome.reserved
+        // 284 content − 34 percent − 42 countdown − three 5 px gaps, minus the
+        // 40 px a bar needs to still read as a bar.
+        let labelWidth = labelColumnWidth(rows.map(\.slotLabel), minimum: 126, maximum: 153)
+        // The column grows first. Only when a name still outruns the grown
+        // column, *and* the panel has the height for a second line, does the
+        // slot split — five rows on a 152 px panel do not, and a clipped name
+        // beats five rows squeezed to nine pixels each.
+        let roomPerRow = rows.isEmpty ? 0 : (available - gap * max(0, rows.count - 1)) / rows.count
+        let twoLines = roomPerRow >= 26
+            && rows.contains { EInkSlotLabel.needsTwoLines($0.slotLabel, columnWidth: labelWidth) }
+        let height = fittedRowHeight(
+            available: available,
+            count: rows.count,
+            gap: gap,
+            preferred: twoLines ? 26 : chrome.preferredRowHeight(18)
+        )
         let list = rows.map { quota in
             row(
                 [
-                    text("\(quota.providerDisplayName) · \(quota.windowTitle)", pixel, width: .points(126)),
-                    horizontalBar(quota.remainingPercent),
-                    text("\(quota.remainingPercent)%", sans(14), width: .points(34), align: .trailing),
+                    slotLabel(quota, width: .points(labelWidth), twoLines: twoLines),
+                    horizontalBar(quota.remainingPercent).bound(.quota(quota.fieldID, .percent)),
+                    text("\(quota.remainingPercent)%", sans(14), width: .points(34), align: .trailing)
+                        .bound(.quota(quota.fieldID, .percent)),
                     text(quota.countdown, pixel, width: .points(42), align: .trailing)
+                        .bound(.quota(quota.fieldID, .countdown))
                 ],
                 height: .points(height),
                 gap: 5,
                 align: .center
-            )
+            ).module(slotModule(quota.fieldID))
         }
         return screen(
-            [header("VIBE BAR", "QUOTA LEFT · \(snapshot.generatedAtLabel)")]
-                + [column(list, height: .flex(1), gap: gap)]
-                + [footer],
+            chrome.compose([column(list, height: .flex(1), gap: gap)]),
             frame: frame,
             gap: gap
         )
     }
 
-    static func ledgerPortrait(_ rows: [EInkQuotaRow], _ snapshot: EInkDataSnapshot, frame: EInkRect) -> EInkNode {
+    static func ledgerPortrait(
+        _ rows: [EInkQuotaRow],
+        _ snapshot: EInkDataSnapshot,
+        frame: EInkRect,
+        options: EInkSlideOptions = .default
+    ) -> EInkNode {
+        let gap = 4
+        let chrome = chrome(
+            options,
+            defaults: ChromeDefaults(
+                right: snapshot.generatedAtLabel,
+                footer: usageFooterPortrait(snapshot)
+            ),
+            snapshot: snapshot,
+            gap: gap
+        )
         let groups = rows.map { quota in
             column(
                 [
@@ -39,14 +123,16 @@ extension EInkPresets {
                         [
                             text(quota.providerDisplayName, pixelBold),
                             text(quota.countdown, pixel, width: .flex(1), align: .trailing)
+                                .bound(.quota(quota.fieldID, .countdown))
                         ],
                         height: .points(12)
                     ),
                     row(
                         [
                             text(quota.windowTitle, pixel, width: .points(48)),
-                            horizontalBar(quota.remainingPercent),
+                            horizontalBar(quota.remainingPercent).bound(.quota(quota.fieldID, .percent)),
                             text("\(quota.remainingPercent)%", sans(14), width: .points(34), align: .trailing)
+                                .bound(.quota(quota.fieldID, .percent))
                         ],
                         height: .points(14),
                         gap: 4,
@@ -55,52 +141,79 @@ extension EInkPresets {
                 ],
                 height: .points(28),
                 gap: 2
-            )
+            ).module(slotModule(quota.fieldID))
         }
         return screen(
-            [header("VIBE BAR", snapshot.generatedAtLabel)] + groups + [verticalSpacer(), usageFooterPortrait(snapshot)],
+            chrome.compose(groups + [verticalSpacer()]),
             frame: frame,
-            gap: 4
+            gap: gap
         )
     }
 
     // MARK: - Rings
 
+    /// Rings always print the two-line form, centred: the cell is 48 px wide
+    /// and no one-line name fits it.
     static func ringCell(_ quota: EInkQuotaRow, size: Int, labelSize: Int) -> EInkNode {
         column(
             [
-                ring(quota.remainingPercent, size: size, stroke: 6, labelSize: labelSize),
+                ring(quota.remainingPercent, size: size, stroke: 6, labelSize: labelSize)
+                    .bound(.quota(quota.fieldID, .percent)),
                 text(quota.providerDisplayName, pixelBold, align: .center),
                 text(quota.windowTitle, pixel, align: .center),
-                text(quota.countdown, pixel, align: .center)
+                text(quota.countdown, pixel, align: .center).bound(.quota(quota.fieldID, .countdown))
             ],
             width: .flex(1),
             height: .auto,
             gap: 1,
             align: .center
-        )
+        ).module(slotModule(quota.fieldID))
     }
 
-    static func ringsLandscape(_ rows: [EInkQuotaRow], _ snapshot: EInkDataSnapshot, frame: EInkRect) -> EInkNode {
-        let cells = longestInMiddle(rows).map { ringCell($0, size: 48, labelSize: 14) }
+    static func ringsLandscape(
+        _ rows: [EInkQuotaRow],
+        _ snapshot: EInkDataSnapshot,
+        frame: EInkRect,
+        options: EInkSlideOptions = .default
+    ) -> EInkNode {
+        let gap = 4
+        let chrome = chrome(
+            options,
+            defaults: ChromeDefaults(
+                right: "QUOTA LEFT · \(snapshot.generatedAtLabel)",
+                footer: usageFooter(snapshot)
+            ),
+            snapshot: snapshot,
+            gap: gap
+        )
+        let size = chrome.compact ? 60 : 48
+        let cells = longestInMiddle(rows).map { ringCell($0, size: size, labelSize: chrome.compact ? 16 : 14) }
         return screen(
-            [
-                header("VIBE BAR", "QUOTA LEFT · \(snapshot.generatedAtLabel)"),
-                row(cells, height: .flex(1), align: .start),
-                usageFooter(snapshot)
-            ],
+            chrome.compose([row(cells, height: .flex(1), align: .start)]),
             frame: frame,
-            gap: 4
+            gap: gap
         )
     }
 
-    static func ringsPortrait(_ rows: [EInkQuotaRow], _ snapshot: EInkDataSnapshot, frame: EInkRect) -> EInkNode {
+    static func ringsPortrait(
+        _ rows: [EInkQuotaRow],
+        _ snapshot: EInkDataSnapshot,
+        frame: EInkRect,
+        options: EInkSlideOptions = .default
+    ) -> EInkNode {
+        let gap = 4
+        let chrome = chrome(
+            options,
+            defaults: ChromeDefaults(right: snapshot.generatedAtLabel),
+            snapshot: snapshot,
+            gap: gap
+        )
         var lines: [EInkNode] = []
         for start in stride(from: 0, to: rows.count, by: 2) {
             let chunk = Array(rows[start..<min(start + 2, rows.count)])
             lines.append(row(chunk.map { ringCell($0, size: 44, labelSize: 13) }, height: .points(83), align: .start))
         }
-        return screen([header("VIBE BAR", snapshot.generatedAtLabel)] + lines, frame: frame, gap: 4)
+        return screen(chrome.compose(lines), frame: frame, gap: gap)
     }
 
     // MARK: - Rail
@@ -108,8 +221,10 @@ extension EInkPresets {
     static func railCell(_ quota: EInkQuotaRow, barHeight: Int, width: EInkLength) -> EInkNode {
         column(
             [
-                text("\(quota.remainingPercent)", sans(13), align: .center),
-                verticalBar(quota.remainingPercent, width: 22, height: barHeight),
+                text("\(quota.remainingPercent)", sans(13), align: .center)
+                    .bound(.quota(quota.fieldID, .percent)),
+                verticalBar(quota.remainingPercent, width: 22, height: barHeight)
+                    .bound(.quota(quota.fieldID, .percent)),
                 text(quota.providerDisplayName, pixelBold, align: .center),
                 text(quota.windowTitle, pixel, align: .center)
             ],
@@ -117,23 +232,47 @@ extension EInkPresets {
             height: .auto,
             gap: 2,
             align: .center
-        )
+        ).module(slotModule(quota.fieldID))
     }
 
-    static func railLandscape(_ rows: [EInkQuotaRow], _ snapshot: EInkDataSnapshot, frame: EInkRect) -> EInkNode {
-        let cells = longestInMiddle(rows).map { railCell($0, barHeight: 60, width: .flex(1)) }
+    static func railLandscape(
+        _ rows: [EInkQuotaRow],
+        _ snapshot: EInkDataSnapshot,
+        frame: EInkRect,
+        options: EInkSlideOptions = .default
+    ) -> EInkNode {
+        let gap = 4
+        let chrome = chrome(
+            options,
+            defaults: ChromeDefaults(
+                right: "QUOTA LEFT · \(snapshot.generatedAtLabel)",
+                footer: usageFooter(snapshot)
+            ),
+            snapshot: snapshot,
+            gap: gap
+        )
+        let barHeight = chrome.compact ? 84 : 60
+        let cells = longestInMiddle(rows).map { railCell($0, barHeight: barHeight, width: .flex(1)) }
         return screen(
-            [
-                header("VIBE BAR", "QUOTA LEFT · \(snapshot.generatedAtLabel)"),
-                row(cells, height: .flex(1), align: .end),
-                usageFooter(snapshot)
-            ],
+            chrome.compose([row(cells, height: .flex(1), align: .end)]),
             frame: frame,
-            gap: 4
+            gap: gap
         )
     }
 
-    static func railPortrait(_ rows: [EInkQuotaRow], _ snapshot: EInkDataSnapshot, frame: EInkRect) -> EInkNode {
+    static func railPortrait(
+        _ rows: [EInkQuotaRow],
+        _ snapshot: EInkDataSnapshot,
+        frame: EInkRect,
+        options: EInkSlideOptions = .default
+    ) -> EInkNode {
+        let gap = 6
+        let chrome = chrome(
+            options,
+            defaults: ChromeDefaults(right: snapshot.generatedAtLabel),
+            snapshot: snapshot,
+            gap: gap
+        )
         let widths: [EInkLength] = [.points(60), .points(40), .points(40)]
         var lines: [EInkNode] = []
         for start in stride(from: 0, to: rows.count, by: 3) {
@@ -143,6 +282,6 @@ extension EInkPresets {
             }
             lines.append(row(cells, height: .points(127), justify: .between, align: .end))
         }
-        return screen([header("VIBE BAR", snapshot.generatedAtLabel)] + lines, frame: frame, gap: 6)
+        return screen(chrome.compose(lines), frame: frame, gap: gap)
     }
 }

--- a/Sources/VibeBarCore/Services/EInkRenderer.swift
+++ b/Sources/VibeBarCore/Services/EInkRenderer.swift
@@ -113,7 +113,7 @@ public enum EInkRenderer {
         let options = slide.options
         let selected = fieldIDs ?? slide.orderedQuotaFieldIDs
         func quotaRows() -> [EInkQuotaRow] {
-            snapshot.quotaRows(fieldIDs: selected, limit: capacity)
+            snapshot.quotaRows(fieldIDs: selected, limit: capacity).map { $0.relabeled(with: options) }
         }
         func resolved() -> [EInkUsagePeriod] {
             periods ?? resolvedPeriods(slide, capacity: capacity)

--- a/Sources/VibeBarCore/Services/EInkRenderer.swift
+++ b/Sources/VibeBarCore/Services/EInkRenderer.swift
@@ -17,25 +17,65 @@ public enum EInkRenderError: Error, Equatable, Sendable {
 /// device accepts. Pure: same inputs always produce identical bytes, which is
 /// what lets the sync engine skip a push that would change nothing.
 public enum EInkRenderer {
+    /// How a custom slide's layouts are keyed in `einkCanvasLayouts`.
+    ///
+    /// Round 1 stored one layout per slide, which meant rotating the panel
+    /// showed a landscape design turned on its side. A custom slide now
+    /// carries up to four, one per orientation, under `"<layoutID>/<degrees>"`
+    /// — `EInkCanvasLayoutMigration` moves a round 1 entry onto the device's
+    /// current orientation.
+    public static func layoutKey(_ layoutID: String, orientation: EInkOrientation) -> String {
+        "\(layoutID)/\(orientation.rawValue)"
+    }
+
+    /// The layout to draw, in order of preference: this orientation's, then a
+    /// round 1 key that has not been migrated yet.
+    public static func layout(
+        _ layoutID: String,
+        orientation: EInkOrientation,
+        layouts: [String: EInkCanvasLayout]
+    ) -> EInkCanvasLayout? {
+        layouts[layoutKey(layoutID, orientation: orientation)] ?? layouts[layoutID]
+    }
+
     /// The layout tree, before it is flattened to absolute boxes. Exposed so
     /// the preview can reuse the same geometry the device gets.
     ///
-    /// `layouts` is the Studio's layout table, keyed by layout id. A slide
-    /// that names a custom layout throws rather than falling back to a
-    /// preset — see `EInkRenderError`.
+    /// `layouts` is the Studio's layout table. A slide that names a custom
+    /// layout with nothing stored for *this* orientation is re-exploded from
+    /// its preset rather than refused: the alternative is a blank panel after
+    /// a rotation, and the exploded layout is the same picture the preset
+    /// would have drawn. A slide whose layout is missing entirely still
+    /// throws — see `EInkRenderError`.
     public static func tree(
         slide: EInkSlide,
         orientation: EInkOrientation,
         profile: EInkDeviceProfile = .quote0,
         snapshot: EInkDataSnapshot,
-        layouts: [String: EInkCanvasLayout] = [:]
+        layouts: [String: EInkCanvasLayout] = [:],
+        calendar: Calendar = .current
     ) throws -> EInkNode {
         let size = profile.frameSize(for: orientation)
         let frame = EInkRect(x: 0, y: 0, width: size.width, height: size.height)
         guard let preset = slide.kind.preset else {
             let layoutID = slide.kind.layoutID ?? ""
-            guard let layout = layouts[layoutID] else {
-                throw EInkRenderError.layoutMissing(layoutID: layoutID)
+            guard let layout = layout(layoutID, orientation: orientation, layouts: layouts) else {
+                guard layouts.keys.contains(where: { $0 == layoutID || $0.hasPrefix(layoutID + "/") }) else {
+                    throw EInkRenderError.layoutMissing(layoutID: layoutID)
+                }
+                return EInkCustomLayoutRenderer.tree(
+                    layout: EInkPresetExploder.explode(
+                        slide: slide,
+                        orientation: orientation,
+                        profile: profile,
+                        snapshot: snapshot,
+                        calendar: calendar
+                    ),
+                    slide: slide,
+                    orientation: orientation,
+                    profile: profile,
+                    snapshot: snapshot
+                )
             }
             return EInkCustomLayoutRenderer.tree(
                 layout: layout,
@@ -45,51 +85,109 @@ public enum EInkRenderer {
                 snapshot: snapshot
             )
         }
+        return presetTree(
+            preset,
+            slide: slide,
+            orientation: orientation,
+            snapshot: snapshot,
+            frame: frame,
+            calendar: calendar
+        )
+    }
+
+    /// One preset laid out inside `frame`, honouring the slide's composition
+    /// options. Shared with the Studio's whole-preset element and with the
+    /// exploder, so the three cannot drift.
+    public static func presetTree(
+        _ preset: EInkPreset,
+        slide: EInkSlide,
+        orientation: EInkOrientation,
+        snapshot: EInkDataSnapshot,
+        frame: EInkRect,
+        calendar: Calendar = .current,
+        fieldIDs: [String]? = nil,
+        periods: [EInkUsagePeriod]? = nil
+    ) -> EInkNode {
         let capacity = preset.capacity(for: orientation)
         let portrait = orientation.isPortrait
+        let options = slide.options
+        let selected = fieldIDs ?? slide.orderedQuotaFieldIDs
+        func quotaRows() -> [EInkQuotaRow] {
+            snapshot.quotaRows(fieldIDs: selected, limit: capacity)
+        }
+        func resolved() -> [EInkUsagePeriod] {
+            periods ?? resolvedPeriods(slide, capacity: capacity)
+        }
 
         switch preset {
         case .quotaLedger:
-            let rows = snapshot.quotaRows(fieldIDs: slide.quotaFieldIDs, limit: capacity)
+            let rows = quotaRows()
             return portrait
-                ? EInkPresets.ledgerPortrait(rows, snapshot, frame: frame)
-                : EInkPresets.ledgerLandscape(rows, snapshot, frame: frame)
+                ? EInkPresets.ledgerPortrait(rows, snapshot, frame: frame, options: options)
+                : EInkPresets.ledgerLandscape(rows, snapshot, frame: frame, options: options)
         case .quotaRings:
-            let rows = snapshot.quotaRows(fieldIDs: slide.quotaFieldIDs, limit: capacity)
+            let rows = quotaRows()
             return portrait
-                ? EInkPresets.ringsPortrait(rows, snapshot, frame: frame)
-                : EInkPresets.ringsLandscape(rows, snapshot, frame: frame)
+                ? EInkPresets.ringsPortrait(rows, snapshot, frame: frame, options: options)
+                : EInkPresets.ringsLandscape(rows, snapshot, frame: frame, options: options)
         case .quotaRail:
-            let rows = snapshot.quotaRows(fieldIDs: slide.quotaFieldIDs, limit: capacity)
+            let rows = quotaRows()
             return portrait
-                ? EInkPresets.railPortrait(rows, snapshot, frame: frame)
-                : EInkPresets.railLandscape(rows, snapshot, frame: frame)
+                ? EInkPresets.railPortrait(rows, snapshot, frame: frame, options: options)
+                : EInkPresets.railLandscape(rows, snapshot, frame: frame, options: options)
         case .usageTiles:
-            let periods = resolvedPeriods(slide, capacity: capacity)
             return portrait
-                ? EInkPresets.tilesPortrait(periods, snapshot, frame: frame)
-                : EInkPresets.tilesLandscape(periods, snapshot, frame: frame)
+                ? EInkPresets.tilesPortrait(resolved(), snapshot, frame: frame, options: options)
+                : EInkPresets.tilesLandscape(resolved(), snapshot, frame: frame, options: options)
         case .usageSplit:
-            let periods = resolvedPeriods(slide, capacity: capacity)
             return portrait
-                ? EInkPresets.splitPortrait(periods, snapshot, frame: frame)
-                : EInkPresets.splitLandscape(periods, snapshot, frame: frame)
+                ? EInkPresets.splitPortrait(resolved(), snapshot, frame: frame, options: options)
+                : EInkPresets.splitLandscape(resolved(), snapshot, frame: frame, options: options)
         case .usageTable:
             return portrait
-                ? EInkPresets.tablePortrait(capacity, snapshot, frame: frame)
-                : EInkPresets.tableLandscape(capacity, snapshot, frame: frame)
+                ? EInkPresets.tablePortrait(capacity, snapshot, frame: frame, options: options)
+                : EInkPresets.tableLandscape(capacity, snapshot, frame: frame, options: options)
         case .usageDual:
             return portrait
-                ? EInkPresets.dualPortrait(capacity, snapshot, frame: frame)
-                : EInkPresets.dualLandscape(capacity, snapshot, frame: frame)
+                ? EInkPresets.dualPortrait(capacity, snapshot, frame: frame, options: options)
+                : EInkPresets.dualLandscape(capacity, snapshot, frame: frame, options: options)
         case .usageTrend:
             // `slide.usagePeriods` is deliberately not read here: trend has
             // `SelectionAxis.none` and always draws today plus the last seven
             // days. A slide carrying periods from an earlier preset choice is
             // ignored rather than half-honoured.
             return portrait
-                ? EInkPresets.trendPortrait(snapshot, frame: frame)
-                : EInkPresets.trendLandscape(snapshot, frame: frame)
+                ? EInkPresets.trendPortrait(snapshot, frame: frame, options: options)
+                : EInkPresets.trendLandscape(snapshot, frame: frame, options: options)
+        case .briefing:
+            return EInkPresets.briefing(quotaRows(), snapshot, frame: frame, portrait: portrait, options: options)
+        case .forecast:
+            return EInkPresets.forecast(
+                quotaRows(),
+                snapshot,
+                frame: frame,
+                portrait: portrait,
+                calendar: calendar,
+                options: options
+            )
+        case .resets:
+            return EInkPresets.resets(quotaRows(), snapshot, frame: frame, portrait: portrait, options: options)
+        case .heatmap:
+            return EInkPresets.heatmap(snapshot, frame: frame, portrait: portrait, options: options)
+        case .topModels:
+            return EInkPresets.topModels(
+                snapshot,
+                frame: frame,
+                portrait: portrait,
+                limit: preset.rowCount(for: orientation),
+                options: options
+            )
+        case .alert:
+            // The slide names the bucket that tripped; the engine builds it.
+            let row = selected.first.flatMap { fieldID in
+                snapshot.quota.first { $0.fieldID == fieldID }
+            } ?? snapshot.quota.min { $0.remainingPercent < $1.remainingPercent }
+            return EInkPresets.alert(row, snapshot, frame: frame, portrait: portrait, calendar: calendar)
         }
     }
 
@@ -108,14 +206,18 @@ public enum EInkRenderer {
         refreshNow: Bool = false,
         taskKey: String? = nil,
         taskAlias: String? = nil,
-        layouts: [String: EInkCanvasLayout] = [:]
+        layouts: [String: EInkCanvasLayout] = [:],
+        border: Int = 0,
+        link: String? = nil,
+        calendar: Calendar = .current
     ) throws -> DotCanvasPayload {
         let node = try tree(
             slide: slide,
             orientation: device.orientation,
             profile: device.profile,
             snapshot: snapshot,
-            layouts: layouts
+            layouts: layouts,
+            calendar: calendar
         )
         return try DotCanvasEncoder.encode(
             node,
@@ -124,7 +226,9 @@ public enum EInkRenderer {
             refreshNow: refreshNow,
             taskKey: taskKey,
             taskAlias: taskAlias,
-            generatedAtISO: snapshot.generatedAtISO
+            generatedAtISO: snapshot.generatedAtISO,
+            border: border,
+            link: link
         )
     }
 
@@ -134,7 +238,8 @@ public enum EInkRenderer {
         device: EInkDeviceConfig,
         taskKey: String?,
         generatedAtISO: String = "",
-        refreshNow: Bool = false
+        refreshNow: Bool = false,
+        link: String? = nil
     ) throws -> DotCanvasPayload {
         let size = device.profile.frameSize(for: device.orientation)
         let frame = EInkRect(x: 0, y: 0, width: size.width, height: size.height)
@@ -145,7 +250,8 @@ public enum EInkRenderer {
             refreshNow: refreshNow,
             taskKey: taskKey,
             taskAlias: unusedSlotTaskAlias,
-            generatedAtISO: generatedAtISO
+            generatedAtISO: generatedAtISO,
+            link: link
         )
     }
 

--- a/Sources/VibeBarCore/Services/EInkSyncService.swift
+++ b/Sources/VibeBarCore/Services/EInkSyncService.swift
@@ -676,8 +676,7 @@ public final class EInkSyncService: ObservableObject {
         // the state remembers which bucket so a relaunch does not push the
         // same news again. `border: 1` rides on every payload while it stands,
         // which is what turns the screen's frame black.
-        let snapshotForAlert = assembly.snapshot
-        let alertingFieldID = EInkAlertEvaluator.offendingFieldID(device: device, snapshot: snapshotForAlert)
+        let alertingFieldID = EInkAlertEvaluator.offendingFieldID(device: device, snapshot: assembly.snapshot)
         let alertIsNew = alertingFieldID != nil && alertingFieldID != state.alertingFieldID
         state.alertingFieldID = alertingFieldID
         let border = alertingFieldID == nil ? 0 : 1
@@ -686,7 +685,7 @@ public final class EInkSyncService: ObservableObject {
         // behind the panel just jumped: redraw now rather than at the end of
         // the cadence.
         let boundaryPassed = EInkAlertEvaluator.resetBoundaryPassed(recorded: state.nextResetAt, now: clock())
-        state.nextResetAt = EInkAlertEvaluator.nextResetAt(snapshotForAlert, after: clock())
+        state.nextResetAt = EInkAlertEvaluator.nextResetAt(assembly.snapshot, after: clock())
 
         await writeQuietHours(device: device, key: key, state: &state, generation: generation)
 

--- a/Sources/VibeBarCore/Services/EInkSyncService.swift
+++ b/Sources/VibeBarCore/Services/EInkSyncService.swift
@@ -676,7 +676,11 @@ public final class EInkSyncService: ObservableObject {
         // the state remembers which bucket so a relaunch does not push the
         // same news again. `border: 1` rides on every payload while it stands,
         // which is what turns the screen's frame black.
-        let alertingFieldID = EInkAlertEvaluator.offendingFieldID(device: device, snapshot: assembly.snapshot)
+        let alertingFieldID = EInkAlertEvaluator.offendingFieldID(
+            device: device,
+            snapshot: assembly.snapshot,
+            layouts: layouts
+        )
         let alertIsNew = alertingFieldID != nil && alertingFieldID != state.alertingFieldID
         state.alertingFieldID = alertingFieldID
         let border = alertingFieldID == nil ? 0 : 1
@@ -1033,11 +1037,7 @@ public final class EInkSyncService: ObservableObject {
         if let inFlight = inFlightAssembly, inFlight.key == key {
             return try await inFlight.task.value
         }
-        let request = EInkSnapshotRequest(
-            quotaFieldIDs: requested,
-            includesUsage: includesUsage,
-            customLabels: settings.customSlotLabels
-        )
+        let request = EInkSnapshotRequest(quotaFieldIDs: requested, includesUsage: includesUsage)
         let provider = snapshotProvider
         let task = Task<EInkAssemblyOutcome, Error> { try await provider(request) }
         inFlightAssembly = (key, task)

--- a/Sources/VibeBarCore/Services/EInkSyncService.swift
+++ b/Sources/VibeBarCore/Services/EInkSyncService.swift
@@ -1319,6 +1319,11 @@ public final class EInkSyncService: ObservableObject {
     /// and, on battery, real power — redrawing the same numbers under a new
     /// clock. A panel that skips keeps the timestamp of the data it is
     /// actually showing, which is the truer label anyway.
+    ///
+    /// `border` and `link` are folded in beside the drawing. Neither is a
+    /// pixel, but both are things the *device* does — a black frame, and where
+    /// a tap goes — and a change to either with the numbers unmoved would
+    /// otherwise be skipped as "nothing new" and never reach the panel at all.
     public nonisolated static func digest(of payload: DotCanvasPayload, ignoring label: String?) -> String {
         let encoder = DotCanvasPayload.jsonEncoder()
         guard let data = try? encoder.encode(payload.windowData) else { return UUID().uuidString }
@@ -1327,6 +1332,7 @@ public final class EInkSyncService: ObservableObject {
             text = text.replacingOccurrences(of: label, with: "")
             hashed = Data(text.utf8)
         }
+        hashed.append(Data("|border:\(payload.border)|link:\(payload.link ?? "")".utf8))
         return SHA256.hash(data: hashed).map { String(format: "%02x", $0) }.joined()
     }
 }

--- a/Sources/VibeBarCore/Services/EInkSyncService.swift
+++ b/Sources/VibeBarCore/Services/EInkSyncService.swift
@@ -199,6 +199,9 @@ public final class EInkSyncService: ObservableObject {
     /// default priority order, and the usage half only when a slide draws it.
     private let snapshotProvider: @Sendable (EInkSnapshotRequest) async throws -> EInkAssemblyOutcome
     private let clock: @Sendable () -> Date
+    /// Where a tapped panel goes when the device is set to "remote dashboard".
+    /// Injected so a test can have one without a workspace on disk.
+    private let remoteDashboardURL: @Sendable () -> URL?
     /// Spacing between two canvas writes in the same pass. A stored property
     /// only so tests can collapse it; not part of the public API.
     private var requestSpacing: Duration
@@ -282,6 +285,7 @@ public final class EInkSyncService: ObservableObject {
         apiKeyProvider: @escaping @Sendable () -> EInkCredentialProbe = { EInkCredentialStore.probe() },
         snapshotProvider: @escaping @Sendable (EInkSnapshotRequest) async throws -> EInkAssemblyOutcome,
         clock: @escaping @Sendable () -> Date = Date.init,
+        remoteDashboardURL: @escaping @Sendable () -> URL? = { EInkRemoteDashboard.current() },
         requestSpacing: Duration = .milliseconds(150),
         retryDelays: [Duration] = [.seconds(1), .seconds(2)],
         snapshotReuseWindow: Duration = .seconds(5)
@@ -291,6 +295,7 @@ public final class EInkSyncService: ObservableObject {
         self.apiKeyProvider = apiKeyProvider
         self.snapshotProvider = snapshotProvider
         self.clock = clock
+        self.remoteDashboardURL = remoteDashboardURL
         self.requestSpacing = requestSpacing
         self.retryDelays = retryDelays
         self.snapshotReuseWindow = snapshotReuseWindow
@@ -307,9 +312,14 @@ public final class EInkSyncService: ObservableObject {
     /// the panel. Loops are restarted rather than reconciled: there are at
     /// most a handful of devices, and a diff would be more code than it saves.
     public func apply(settings: EInkSyncSettings, layouts: [String: EInkCanvasLayout]) {
-        let changed = settings != self.settings || layouts != self.layouts
+        // Round 1 stored one layout per slide. Migrating on the way in means
+        // the engine never has to guess which orientation a bare key was
+        // authored for, and a rotation falls back to the preset's own
+        // arrangement instead of drawing a landscape design on its side.
+        let migrated = EInkCanvasLayoutMigration.migrated(layouts, devices: settings.devices)
+        let changed = settings != self.settings || migrated != self.layouts
         self.settings = settings.sanitized
-        self.layouts = layouts
+        self.layouts = migrated
         guard changed else { return }
         configurationGeneration += 1
         // A settings edit must *not* clear a rejected key. `apiKeyPresent`
@@ -662,6 +672,24 @@ public final class EInkSyncService: ObservableObject {
         }
         guard generation == configurationGeneration else { return EInkPushOutcome() }
 
+        // Alerts are edges: the panel flips the moment a bucket crosses, and
+        // the state remembers which bucket so a relaunch does not push the
+        // same news again. `border: 1` rides on every payload while it stands,
+        // which is what turns the screen's frame black.
+        let snapshotForAlert = assembly.snapshot
+        let alertingFieldID = EInkAlertEvaluator.offendingFieldID(device: device, snapshot: snapshotForAlert)
+        let alertIsNew = alertingFieldID != nil && alertingFieldID != state.alertingFieldID
+        state.alertingFieldID = alertingFieldID
+        let border = alertingFieldID == nil ? 0 : 1
+        let link = device.tapLink.url(remoteDashboard: remoteDashboardURL())?.absoluteString
+        // A reset the last pass was waiting for has happened, so the figures
+        // behind the panel just jumped: redraw now rather than at the end of
+        // the cadence.
+        let boundaryPassed = EInkAlertEvaluator.resetBoundaryPassed(recorded: state.nextResetAt, now: clock())
+        state.nextResetAt = EInkAlertEvaluator.nextResetAt(snapshotForAlert, after: clock())
+
+        await writeQuietHours(device: device, key: key, state: &state, generation: generation)
+
         var pushed = 0
         var skipped = 0
         var failure = plan.failure
@@ -685,6 +713,14 @@ public final class EInkSyncService: ObservableObject {
             }
 
             let payload: DotCanvasPayload
+            // An alert takes over the single slide and the first loop slot,
+            // and nothing else: the rest of a carousel keeps saying what it
+            // says, so the reader still has the context the alert lacks.
+            let isFirstSlide = item.slideID == plan.items.first(where: { !$0.isUnusedSlot })?.slideID
+            let alertSlide = alertingFieldID
+                .map(EInkAlertEvaluator.alertSlide(fieldID:))
+                .flatMap { isFirstSlide && !item.isUnusedSlot ? $0 : nil }
+            let refreshNow = item.refreshNow || boundaryPassed || (alertIsNew && alertSlide != nil)
             do {
                 switch item.content {
                 case .unusedSlot:
@@ -692,10 +728,12 @@ public final class EInkSyncService: ObservableObject {
                         device: device,
                         taskKey: item.taskKey,
                         generatedAtISO: snapshot.generatedAtISO,
-                        refreshNow: item.refreshNow
+                        refreshNow: refreshNow,
+                        link: link
                     )
                 case let .slide(slideID):
-                    guard let slide = device.slide(id: slideID) else { continue }
+                    guard let configured = device.slide(id: slideID) else { continue }
+                    let slide = alertSlide ?? configured
                     // A usage slide drawn from an empty set would print "$0
                     // today" and be believed. Skip it and say why instead.
                     if assembly.usageUnavailable, slide.needsUsageData(layouts: layouts) { continue }
@@ -703,10 +741,12 @@ public final class EInkSyncService: ObservableObject {
                         slide: slide,
                         device: device,
                         snapshot: snapshot,
-                        refreshNow: item.refreshNow,
+                        refreshNow: refreshNow,
                         taskKey: item.taskKey,
                         taskAlias: EInkRenderer.defaultTaskAlias(slide: slide, orientation: device.orientation),
-                        layouts: layouts
+                        layouts: layouts,
+                        border: border,
+                        link: link
                     )
                 }
             } catch {
@@ -836,6 +876,45 @@ public final class EInkSyncService: ObservableObject {
         return EInkPushOutcome(pushed: pushed, skipped: skipped, failure: failure, errorDetail: detail)
     }
 
+    /// Writes the device's sleep window, once per change.
+    ///
+    /// Quiet hours live on the *device* — it is the panel that goes dark — so
+    /// this is a write to someone else's setting, and it happens only when the
+    /// user's window differs from the one Vibe Bar last sent. A failure is
+    /// logged and dropped rather than failing the pass: the panel is the
+    /// point, and a sleep window that did not take is not a reason to leave
+    /// the numbers stale.
+    private func writeQuietHours(
+        device: EInkDeviceConfig,
+        key: String,
+        state: inout EInkDeviceSyncState,
+        generation: Int
+    ) async {
+        let hours = device.quietHours.sanitized
+        // Never touch a device the user has not asked for quiet hours on. The
+        // default window is a *suggestion* in the settings pane, not a setting
+        // Vibe Bar is entitled to push; only once the toggle has been on does
+        // turning it off earn a write of its own.
+        guard hours.enabled || state.quietHoursSignature != nil else { return }
+        guard let window = hours.window, window.start != window.end else { return }
+        let signature = "\(hours.enabled)|\(window.start)|\(window.end)"
+        guard state.quietHoursSignature != signature else { return }
+        await paceRequest()
+        guard !Task.isCancelled, generation == configurationGeneration else { return }
+        do {
+            try await client.updateSleep(
+                deviceID: device.deviceID,
+                enabled: hours.enabled,
+                start: window.start,
+                end: window.end,
+                apiKey: key
+            )
+            state.quietHoursSignature = signature
+        } catch {
+            SafeLog.warn("eink quiet hours write failed: \(SafeLog.sanitize(String(describing: error)))")
+        }
+    }
+
     /// A status read reports its own failure.
     ///
     /// Swallowing it meant a pass whose pushes were all skipped as unchanged
@@ -955,7 +1034,11 @@ public final class EInkSyncService: ObservableObject {
         if let inFlight = inFlightAssembly, inFlight.key == key {
             return try await inFlight.task.value
         }
-        let request = EInkSnapshotRequest(quotaFieldIDs: requested, includesUsage: includesUsage)
+        let request = EInkSnapshotRequest(
+            quotaFieldIDs: requested,
+            includesUsage: includesUsage,
+            customLabels: settings.customSlotLabels
+        )
         let provider = snapshotProvider
         let task = Task<EInkAssemblyOutcome, Error> { try await provider(request) }
         inFlightAssembly = (key, task)

--- a/Sources/VibeBarCore/Services/EInkUsagePresets.swift
+++ b/Sources/VibeBarCore/Services/EInkUsagePresets.swift
@@ -47,9 +47,20 @@ extension EInkPresets {
         )
     }
 
-    static func tilesLandscape(_ periods: [EInkUsagePeriod], _ snapshot: EInkDataSnapshot, frame: EInkRect) -> EInkNode {
+    static func tilesLandscape(
+        _ periods: [EInkUsagePeriod],
+        _ snapshot: EInkDataSnapshot,
+        frame: EInkRect,
+        options: EInkSlideOptions = .default
+    ) -> EInkNode {
+        let chrome = chrome(
+            options,
+            defaults: ChromeDefaults(right: "USAGE · \(snapshot.generatedAtLabel)"),
+            snapshot: snapshot,
+            gap: 4
+        )
         let tiles = periods.map { tile($0.caption, snapshot.usage[$0], size: 18, width: .flex(1)) }
-        var children: [EInkNode] = [header("VIBE BAR", "USAGE · \(snapshot.generatedAtLabel)")]
+        var children: [EInkNode] = []
         let first = Array(tiles.prefix(2))
         let second = Array(tiles.dropFirst(2))
         children.append(row(decorated(first), height: .flex(1), gap: 8))
@@ -57,7 +68,7 @@ extension EInkPresets {
             children.append(rule())
             children.append(row(decorated(second), height: .flex(1), gap: 8))
         }
-        return screen(children, frame: frame, gap: 4)
+        return screen(chrome.compose(children), frame: frame, gap: 4)
     }
 
     /// Every tile after the first in a row gets the demo's left rule.
@@ -65,24 +76,46 @@ extension EInkPresets {
         tiles.enumerated().map { index, tile in index == 0 ? tile : leftRuled(tile) }
     }
 
-    static func tilesPortrait(_ periods: [EInkUsagePeriod], _ snapshot: EInkDataSnapshot, frame: EInkRect) -> EInkNode {
-        var children: [EInkNode] = [header("VIBE BAR", snapshot.generatedAtLabel)]
+    static func tilesPortrait(
+        _ periods: [EInkUsagePeriod],
+        _ snapshot: EInkDataSnapshot,
+        frame: EInkRect,
+        options: EInkSlideOptions = .default
+    ) -> EInkNode {
+        let chrome = chrome(
+            options,
+            defaults: ChromeDefaults(right: snapshot.generatedAtLabel),
+            snapshot: snapshot,
+            gap: 5
+        )
+        var children: [EInkNode] = []
         for (index, period) in periods.enumerated() {
             if index > 0 { children.append(rule()) }
             children.append(tile(period.caption, snapshot.usage[period], size: 18, width: .flex(1)))
         }
-        return screen(children, frame: frame, gap: 5)
+        return screen(chrome.compose(children), frame: frame, gap: 5)
     }
 
     // MARK: - Split
 
-    static func splitLandscape(_ periods: [EInkUsagePeriod], _ snapshot: EInkDataSnapshot, frame: EInkRect) -> EInkNode {
+    static func splitLandscape(
+        _ periods: [EInkUsagePeriod],
+        _ snapshot: EInkDataSnapshot,
+        frame: EInkRect,
+        options: EInkSlideOptions = .default
+    ) -> EInkNode {
+        let chrome = chrome(
+            options,
+            defaults: ChromeDefaults(right: "USAGE · \(snapshot.generatedAtLabel)"),
+            snapshot: snapshot,
+            gap: 4
+        )
         var blocks: [EInkNode] = []
         for (index, period) in periods.prefix(2).enumerated() {
             let block = usageBlock(period.caption, snapshot.usage[period], size: 26)
             blocks.append(index == 0 ? block : leftRuled(block, gap: 10))
         }
-        var children: [EInkNode] = [header("VIBE BAR", "USAGE · \(snapshot.generatedAtLabel)")]
+        var children: [EInkNode] = []
         children.append(row(blocks, height: .flex(1), gap: 10))
         if let trailing = periods.dropFirst(2).first {
             let totals = snapshot.usage[trailing]
@@ -104,16 +137,27 @@ extension EInkPresets {
                 )
             )
         }
-        return screen(children, frame: frame, gap: 4)
+        return screen(chrome.compose(children), frame: frame, gap: 4)
     }
 
-    static func splitPortrait(_ periods: [EInkUsagePeriod], _ snapshot: EInkDataSnapshot, frame: EInkRect) -> EInkNode {
-        var children: [EInkNode] = [header("VIBE BAR", snapshot.generatedAtLabel)]
+    static func splitPortrait(
+        _ periods: [EInkUsagePeriod],
+        _ snapshot: EInkDataSnapshot,
+        frame: EInkRect,
+        options: EInkSlideOptions = .default
+    ) -> EInkNode {
+        let chrome = chrome(
+            options,
+            defaults: ChromeDefaults(right: snapshot.generatedAtLabel),
+            snapshot: snapshot,
+            gap: 4
+        )
+        var children: [EInkNode] = []
         for (index, period) in periods.enumerated() {
             if index > 0 { children.append(rule()) }
             children.append(usageBlock(period.caption, snapshot.usage[period], size: 20, gap: 3))
         }
-        return screen(children, frame: frame, gap: 4)
+        return screen(chrome.compose(children), frame: frame, gap: 4)
     }
 
     // MARK: - Table
@@ -191,7 +235,12 @@ extension EInkPresets {
         return output
     }
 
-    static func tableLandscape(_ limit: Int, _ snapshot: EInkDataSnapshot, frame: EInkRect) -> EInkNode {
+    static func tableLandscape(
+        _ limit: Int,
+        _ snapshot: EInkDataSnapshot,
+        frame: EInkRect,
+        options: EInkSlideOptions = .default
+    ) -> EInkNode {
         let totals = snapshot.usage.today
         let week = snapshot.usage.week
         let columns = [
@@ -202,10 +251,21 @@ extension EInkPresets {
         ]
         let count = min(limit, totals.rows.count)
         let gap = 3
-        let childCount = 3 + count + 1
-        let available = frame.height - 2 * margin - 14 - 12 - 15 - 14 - gap * max(0, childCount - 1)
-        let rowHeight = fittedRowHeight(available: available, count: max(1, count), gap: gap, preferred: 14)
-        var children: [EInkNode] = [header("VIBE BAR", "USAGE · \(snapshot.generatedAtLabel)")]
+        let chrome = chrome(
+            options,
+            defaults: ChromeDefaults(right: "USAGE · \(snapshot.generatedAtLabel)"),
+            snapshot: snapshot,
+            gap: gap
+        )
+        let childCount = 2 + count + 1
+        let available = frame.height - 2 * margin - chrome.reserved - 12 - 15 - 14 - gap * max(0, childCount - 1)
+        let rowHeight = fittedRowHeight(
+            available: available,
+            count: max(1, count),
+            gap: gap,
+            preferred: chrome.preferredRowHeight(14)
+        )
+        var children: [EInkNode] = []
         children += tableRows(
             caption: nil,
             totals: totals,
@@ -228,7 +288,7 @@ extension EInkPresets {
                 align: .center
             )
         )
-        return screen(children, frame: frame, gap: gap)
+        return screen(chrome.compose(children), frame: frame, gap: gap)
     }
 
     /// A header row whose cells size to their own text instead of to the
@@ -252,7 +312,12 @@ extension EInkPresets {
         return row(children, height: .points(12), gap: gap, align: .center)
     }
 
-    static func tablePortrait(_ limit: Int, _ snapshot: EInkDataSnapshot, frame: EInkRect) -> EInkNode {
+    static func tablePortrait(
+        _ limit: Int,
+        _ snapshot: EInkDataSnapshot,
+        frame: EInkRect,
+        options: EInkSlideOptions = .default
+    ) -> EInkNode {
         // 68 + 34 + 34 plus two 2 px gaps is exactly the 140 px content
         // width, and every part of that split is a measured number rather
         // than a guess (Fusion Pixel 12 px, via `EInkTextMetrics`):
@@ -280,11 +345,22 @@ extension EInkPresets {
         let blocks: [(String, EInkUsageTotals)] = [("TODAY", snapshot.usage.today), ("7 DAYS", snapshot.usage.week)]
         let counts = blocks.map { min(limit, $0.1.rows.count) }
         let gap = 2
-        let childCount = 1 + counts.reduce(0) { $0 + $1 + 3 }
-        let fixed = 14 + blocks.count * (12 + 12 + 15)
+        let chrome = chrome(
+            options,
+            defaults: ChromeDefaults(right: snapshot.generatedAtLabel),
+            snapshot: snapshot,
+            gap: gap
+        )
+        let childCount = counts.reduce(0) { $0 + $1 + 3 }
+        let fixed = chrome.reserved + blocks.count * (12 + 12 + 15)
         let available = frame.height - 2 * margin - fixed - gap * max(0, childCount - 1)
-        let rowHeight = fittedRowHeight(available: available, count: max(1, counts.reduce(0, +)), gap: gap, preferred: 14)
-        var children: [EInkNode] = [header("VIBE BAR", snapshot.generatedAtLabel)]
+        let rowHeight = fittedRowHeight(
+            available: available,
+            count: max(1, counts.reduce(0, +)),
+            gap: gap,
+            preferred: chrome.preferredRowHeight(14)
+        )
+        var children: [EInkNode] = []
         for (index, block) in blocks.enumerated() {
             children += tableRows(
                 caption: block.0,
@@ -298,7 +374,7 @@ extension EInkPresets {
                 headerFitsColumns: false
             )
         }
-        return screen(children, frame: frame, gap: gap)
+        return screen(chrome.compose(children), frame: frame, gap: gap)
     }
 
     // MARK: - Dual bars
@@ -362,12 +438,31 @@ extension EInkPresets {
         }
     }
 
-    static func dualLandscape(_ limit: Int, _ snapshot: EInkDataSnapshot, frame: EInkRect) -> EInkNode {
+    static func dualLandscape(
+        _ limit: Int,
+        _ snapshot: EInkDataSnapshot,
+        frame: EInkRect,
+        options: EInkSlideOptions = .default
+    ) -> EInkNode {
         let totals = snapshot.usage.today
         let count = max(1, min(limit, totals.rows.count))
         let gap = 3
-        let available = frame.height - 2 * margin - 14 - 15 - gap * (count + 1)
-        let rowHeight = fittedRowHeight(available: available, count: count, gap: gap, preferred: 26)
+        let chrome = chrome(
+            options,
+            defaults: ChromeDefaults(
+                right: "COST / TOKENS · TODAY · \(snapshot.generatedAtLabel)",
+                footer: usageFooter(snapshot)
+            ),
+            snapshot: snapshot,
+            gap: gap
+        )
+        let available = frame.height - 2 * margin - chrome.reserved - gap * (count - 1)
+        let rowHeight = fittedRowHeight(
+            available: available,
+            count: count,
+            gap: gap,
+            preferred: chrome.preferredRowHeight(26)
+        )
         let rows = dualRows(
             totals,
             limit: count,
@@ -377,14 +472,15 @@ extension EInkPresets {
             stackedLabel: false,
             rowHeight: rowHeight
         )
-        return screen(
-            [header("VIBE BAR", "COST / TOKENS · TODAY · \(snapshot.generatedAtLabel)")] + rows + [usageFooter(snapshot)],
-            frame: frame,
-            gap: gap
-        )
+        return screen(chrome.compose(rows), frame: frame, gap: gap)
     }
 
-    static func dualPortrait(_ limit: Int, _ snapshot: EInkDataSnapshot, frame: EInkRect) -> EInkNode {
+    static func dualPortrait(
+        _ limit: Int,
+        _ snapshot: EInkDataSnapshot,
+        frame: EInkRect,
+        options: EInkSlideOptions = .default
+    ) -> EInkNode {
         let totals = snapshot.usage.today
         let count = max(1, min(limit, totals.rows.count))
         let rows = dualRows(
@@ -412,9 +508,14 @@ extension EInkPresets {
             ),
             paddingTop: 3
         )
+        let chrome = chrome(
+            options,
+            defaults: ChromeDefaults(right: snapshot.generatedAtLabel, footer: footer),
+            snapshot: snapshot,
+            gap: 4
+        )
         return screen(
-            [header("VIBE BAR", snapshot.generatedAtLabel), text("COST / TOKENS · TODAY", pixel, height: .points(12))]
-                + rows + [verticalSpacer(), footer],
+            chrome.compose([text("COST / TOKENS · TODAY", pixel, height: .points(12))] + rows + [verticalSpacer()]),
             frame: frame,
             gap: 4
         )
@@ -458,7 +559,11 @@ extension EInkPresets {
         )
     }
 
-    static func trendLandscape(_ snapshot: EInkDataSnapshot, frame: EInkRect) -> EInkNode {
+    static func trendLandscape(
+        _ snapshot: EInkDataSnapshot,
+        frame: EInkRect,
+        options: EInkSlideOptions = .default
+    ) -> EInkNode {
         let totals = snapshot.usage.today
         let points = snapshot.trend
         let left = column(
@@ -498,22 +603,34 @@ extension EInkPresets {
                 gap: 4
             )
         )
+        let chrome = chrome(
+            options,
+            defaults: ChromeDefaults(right: "USAGE · \(snapshot.generatedAtLabel)"),
+            snapshot: snapshot,
+            gap: 4
+        )
         return screen(
-            [
-                header("VIBE BAR", "USAGE · \(snapshot.generatedAtLabel)"),
-                row([left, right], height: .flex(1), gap: 8)
-            ],
+            chrome.compose([row([left, right], height: .flex(1), gap: 8)]),
             frame: frame,
             gap: 4
         )
     }
 
-    static func trendPortrait(_ snapshot: EInkDataSnapshot, frame: EInkRect) -> EInkNode {
+    static func trendPortrait(
+        _ snapshot: EInkDataSnapshot,
+        frame: EInkRect,
+        options: EInkSlideOptions = .default
+    ) -> EInkNode {
         let totals = snapshot.usage.today
         let points = snapshot.trend
+        let chrome = chrome(
+            options,
+            defaults: ChromeDefaults(right: snapshot.generatedAtLabel),
+            snapshot: snapshot,
+            gap: 5
+        )
         return screen(
-            [
-                header("VIBE BAR", snapshot.generatedAtLabel),
+            chrome.compose([
                 text("TODAY", pixelBold, height: .points(12)),
                 bigStat(EInkFormat.money(totals.costUSD), "cost", size: 22),
                 bigStat(EInkFormat.tokens(totals.tokens), "tokens", size: 22),
@@ -536,7 +653,7 @@ extension EInkPresets {
                     gap: 6
                 ),
                 trendDates(points, barWidth: 14, gap: 6)
-            ],
+            ]),
             frame: frame,
             gap: 5
         )

--- a/Sources/VibeBarCore/Services/EInkUsageSource.swift
+++ b/Sources/VibeBarCore/Services/EInkUsageSource.swift
@@ -26,6 +26,10 @@ public struct EInkLedgerUsageSource: EInkUsageQuerying {
     public func trend(_ filter: UsageQueryFilter, bucket: UsageTrendBucket) async throws -> UsageTrendSeries {
         try await ledger.trend(filter, bucket: bucket)
     }
+
+    public func modelStats(_ filter: UsageQueryFilter) async throws -> [UsageModelStat] {
+        try await ledger.modelStats(filter)
+    }
 }
 
 /// Stands in when the ledger could not be opened at all.
@@ -52,6 +56,10 @@ public struct EInkEmptyUsageSource: EInkUsageQuerying {
     }
 
     public func trend(_ filter: UsageQueryFilter, bucket: UsageTrendBucket) async throws -> UsageTrendSeries {
+        throw LedgerUnavailable()
+    }
+
+    public func modelStats(_ filter: UsageQueryFilter) async throws -> [UsageModelStat] {
         throw LedgerUnavailable()
     }
 }

--- a/Sources/VibeBarCore/Utilities/DotCanvasEncoder.swift
+++ b/Sources/VibeBarCore/Utilities/DotCanvasEncoder.swift
@@ -70,7 +70,10 @@ public struct DotCanvasPayload: Encodable, Equatable, Sendable {
     public var data: DotCanvasValue
     public var windowData: DotCanvasValue
     public var layoutFull: DotCanvasValue
+    /// 0 = white screen border, 1 = black. Black is the alert state.
     public var border: Int
+    /// Where a phone tapping the (NFC) panel is sent. Omitted when absent.
+    public var link: String?
 
     public static let defaultLayoutFull = DotCanvasValue.object([
         "tw": .string("p-0 bg-white"),
@@ -84,7 +87,8 @@ public struct DotCanvasPayload: Encodable, Equatable, Sendable {
         data: DotCanvasValue,
         windowData: DotCanvasValue,
         layoutFull: DotCanvasValue = DotCanvasPayload.defaultLayoutFull,
-        border: Int = 0
+        border: Int = 0,
+        link: String? = nil
     ) {
         self.refreshNow = refreshNow
         self.taskKey = taskKey
@@ -93,10 +97,11 @@ public struct DotCanvasPayload: Encodable, Equatable, Sendable {
         self.windowData = windowData
         self.layoutFull = layoutFull
         self.border = border
+        self.link = link
     }
 
     private enum CodingKeys: String, CodingKey {
-        case refreshNow, taskKey, taskAlias, data, windowData, layoutFull, border
+        case refreshNow, taskKey, taskAlias, data, windowData, layoutFull, border, link
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -108,6 +113,7 @@ public struct DotCanvasPayload: Encodable, Equatable, Sendable {
         try c.encode(windowData, forKey: .windowData)
         try c.encode(layoutFull, forKey: .layoutFull)
         try c.encode(border, forKey: .border)
+        try c.encodeIfPresent(link, forKey: .link)
     }
 
     /// Deterministic bytes: the sync engine compares digests to avoid a
@@ -180,7 +186,9 @@ public enum DotCanvasEncoder {
         refreshNow: Bool = false,
         taskKey: String? = nil,
         taskAlias: String? = nil,
-        generatedAtISO: String = ""
+        generatedAtISO: String = "",
+        border: Int = 0,
+        link: String? = nil
     ) throws -> DotCanvasPayload {
         let frameSize = profile.frameSize(for: orientation)
         let frame = EInkRect(x: 0, y: 0, width: frameSize.width, height: frameSize.height)
@@ -192,7 +200,9 @@ public enum DotCanvasEncoder {
             refreshNow: refreshNow,
             taskKey: taskKey,
             taskAlias: taskAlias,
-            generatedAtISO: generatedAtISO
+            generatedAtISO: generatedAtISO,
+            border: border,
+            link: link
         )
     }
 
@@ -203,7 +213,9 @@ public enum DotCanvasEncoder {
         refreshNow: Bool = false,
         taskKey: String? = nil,
         taskAlias: String? = nil,
-        generatedAtISO: String = ""
+        generatedAtISO: String = "",
+        border: Int = 0,
+        link: String? = nil
     ) throws -> DotCanvasPayload {
         let elements = try boxes.map(element(for:))
         let root = rootElement(children: elements, orientation: orientation, profile: profile)
@@ -212,7 +224,9 @@ public enum DotCanvasEncoder {
             taskKey: taskKey,
             taskAlias: taskAlias,
             data: .object(["generatedAt": .string(generatedAtISO)]),
-            windowData: .object(["default": .array([root])])
+            windowData: .object(["default": .array([root])]),
+            border: border == 1 ? 1 : 0,
+            link: link
         )
         try validate(payload)
         return payload

--- a/Sources/VibeBarCore/Utilities/EInkHeatmapRasterizer.swift
+++ b/Sources/VibeBarCore/Utilities/EInkHeatmapRasterizer.swift
@@ -1,0 +1,180 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+/// Draws the 7 × 24 activity grid as a pre-thresholded 1-bit PNG.
+///
+/// It is an image rather than 168 `div`s for two reasons, and only the second
+/// one is about taste: the Canvas API caps a payload at 80 elements, and the
+/// panel's own dithering would smear a 2 px dot into grey noise. The PNG ships
+/// already black-and-white and the element carries `img-dither-none`, so what
+/// the panel prints is exactly what this drew.
+///
+/// Dot size comes from the cell's *quantile*, not from its share of the
+/// maximum: one all-night session would otherwise flatten every other hour to
+/// a single pixel, and the question the grid answers is "when do I work", not
+/// "when was my single busiest hour".
+public enum EInkHeatmapRasterizer {
+    public enum RasterError: Error, Equatable, Sendable {
+        case invalidSize(Int)
+        case contextUnavailable
+        case encodingFailed
+    }
+
+    /// The four dot diameters, smallest (no activity) first.
+    public static let dotDiameters = [0, 1, 2, 3]
+
+    /// `data:image/png;base64,…` for the grid.
+    ///
+    /// `weekdaysAcross` puts the seven days on the x axis (the portrait
+    /// arrangement) instead of the twenty-four hours (landscape).
+    public static func dataURI(
+        heatmap: EInkHeatmap,
+        cellSize: Int,
+        weekdaysAcross: Bool
+    ) throws -> String {
+        let key = CacheKey(
+            signature: signature(of: heatmap),
+            cellSize: cellSize,
+            weekdaysAcross: weekdaysAcross
+        )
+        if let cached = cache.value(for: key) { return cached }
+        let data = try pngData(heatmap: heatmap, cellSize: cellSize, weekdaysAcross: weekdaysAcross)
+        let uri = "data:image/png;base64," + data.base64EncodedString()
+        cache.store(uri, for: key)
+        return uri
+    }
+
+    public static func size(cellSize: Int, weekdaysAcross: Bool) -> (width: Int, height: Int) {
+        weekdaysAcross ? (cellSize * 7, cellSize * 24) : (cellSize * 24, cellSize * 7)
+    }
+
+    public static func pngData(
+        heatmap: EInkHeatmap,
+        cellSize: Int,
+        weekdaysAcross: Bool
+    ) throws -> Data {
+        guard cellSize >= 3, cellSize <= 64 else { throw RasterError.invalidSize(cellSize) }
+        let size = size(cellSize: cellSize, weekdaysAcross: weekdaysAcross)
+        let bytesPerRow = (size.width + 7) / 8
+        // 1 == white in a gray colour space, so start the sheet white.
+        var bits = [UInt8](repeating: 0xFF, count: bytesPerRow * size.height)
+        let levels = quantileLevels(heatmap)
+
+        for weekday in 0..<7 {
+            for hour in 0..<24 {
+                let diameter = dotDiameters[levels[weekday][hour]]
+                guard diameter > 0 else { continue }
+                let column = weekdaysAcross ? weekday : hour
+                let rowIndex = weekdaysAcross ? hour : weekday
+                let originX = column * cellSize + (cellSize - diameter) / 2
+                let originY = rowIndex * cellSize + (cellSize - diameter) / 2
+                for y in originY..<(originY + diameter) {
+                    guard y >= 0, y < size.height else { continue }
+                    for x in originX..<(originX + diameter) {
+                        guard x >= 0, x < size.width else { continue }
+                        bits[y * bytesPerRow + x / 8] &= ~UInt8(0x80 >> (x % 8))
+                    }
+                }
+            }
+        }
+        return try encode(bits: bits, width: size.width, height: size.height, bytesPerRow: bytesPerRow)
+    }
+
+    /// `0...3` per cell: empty, and then the three quantiles of the non-empty
+    /// cells.
+    public static func quantileLevels(_ heatmap: EInkHeatmap) -> [[Int]] {
+        let values = heatmap.cells.flatMap { $0 }.filter { $0 > 0 }.sorted()
+        guard !values.isEmpty else { return Array(repeating: Array(repeating: 0, count: 24), count: 7) }
+        func quantile(_ fraction: Double) -> Int {
+            let index = min(values.count - 1, max(0, Int((Double(values.count - 1) * fraction).rounded())))
+            return values[index]
+        }
+        let low = quantile(1.0 / 3)
+        let high = quantile(2.0 / 3)
+        return heatmap.cells.map { row in
+            row.map { value in
+                if value <= 0 { return 0 }
+                if value <= low { return 1 }
+                if value <= high { return 2 }
+                return 3
+            }
+        }
+    }
+
+    // MARK: - Encoding
+
+    private static func encode(bits: [UInt8], width: Int, height: Int, bytesPerRow: Int) throws -> Data {
+        guard let space = CGColorSpace(name: CGColorSpace.linearGray)
+                ?? CGColorSpace(name: CGColorSpace.genericGrayGamma2_2),
+              let provider = CGDataProvider(data: Data(bits) as CFData),
+              let image = CGImage(
+                width: width,
+                height: height,
+                bitsPerComponent: 1,
+                bitsPerPixel: 1,
+                bytesPerRow: bytesPerRow,
+                space: space,
+                bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.none.rawValue),
+                provider: provider,
+                decode: nil,
+                shouldInterpolate: false,
+                intent: .defaultIntent
+              )
+        else { throw RasterError.encodingFailed }
+
+        let output = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(
+            output as CFMutableData,
+            UTType.png.identifier as CFString,
+            1,
+            nil
+        ) else { throw RasterError.encodingFailed }
+        CGImageDestinationAddImage(destination, image, nil)
+        guard CGImageDestinationFinalize(destination) else { throw RasterError.encodingFailed }
+        return output as Data
+    }
+
+    // MARK: - Cache
+
+    /// The levels, not the counts: two refreshes an hour apart almost always
+    /// draw the same dots, and the cache should hit then.
+    static func signature(of heatmap: EInkHeatmap) -> String {
+        quantileLevels(heatmap).map { $0.map(String.init).joined() }.joined(separator: "|")
+    }
+
+    struct CacheKey: Hashable, Sendable {
+        var signature: String
+        var cellSize: Int
+        var weekdaysAcross: Bool
+    }
+
+    private final class Cache: @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [CacheKey: String] = [:]
+
+        func value(for key: CacheKey) -> String? {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage[key]
+        }
+
+        func store(_ value: String, for key: CacheKey) {
+            lock.lock()
+            defer { lock.unlock() }
+            if storage.count > 32 { storage.removeAll(keepingCapacity: true) }
+            storage[key] = value
+        }
+
+        func removeAll() {
+            lock.lock()
+            defer { lock.unlock() }
+            storage.removeAll()
+        }
+    }
+
+    private static let cache = Cache()
+
+    public static func clearCache() { cache.removeAll() }
+}

--- a/Tests/VibeBarCoreTests/EInkCanvasLayoutTests.swift
+++ b/Tests/VibeBarCoreTests/EInkCanvasLayoutTests.swift
@@ -92,7 +92,11 @@ final class EInkCanvasLayoutTests: XCTestCase {
         }
         XCTAssertEqual(EInkCanvasElement.Kind.usageTrend.preset, .usageTrend)
         XCTAssertNil(EInkCanvasElement.Kind.text.preset)
-        XCTAssertEqual(EInkCanvasElement.Kind.allCases.count, 6 + EInkPreset.allCases.count)
+        // Eight primitives — the six the Studio's palette offers plus the
+        // two only the exploder produces (`fill`, `image`) — and one
+        // whole-preset block per user-selectable preset. `alert` is the
+        // engine's, so it has no block.
+        XCTAssertEqual(EInkCanvasElement.Kind.allCases.count, 8 + EInkPreset.userSelectable.count)
     }
 
     func testCodableRoundTrip() throws {

--- a/Tests/VibeBarCoreTests/EInkDataAssemblerTests.swift
+++ b/Tests/VibeBarCoreTests/EInkDataAssemblerTests.swift
@@ -85,22 +85,39 @@ final class EInkDataAssemblerTests: XCTestCase {
         XCTAssertEqual(rows[2].countdown, "")
     }
 
-    /// Deliberately short, and deliberately not `ToolType.hierarchy` — see
-    /// the doc comment on `EInkProviderLabel`.
-    func testProviderLabelsAreTheShortPanelForms() {
-        XCTAssertEqual(EInkProviderLabel.short(for: .codex), "Codex")
-        XCTAssertEqual(EInkProviderLabel.short(for: .claude), "Claude")
-        XCTAssertEqual(EInkProviderLabel.short(for: .grok), "Grok")
-        XCTAssertEqual(EInkProviderLabel.short(for: .antigravity), "AntiGravity")
-        XCTAssertEqual(EInkProviderLabel.short(for: .gemini), "Gemini")
-        XCTAssertEqual(EInkProviderLabel.short(for: .cursor), "Cursor")
-        for tool in ToolType.allCases {
-            XCTAssertLessThanOrEqual(
-                EInkTextMetrics.width(EInkProviderLabel.short(for: tool), font: .pixel12(bold: false)),
-                126,
-                "\(tool.rawValue) does not fit the ledger's provider column"
-            )
-        }
+    /// A row's two halves are the naming tiers, which is what lets a one-line
+    /// slot print "Claude · Fable · Weekly" and a two-line one split it in the
+    /// right place.
+    func testQuotaRowsCarryTheNamingTiersSplitForTwoLineSlots() async {
+        let accounts: [ToolType: AccountQuota] = [
+            .claude: account(tool: .claude, buckets: [
+                QuotaBucket(id: "weekly_fable", title: "Weekly", shortLabel: "7d", usedPercent: 33, resetAt: nil)
+            ])
+        ]
+        let ledger = FakeUsageLedger(summaries: [.empty], harnessRows: [], trendPoints: [])
+        var assembler = assembler(accounts: accounts, ledger: ledger)
+        assembler.quotaPriority = [.init(tool: .claude, bucketID: "weekly_fable")]
+        let rows = await assembler.quotaRows(now: now)
+        XCTAssertEqual(rows.first?.providerDisplayName, "Claude")
+        XCTAssertEqual(rows.first?.windowTitle, "Fable · Weekly")
+        XCTAssertEqual(rows.first?.slotLabel, "Claude · Fable · Weekly")
+    }
+
+    /// A slide's own label wins, and it is split on the same separator so the
+    /// two-line slots still put the first tier on top.
+    func testACustomLabelReplacesTheDefaultAndStillSplits() async {
+        let accounts: [ToolType: AccountQuota] = [
+            .claude: account(tool: .claude, buckets: [
+                QuotaBucket(id: "weekly_fable", title: "Weekly", shortLabel: "7d", usedPercent: 33, resetAt: nil)
+            ])
+        ]
+        let ledger = FakeUsageLedger(summaries: [.empty], harnessRows: [], trendPoints: [])
+        var assembler = assembler(accounts: accounts, ledger: ledger)
+        assembler.quotaPriority = [.init(tool: .claude, bucketID: "weekly_fable")]
+        assembler.customLabels = ["claude.weekly_fable": "Story · Weekly"]
+        let rows = await assembler.quotaRows(now: now)
+        XCTAssertEqual(rows.first?.providerDisplayName, "Story")
+        XCTAssertEqual(rows.first?.windowTitle, "Weekly")
     }
 
     func testUsageWindowsAreTodayFromLocalMidnightPlusRollingSevenAndThirtyDays() async throws {
@@ -239,7 +256,10 @@ extension EInkDataAssemblerTests {
         ]
         let ledger = FakeUsageLedger(summaries: [.empty], harnessRows: [], trendPoints: [])
         let rows = await assembler(accounts: accounts, ledger: ledger).quotaRows(now: now)
-        XCTAssertEqual(rows.map(\.windowTitle), ["5 Hours", "Weekly", ""])
+        // The last bucket reports no title and no group at all, so the name
+        // comes from the catalog — written out in full, and still never the
+        // provider's own "WK".
+        XCTAssertEqual(rows.map(\.windowTitle), ["5 Hours", "Weekly", "Weekly"])
         for row in rows {
             XCTAssertFalse(row.windowTitle == "5h" || row.windowTitle == "WK")
         }

--- a/Tests/VibeBarCoreTests/EInkDataAssemblerTests.swift
+++ b/Tests/VibeBarCoreTests/EInkDataAssemblerTests.swift
@@ -103,9 +103,11 @@ final class EInkDataAssemblerTests: XCTestCase {
         XCTAssertEqual(rows.first?.slotLabel, "Claude · Fable · Weekly")
     }
 
-    /// A slide's own label wins, and it is split on the same separator so the
-    /// two-line slots still put the first tier on top.
-    func testACustomLabelReplacesTheDefaultAndStillSplits() async {
+    /// The snapshot carries the default name. A slide's own override is
+    /// applied while *that slide* draws, because the snapshot is shared — two
+    /// slides naming the same bucket differently must not both get the first
+    /// one's name.
+    func testTheSnapshotCarriesTheDefaultNameAndNotAnySlidesOverride() async {
         let accounts: [ToolType: AccountQuota] = [
             .claude: account(tool: .claude, buckets: [
                 QuotaBucket(id: "weekly_fable", title: "Weekly", shortLabel: "7d", usedPercent: 33, resetAt: nil)
@@ -114,10 +116,16 @@ final class EInkDataAssemblerTests: XCTestCase {
         let ledger = FakeUsageLedger(summaries: [.empty], harnessRows: [], trendPoints: [])
         var assembler = assembler(accounts: accounts, ledger: ledger)
         assembler.quotaPriority = [.init(tool: .claude, bucketID: "weekly_fable")]
-        assembler.customLabels = ["claude.weekly_fable": "Story · Weekly"]
-        let rows = await assembler.quotaRows(now: now)
-        XCTAssertEqual(rows.first?.providerDisplayName, "Story")
-        XCTAssertEqual(rows.first?.windowTitle, "Weekly")
+        let row = await assembler.quotaRows(now: now).first
+        XCTAssertEqual(row?.slotLabel, "Claude · Fable · Weekly")
+
+        var options = EInkSlideOptions.default
+        options.customLabels = ["claude.weekly_fable": "Story · Weekly"]
+        let relabeled = row?.relabeled(with: options)
+        XCTAssertEqual(relabeled?.providerDisplayName, "Story")
+        XCTAssertEqual(relabeled?.windowTitle, "Weekly")
+        // A slide with no override of its own still sees the default.
+        XCTAssertEqual(row?.relabeled(with: .default).slotLabel, "Claude · Fable · Weekly")
     }
 
     func testUsageWindowsAreTodayFromLocalMidnightPlusRollingSevenAndThirtyDays() async throws {

--- a/Tests/VibeBarCoreTests/EInkFixtures.swift
+++ b/Tests/VibeBarCoreTests/EInkFixtures.swift
@@ -82,6 +82,42 @@ enum EInkFixtures {
         return points
     }
 
+    /// A 7 × 24 grid with a clear busiest cell, so the heatmap's header has
+    /// something definite to say.
+    static func heatmap() -> EInkHeatmap {
+        var cells = Array(repeating: Array(repeating: 0, count: 24), count: 7)
+        for weekday in 0..<7 {
+            for hour in 9..<19 {
+                cells[weekday][hour] = 1_000 * (weekday + 1) + 100 * hour
+            }
+        }
+        cells[2][21] = 9_000_000
+        return EInkHeatmap(cells: cells, totalTokens: cells.flatMap { $0 }.reduce(0, +))
+    }
+
+    static func modelRows(count: Int = 6) -> [EInkModelRow] {
+        let names = [
+            "claude-opus-5", "gpt-5.3-codex", "gemini-3-pro",
+            "claude-sonnet-4-6", "grok-4", "gpt-6-astra"
+        ]
+        return (0..<count).map { index in
+            EInkModelRow(
+                model: names[index % names.count],
+                costUSD: Double(940 - index * 137) / 11,
+                tokens: Int64(1_400_000_000) / Int64(index + 1),
+                requests: 4_311 / (index + 1)
+            )
+        }
+    }
+
+    static func forecast(_ verdict: QuotaPaceForecast.Verdict, projected: Double, runsOutIn: TimeInterval?) -> EInkQuotaForecast {
+        EInkQuotaForecast(
+            verdict: verdict,
+            projectedUsedPercent: projected,
+            runOutAt: runsOutIn.map { referenceDate.addingTimeInterval($0) }
+        )
+    }
+
     static func snapshot(quotaCount: Int = 7, harnessCount: Int = 6) -> EInkDataSnapshot {
         let usage = EInkUsageSet(
             today: usageTotals(rowCount: harnessCount, scale: 0.002),
@@ -89,13 +125,28 @@ enum EInkFixtures {
             month: usageTotals(rowCount: harnessCount, scale: 0.2),
             allTime: usageTotals(rowCount: harnessCount, scale: 1)
         )
+        let verdicts: [QuotaPaceForecast.Verdict] = [.surplus, .enough, .watch, .atRisk, .learning, .enough, .surplus]
+        let quota = quotaRows(count: quotaCount).enumerated().map { index, row -> EInkQuotaRow in
+            var copy = row
+            copy.forecast = forecast(
+                verdicts[index % verdicts.count],
+                projected: Double(40 + index * 9),
+                runsOutIn: index % 2 == 0 ? Double(index + 1) * 3_600 : nil
+            )
+            return copy
+        }
         return EInkDataSnapshot(
             generatedAt: referenceDate,
             generatedAtLabel: EInkFormat.timestampLabel(referenceDate, calendar: calendar()),
             generatedAtISO: "2026-01-01T00:00:00Z",
-            quota: quotaRows(count: quotaCount),
+            quota: quota,
             usage: usage,
-            trend: trendPoints()
+            trend: trendPoints(),
+            clockLabel: EInkFormat.clockLabel(referenceDate, calendar: calendar()),
+            dateLabel: EInkFormat.dateLabel(referenceDate, calendar: calendar()),
+            heatmap: heatmap(),
+            topModels: modelRows(),
+            providerStatusLine: "All providers operational"
         )
     }
 

--- a/Tests/VibeBarCoreTests/EInkPlaybackPersistenceTests.swift
+++ b/Tests/VibeBarCoreTests/EInkPlaybackPersistenceTests.swift
@@ -1,0 +1,157 @@
+import XCTest
+@testable import VibeBarCore
+
+/// Round 1 stored "seconds per slide" *inside* the carousel case, so switching
+/// to One slide and back put 300 back. Round 2 stores the mode and the cadence
+/// as independent fields; these are the tests that say so.
+final class EInkPlaybackPersistenceTests: XCTestCase {
+    private func encoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }
+
+    private func roundTrip(_ device: EInkDeviceConfig) throws -> EInkDeviceConfig {
+        try JSONDecoder().decode(EInkDeviceConfig.self, from: try encoder().encode(device))
+    }
+
+    func testSwitchingToOneSlideAndBackKeepsTheSecondsPerSlide() {
+        var device = EInkDeviceConfig(deviceID: "panel-1")
+        device.playbackMode = .appTimer
+        device.secondsPerSlide = 45
+        device.playbackMode = .single
+        device.singleSlideID = "slide-2"
+        XCTAssertEqual(device.secondsPerSlide, 45)
+        device.playbackMode = .deviceLoop
+        XCTAssertEqual(device.secondsPerSlide, 45)
+        XCTAssertEqual(device.playback, .carousel(driver: .deviceLoop, secondsPerSlide: 45))
+        // And the slide the single mode was on is still there to come back to.
+        device.playbackMode = .single
+        XCTAssertEqual(device.playback, .single(slideID: "slide-2"))
+    }
+
+    func testTheLegacyPlaybackEnumStillDecodesIntoTheNewFields() throws {
+        let legacy = Data("""
+        {"deviceID":"panel-1","alias":"","enabled":true,"orientation":0,
+         "playback":{"kind":"carousel","driver":"appTimer","secondsPerSlide":600},
+         "dataRefreshMinutes":15,"batteryRefreshMinutes":90,"taskKeys":[],"slides":[]}
+        """.utf8)
+        let decoded = try JSONDecoder().decode(EInkDeviceConfig.self, from: legacy)
+        XCTAssertEqual(decoded.playbackMode, .appTimer)
+        XCTAssertEqual(decoded.secondsPerSlide, 600)
+        XCTAssertEqual(decoded.batteryRefreshMinutes, 90)
+    }
+
+    func testALegacySingleSlideKeepsItsSlideAndGetsTheDefaultCadence() throws {
+        let legacy = Data("""
+        {"deviceID":"panel-1","playback":{"kind":"single","slideID":"slide-7"}}
+        """.utf8)
+        let decoded = try JSONDecoder().decode(EInkDeviceConfig.self, from: legacy)
+        XCTAssertEqual(decoded.playbackMode, .single)
+        XCTAssertEqual(decoded.singleSlideID, "slide-7")
+        XCTAssertEqual(decoded.secondsPerSlide, EInkDeviceConfig.defaultSecondsPerSlide)
+    }
+
+    /// A file written by round 2 and read by round 1 must still work, so both
+    /// shapes go out. The new keys win on the way back in.
+    func testTheNewFieldsWinOverTheLegacyEnumOnDecode() throws {
+        let mixed = Data("""
+        {"deviceID":"panel-1",
+         "playback":{"kind":"single","slideID":"old"},
+         "playbackMode":"deviceLoop","secondsPerSlide":77,"singleSlideID":"new"}
+        """.utf8)
+        let decoded = try JSONDecoder().decode(EInkDeviceConfig.self, from: mixed)
+        XCTAssertEqual(decoded.playbackMode, .deviceLoop)
+        XCTAssertEqual(decoded.secondsPerSlide, 77)
+        XCTAssertEqual(decoded.singleSlideID, "new")
+    }
+
+    func testTheBatteryCadenceRoundTripsThroughSettings() throws {
+        var settings = AppSettings.default
+        var device = EInkDeviceConfig(deviceID: "panel-1")
+        device.batteryRefreshMinutes = 240
+        device.dataRefreshMinutes = 3
+        device.secondsPerSlide = 20
+        settings.einkSync = EInkSyncSettings(apiKeyPresent: true, syncEnabled: true, devices: [device])
+        let decoded = try JSONDecoder().decode(AppSettings.self, from: try encoder().encode(settings))
+        let stored = try XCTUnwrap(decoded.einkSync.devices.first)
+        XCTAssertEqual(stored.batteryRefreshMinutes, 240)
+        XCTAssertEqual(stored.dataRefreshMinutes, 3)
+        XCTAssertEqual(stored.secondsPerSlide, 20)
+    }
+
+    func testTheThreeCadencesClampToTheirRanges() {
+        var device = EInkDeviceConfig(deviceID: "panel-1")
+        device.dataRefreshMinutes = 0
+        device.batteryRefreshMinutes = 100_000
+        device.secondsPerSlide = 1
+        var clamped = device.sanitized
+        XCTAssertEqual(clamped.dataRefreshMinutes, 1)
+        XCTAssertEqual(clamped.batteryRefreshMinutes, 1440)
+        XCTAssertEqual(clamped.secondsPerSlide, 10)
+
+        device.dataRefreshMinutes = 5_000
+        device.batteryRefreshMinutes = 0
+        device.secondsPerSlide = 999_999
+        clamped = device.sanitized
+        XCTAssertEqual(clamped.dataRefreshMinutes, 1440)
+        XCTAssertEqual(clamped.batteryRefreshMinutes, 1)
+        XCTAssertEqual(clamped.secondsPerSlide, 86_400)
+    }
+
+    func testTheRangesAreTheOnesTheSettingsPaneWillOffer() {
+        XCTAssertEqual(EInkDeviceConfig.minimumDataRefreshMinutes, 1)
+        XCTAssertEqual(EInkDeviceConfig.maximumDataRefreshMinutes, 1440)
+        XCTAssertEqual(EInkDeviceConfig.minimumBatteryRefreshMinutes, 1)
+        XCTAssertEqual(EInkDeviceConfig.maximumBatteryRefreshMinutes, 1440)
+        XCTAssertEqual(EInkPlayback.minimumSecondsPerSlide, 10)
+        XCTAssertEqual(EInkPlayback.maximumSecondsPerSlide, 86_400)
+    }
+
+    // MARK: - Alerts, tap link, quiet hours
+
+    func testAlertsDefaultToOnAtTenPercentAndClamp() {
+        XCTAssertTrue(EInkAlertConfig().enabled)
+        XCTAssertEqual(EInkAlertConfig().thresholdPercent, 10)
+        XCTAssertEqual(EInkAlertConfig(enabled: true, thresholdPercent: 0).sanitized.thresholdPercent, 1)
+        XCTAssertEqual(EInkAlertConfig(enabled: true, thresholdPercent: 500).sanitized.thresholdPercent, 99)
+    }
+
+    /// A tap link ends up on a phone, so it is HTTPS only and never carries
+    /// credentials.
+    func testTapLinksAreHTTPSOnlyAndNeverCarryCredentials() {
+        XCTAssertNil(EInkTapLink.none.url(remoteDashboard: URL(string: "https://example.com")))
+        XCTAssertEqual(
+            EInkTapLink.remoteDashboard.url(remoteDashboard: URL(string: "https://example.com")),
+            URL(string: "https://example.com")
+        )
+        XCTAssertNil(EInkTapLink.remoteDashboard.url(remoteDashboard: nil), "no workspace, no link")
+        XCTAssertNil(EInkTapLink.custom("http://example.com").url(remoteDashboard: nil))
+        XCTAssertNil(EInkTapLink.custom("https://user:secret@example.com").url(remoteDashboard: nil))
+        XCTAssertNil(EInkTapLink.custom("javascript:alert(1)").url(remoteDashboard: nil))
+        XCTAssertEqual(
+            EInkTapLink.custom(" https://example.com/panel ").url(remoteDashboard: nil),
+            URL(string: "https://example.com/panel")
+        )
+    }
+
+    func testQuietHoursOnlyAcceptsAWholeHourMinutePair() {
+        XCTAssertEqual(EInkQuietHours.normalized("7:5"), "07:05")
+        XCTAssertEqual(EInkQuietHours.normalized("23:00"), "23:00")
+        XCTAssertNil(EInkQuietHours.normalized("24:00"))
+        XCTAssertNil(EInkQuietHours.normalized("22:60"))
+        XCTAssertNil(EInkQuietHours.normalized("late"))
+        XCTAssertEqual(EInkQuietHours(enabled: true, start: "bad", end: "bad").sanitized.start, "23:00")
+    }
+
+    func testAlertsTapLinkAndQuietHoursRoundTrip() throws {
+        var device = EInkDeviceConfig(deviceID: "panel-1")
+        device.alerts = EInkAlertConfig(enabled: false, thresholdPercent: 25)
+        device.tapLink = .custom("https://example.com/panel")
+        device.quietHours = EInkQuietHours(enabled: true, start: "22:30", end: "06:15")
+        let decoded = try roundTrip(device)
+        XCTAssertEqual(decoded.alerts, device.alerts)
+        XCTAssertEqual(decoded.tapLink, device.tapLink)
+        XCTAssertEqual(decoded.quietHours, device.quietHours)
+    }
+}

--- a/Tests/VibeBarCoreTests/EInkPresetExploderTests.swift
+++ b/Tests/VibeBarCoreTests/EInkPresetExploderTests.swift
@@ -149,6 +149,32 @@ final class EInkPresetExploderTests: XCTestCase {
         }
     }
 
+    /// The scans that decide what a pass fetches have to find an oriented
+    /// layout too, or a migrated round 1 layout draws bound elements from data
+    /// nobody gathered — "$0.00" on a panel, or a blank percentage.
+    func testTheDataDependencyScansFindOrientedLayoutsToo() {
+        var element = EInkCanvasElement(kind: .statTile)
+        element.textBinding = .usageMetric
+        var quotaElement = EInkCanvasElement(kind: .horizontalBar, fieldID: "claude.weekly_fable")
+        quotaElement.x = 6
+        quotaElement.y = 40
+        var layout = EInkCanvasLayout(profile: .quote0, orientation: .degrees90)
+        layout.elements = [element, quotaElement]
+
+        let slide = EInkSlide(id: "slide-1", kind: .custom(layoutID: "slide-1"))
+        let device = EInkDeviceConfig(deviceID: "panel-1", orientation: .degrees90, slides: [slide])
+        let settings = EInkSyncSettings(apiKeyPresent: true, syncEnabled: true, devices: [device])
+        let oriented = [EInkRenderer.layoutKey("slide-1", orientation: .degrees90): layout]
+
+        XCTAssertTrue(slide.needsUsageData(layouts: oriented))
+        XCTAssertTrue(settings.selectedQuotaFieldIDs(layouts: oriented).contains("claude.weekly_fable"))
+        XCTAssertTrue(settings.referencedQuotaFieldIDs(layouts: oriented).contains("claude.weekly_fable"))
+        XCTAssertEqual(
+            EInkAlertEvaluator.watchedFieldIDs(device, layouts: oriented),
+            ["claude.weekly_fable"]
+        )
+    }
+
     func testReflowProducesThePresetArrangementAgain() {
         let snapshot = EInkFixtures.snapshot()
         let slide = EInkFixtures.slide(preset: .quotaRings)

--- a/Tests/VibeBarCoreTests/EInkPresetExploderTests.swift
+++ b/Tests/VibeBarCoreTests/EInkPresetExploderTests.swift
@@ -1,0 +1,161 @@
+import XCTest
+@testable import VibeBarCore
+
+/// The exploder's one hard promise: a preset turned into a Studio layout draws
+/// the same panel it drew before.
+///
+/// Anything less is a button that silently changes what the device shows, and
+/// on a glanceable surface across a room nobody would ever notice which half
+/// moved.
+final class EInkPresetExploderTests: XCTestCase {
+    private func boxes(_ node: EInkNode, orientation: EInkOrientation) -> [EInkDrawBox] {
+        let size = EInkDeviceProfile.quote0.frameSize(for: orientation)
+        return EInkBoxLayout.resolve(node, in: EInkRect(x: 0, y: 0, width: size.width, height: size.height))
+    }
+
+    private func calendar() -> Calendar { EInkFixtures.calendar() }
+
+    func testEveryPresetAtEveryOrientationExplodesIntoTheSameBoxes() throws {
+        let snapshot = EInkFixtures.snapshot()
+        for preset in EInkPreset.allCases {
+            for orientation in EInkOrientation.allCases {
+                let slide = EInkFixtures.slide(preset: preset)
+                let presetTree = try EInkRenderer.tree(
+                    slide: slide,
+                    orientation: orientation,
+                    snapshot: snapshot,
+                    calendar: calendar()
+                )
+                let layout = EInkPresetExploder.explode(
+                    slide: slide,
+                    orientation: orientation,
+                    snapshot: snapshot,
+                    calendar: calendar()
+                )
+                let explodedTree = EInkCustomLayoutRenderer.tree(
+                    layout: layout,
+                    slide: slide,
+                    orientation: orientation,
+                    snapshot: snapshot
+                )
+                XCTAssertEqual(
+                    boxes(explodedTree, orientation: orientation),
+                    boxes(presetTree, orientation: orientation),
+                    "\(preset.rawValue) at \(orientation.rawValue)° does not survive being exploded"
+                )
+            }
+        }
+    }
+
+    /// A slot's elements come back as one group, and the group still follows
+    /// its bucket — the difference between a layout and a screenshot.
+    func testAQuotaSlotBecomesOneGroupThatKeepsItsBinding() {
+        let snapshot = EInkFixtures.snapshot()
+        let slide = EInkFixtures.slide(preset: .quotaLedger, fieldIDs: ["claude.five_hour", "claude.weekly"])
+        let layout = EInkPresetExploder.explode(slide: slide, orientation: .degrees0, snapshot: snapshot)
+
+        let slotModules = Set(layout.elements.compactMap(\.moduleID)).filter { $0.hasPrefix("slot:") }
+        XCTAssertEqual(slotModules, ["slot:claude.five_hour", "slot:claude.weekly"])
+        XCTAssertTrue(layout.elements.contains { $0.moduleID == EInkPresets.headerModule })
+        XCTAssertTrue(layout.elements.contains { $0.moduleID == EInkPresets.footerModule })
+
+        let slot = layout.elements.filter { $0.moduleID == "slot:claude.weekly" }
+        XCTAssertEqual(Set(slot.compactMap(\.groupID)).count, 1, "one slot is one group")
+        XCTAssertTrue(slot.contains { $0.kind == .horizontalBar && $0.fieldID == "claude.weekly" })
+        XCTAssertTrue(slot.contains { $0.kind == .text && $0.textBinding == .label })
+        XCTAssertTrue(slot.contains { $0.kind == .text && $0.textBinding == .countdown })
+    }
+
+    /// A bound bar follows its bucket: change the reading and the exploded
+    /// layout moves with it, without being exploded again.
+    func testAnExplodedBarFollowsItsBucketAfterTheNumbersMove() {
+        var snapshot = EInkFixtures.snapshot()
+        let slide = EInkFixtures.slide(preset: .quotaLedger, fieldIDs: ["claude.five_hour"])
+        let layout = EInkPresetExploder.explode(slide: slide, orientation: .degrees0, snapshot: snapshot)
+
+        snapshot.quota = snapshot.quota.map { row in
+            guard row.fieldID == "claude.five_hour" else { return row }
+            var moved = row
+            moved.remainingPercent = 4
+            return moved
+        }
+        let tree = EInkCustomLayoutRenderer.tree(
+            layout: layout,
+            slide: slide,
+            orientation: .degrees0,
+            snapshot: snapshot
+        )
+        let strings = boxes(tree, orientation: .degrees0).compactMap { box -> String? in
+            if case let .text(value, _, _) = box.content { return value }
+            return nil
+        }
+        XCTAssertTrue(strings.contains("4%"), "the exploded percentage still reads the bucket")
+        XCTAssertFalse(strings.contains("62%"), "the exploded percentage is not frozen")
+    }
+
+    /// A round 1 file has one layout per slide and no orientation in the key.
+    func testTheLayoutTableMigratesOntoTheDevicesCurrentOrientation() {
+        let slide = EInkSlide(id: "slide-1", kind: .custom(layoutID: "slide-1"))
+        let device = EInkDeviceConfig(deviceID: "panel-1", orientation: .degrees90, slides: [slide])
+        let layouts = ["slide-1": EInkCanvasLayout(profile: .quote0, orientation: .degrees90)]
+        XCTAssertTrue(EInkCanvasLayoutMigration.needsMigration(layouts))
+
+        let migrated = EInkCanvasLayoutMigration.migrated(layouts, devices: [device])
+        XCTAssertEqual(Set(migrated.keys), ["slide-1/90"])
+        XCTAssertFalse(EInkCanvasLayoutMigration.needsMigration(migrated))
+        // Running it twice changes nothing.
+        XCTAssertEqual(EInkCanvasLayoutMigration.migrated(migrated, devices: [device]), migrated)
+    }
+
+    /// Rotating a panel whose custom slide has no layout for the new
+    /// orientation draws the preset's arrangement rather than nothing.
+    func testAMissingOrientationFallsBackToExplodingOnTheFly() throws {
+        let snapshot = EInkFixtures.snapshot()
+        var slide = EInkFixtures.slide(preset: .quotaLedger)
+        let layouts = [
+            EInkRenderer.layoutKey("slide-1", orientation: .degrees0):
+                EInkPresetExploder.explode(slide: slide, orientation: .degrees0, snapshot: snapshot)
+        ]
+        slide.kind = .custom(layoutID: "slide-1")
+
+        let drawn = try EInkRenderer.tree(
+            slide: slide,
+            orientation: .degrees90,
+            snapshot: snapshot,
+            layouts: layouts,
+            calendar: calendar()
+        )
+        var presetSlide = slide
+        presetSlide.kind = .preset(.quotaLedger)
+        let expected = try EInkRenderer.tree(
+            slide: presetSlide,
+            orientation: .degrees90,
+            snapshot: snapshot,
+            calendar: calendar()
+        )
+        XCTAssertEqual(boxes(drawn, orientation: .degrees90), boxes(expected, orientation: .degrees90))
+    }
+
+    /// A slide naming a layout id nothing knows about still refuses to draw:
+    /// substituting a preset for a layout the user authored is the failure
+    /// `EInkRenderError` exists to prevent.
+    func testAnEntirelyUnknownLayoutStillThrows() {
+        var slide = EInkFixtures.slide(preset: .quotaLedger)
+        slide.kind = .custom(layoutID: "gone")
+        XCTAssertThrowsError(
+            try EInkRenderer.tree(slide: slide, orientation: .degrees0, snapshot: EInkFixtures.snapshot())
+        ) { error in
+            XCTAssertEqual(error as? EInkRenderError, .layoutMissing(layoutID: "gone"))
+        }
+    }
+
+    func testReflowProducesThePresetArrangementAgain() {
+        let snapshot = EInkFixtures.snapshot()
+        let slide = EInkFixtures.slide(preset: .quotaRings)
+        let exploded = EInkPresetExploder.explode(slide: slide, orientation: .degrees270, snapshot: snapshot)
+        let reflowed = EInkPresetExploder.reflow(slide: slide, orientation: .degrees270, snapshot: snapshot)
+        XCTAssertEqual(exploded.elements.map(\.kind), reflowed.elements.map(\.kind))
+        XCTAssertEqual(exploded.elements.map(\.x), reflowed.elements.map(\.x))
+        XCTAssertEqual(exploded.elements.map(\.y), reflowed.elements.map(\.y))
+    }
+}

--- a/Tests/VibeBarCoreTests/EInkRoundTwoPresetTests.swift
+++ b/Tests/VibeBarCoreTests/EInkRoundTwoPresetTests.swift
@@ -188,6 +188,28 @@ final class EInkRoundTwoPresetTests: XCTestCase {
         )
     }
 
+    /// The share is a share of the *day*, not of the handful of rows the
+    /// assembler kept: on a busy day the tail would otherwise vanish from a
+    /// denominator the footer calls "today's cost".
+    func testTheTopModelShareIsMeasuredAgainstTheWholeDay() throws {
+        var busy = snapshot
+        busy.topModels = [EInkModelRow(model: "claude-opus-5", costUSD: 50, tokens: 1, requests: 1)]
+        busy.usage.today = EInkUsageTotals(costUSD: 200, tokens: 1, requests: 1, rows: [])
+        let tree = EInkRenderer.presetTree(
+            .topModels,
+            slide: EInkFixtures.slide(preset: .topModels),
+            orientation: .degrees0,
+            snapshot: busy,
+            frame: EInkRect(x: 0, y: 0, width: 296, height: 152)
+        )
+        let printed = EInkBoxLayout.resolve(tree, in: EInkRect(x: 0, y: 0, width: 296, height: 152)).compactMap { box -> String? in
+            if case let .text(value, _, _) = box.content { return value }
+            return nil
+        }
+        XCTAssertTrue(printed.contains("25% of today's cost"))
+        XCTAssertFalse(printed.contains("100% of today's cost"))
+    }
+
     func testTopModelsSaysSoWhenThereIsNothingRatherThanDrawingAnEmptyTable() throws {
         var empty = snapshot
         empty.topModels = []

--- a/Tests/VibeBarCoreTests/EInkRoundTwoPresetTests.swift
+++ b/Tests/VibeBarCoreTests/EInkRoundTwoPresetTests.swift
@@ -1,0 +1,234 @@
+import XCTest
+@testable import VibeBarCore
+
+/// The five layouts the owner asked for after round 1, plus the engine's own
+/// alert panel.
+final class EInkRoundTwoPresetTests: XCTestCase {
+    private let snapshot = EInkFixtures.snapshot()
+
+    private func payload(_ preset: EInkPreset, _ orientation: EInkOrientation) throws -> DotCanvasPayload {
+        try EInkRenderer.render(
+            slide: EInkFixtures.slide(preset: preset),
+            device: EInkFixtures.device(orientation: orientation),
+            snapshot: snapshot,
+            calendar: EInkFixtures.calendar()
+        )
+    }
+
+    private func strings(_ preset: EInkPreset, _ orientation: EInkOrientation) throws -> [String] {
+        try payload(preset, orientation).windowData.allStrings.filter { !$0.hasPrefix("data:") }
+    }
+
+    private func boxes(_ preset: EInkPreset, _ orientation: EInkOrientation) throws -> [EInkDrawBox] {
+        let size = EInkDeviceProfile.quote0.frameSize(for: orientation)
+        return EInkBoxLayout.resolve(
+            try EInkRenderer.tree(
+                slide: EInkFixtures.slide(preset: preset),
+                orientation: orientation,
+                snapshot: snapshot,
+                calendar: EInkFixtures.calendar()
+            ),
+            in: EInkRect(x: 0, y: 0, width: size.width, height: size.height)
+        )
+    }
+
+    /// Every new layout has to encode inside the device's own limits at every
+    /// orientation, or it is a layout that works on a Mac and fails on a desk.
+    func testEveryNewLayoutEncodesWithinTheDeviceLimitsAtEveryOrientation() throws {
+        for preset in [EInkPreset.briefing, .forecast, .resets, .heatmap, .topModels, .alert] {
+            for orientation in EInkOrientation.allCases {
+                let payload = try payload(preset, orientation)
+                XCTAssertLessThanOrEqual(
+                    payload.windowData.elementCount,
+                    DotCanvasEncoder.Limits.maxElements,
+                    "\(preset.rawValue) at \(orientation.rawValue)°"
+                )
+                let boxes = try boxes(preset, orientation)
+                let size = EInkDeviceProfile.quote0.frameSize(for: orientation)
+                for box in boxes {
+                    XCTAssertGreaterThanOrEqual(box.frame.x, 0)
+                    XCTAssertGreaterThanOrEqual(box.frame.y, 0)
+                    XCTAssertLessThanOrEqual(box.frame.maxX, size.width, "\(preset.rawValue)")
+                    XCTAssertLessThanOrEqual(box.frame.maxY, size.height, "\(preset.rawValue)")
+                }
+            }
+        }
+    }
+
+    // MARK: - Briefing
+
+    func testBriefingPrintsOneLinePerSlotPlusTheTwoUsageLines() throws {
+        let printed = try strings(.briefing, .degrees0)
+        XCTAssertTrue(printed.contains { $0.hasPrefix("Today $") && $0.contains("requests") })
+        XCTAssertTrue(printed.contains { $0.hasPrefix("7 days $") && $0.contains("busiest") })
+        XCTAssertTrue(printed.contains { $0.contains("% left") || $0.contains("pace") })
+        XCTAssertTrue(printed.contains("Claude · 5 Hours"))
+    }
+
+    func testBriefingUsesTwoLinesPerSlotInPortrait() throws {
+        let boxes = try boxes(.briefing, .degrees90)
+        let labelRow = try XCTUnwrap(boxes.first { box in
+            if case let .text(value, _, _) = box.content { return value == "Claude · 5 Hours" }
+            return false
+        })
+        let statsUnderneath = boxes.contains { box in
+            guard case let .text(value, _, _) = box.content else { return false }
+            return value.contains("%") && box.frame.y == labelRow.frame.maxY + 1
+        }
+        XCTAssertTrue(statsUnderneath, "the figures sit on their own line under the name")
+    }
+
+    // MARK: - Forecast
+
+    func testForecastPrintsTheVerdictInFullAndARunOutTimeWhenThereIsOne() throws {
+        let printed = try strings(.forecast, .degrees0)
+        XCTAssertTrue(printed.contains("SURPLUS"))
+        XCTAssertTrue(printed.contains { $0.hasPrefix("runs out ") })
+        // "AT RISK", never "RISK" or an arrow.
+        XCTAssertFalse(printed.contains { $0 == "RISK" })
+    }
+
+    /// The tick stands where the bar is expected to end up at reset, not where
+    /// it is now.
+    func testForecastDrawsTheProjectedTickInsideTheBar() {
+        var row = EInkFixtures.quotaRows(count: 1)[0]
+        row.remainingPercent = 80
+        row.forecast = EInkQuotaForecast(verdict: .atRisk, projectedUsedPercent: 90, runOutAt: nil)
+        let node = EInkPresets.forecastBar(row, width: 100, height: 10)
+        let boxes = EInkBoxLayout.resolve(node, in: EInkRect(x: 0, y: 0, width: 296, height: 152), bounds: EInkRect(x: 0, y: 0, width: 296, height: 152))
+        let ticks = boxes.filter { $0.content == .fill && $0.frame.width == 1 }
+        XCTAssertEqual(ticks.count, 1)
+        // 100 − 90 projected use = 10 % left, so the tick sits near the left.
+        XCTAssertEqual(ticks.first?.frame.x, 10)
+    }
+
+    /// No forecast at all means no tick — an invented one would be a guess the
+    /// reader cannot tell from a measurement.
+    func testForecastDrawsNoTickWithoutAForecast() {
+        var row = EInkFixtures.quotaRows(count: 1)[0]
+        row.forecast = nil
+        let node = EInkPresets.forecastBar(row, width: 100, height: 10)
+        let boxes = EInkBoxLayout.resolve(node, in: EInkRect(x: 0, y: 0, width: 296, height: 152), bounds: EInkRect(x: 0, y: 0, width: 296, height: 152))
+        XCTAssertFalse(boxes.contains { $0.content == .fill && $0.frame.width == 1 })
+    }
+
+    // MARK: - Resets
+
+    func testResetsSortsBySoonestAndPrintsTheCountdownBeforeTheName() throws {
+        let printed = try strings(.resets, .degrees0)
+        let countdowns = printed.filter { $0.hasPrefix("in ") }
+        XCTAssertFalse(countdowns.isEmpty)
+        XCTAssertEqual(countdowns.first, "in 30m", "the soonest reset leads")
+        XCTAssertTrue(printed.contains("NEXT SEVEN DAYS"))
+    }
+
+    func testResetsDrawsOneTickPerBucketOnItsTimeline() throws {
+        let boxes = try boxes(.resets, .degrees0)
+        let ticks = boxes.filter { $0.content == .fill && $0.frame.width == 2 && $0.frame.height == 7 }
+        let rows = snapshot.quotaRows(fieldIDs: [], limit: EInkPreset.resets.capacity(for: .degrees0))
+        XCTAssertEqual(ticks.count, rows.filter { $0.resetAt != nil }.count)
+    }
+
+    // MARK: - Heatmap
+
+    func testHeatmapShipsOnePreThresholdedImageAndNamesTheBusiestHourInWords() throws {
+        let payload = try payload(.heatmap, .degrees0)
+        let images = payload.windowData.allStrings.filter { $0.hasPrefix("data:image/png") }
+        XCTAssertEqual(images.count, 1, "one image, not 168 elements")
+        let printed = try strings(.heatmap, .degrees0)
+        XCTAssertTrue(printed.contains("busiest Tue 21:00"))
+        XCTAssertTrue(printed.contains("Mon"))
+    }
+
+    func testHeatmapDotSizesComeFromQuantilesNotFromTheMaximum() {
+        var cells = Array(repeating: Array(repeating: 0, count: 24), count: 7)
+        for hour in 0..<9 { cells[0][hour] = hour + 1 }
+        // One enormous outlier must not flatten the other nine hours.
+        cells[0][23] = 10_000_000
+        let levels = EInkHeatmapRasterizer.quantileLevels(EInkHeatmap(cells: cells, totalTokens: 1))
+        XCTAssertEqual(levels[0][0], 1)
+        XCTAssertEqual(levels[0][8], 3)
+        XCTAssertEqual(levels[0][23], 3)
+        XCTAssertEqual(levels[1][0], 0, "an empty cell draws nothing")
+        XCTAssertTrue(levels[0][0...8].contains(2), "the middle quantile is used")
+    }
+
+    func testHeatmapRasterizerProducesAPNGOfTheStatedSize() throws {
+        let data = try EInkHeatmapRasterizer.pngData(heatmap: EInkFixtures.heatmap(), cellSize: 10, weekdaysAcross: false)
+        XCTAssertTrue(data.starts(with: [0x89, 0x50, 0x4E, 0x47]), "PNG magic")
+        let size = EInkHeatmapRasterizer.size(cellSize: 10, weekdaysAcross: false)
+        XCTAssertEqual(size.width, 240)
+        XCTAssertEqual(size.height, 70)
+        XCTAssertThrowsError(try EInkHeatmapRasterizer.pngData(heatmap: .empty, cellSize: 1, weekdaysAcross: false))
+    }
+
+    func testAnEmptyHeatmapClaimsNoBusiestHour() {
+        XCTAssertEqual(EInkHeatmap.empty.busiestLabel, "")
+        XCTAssertNil(EInkHeatmap.empty.busiest)
+    }
+
+    func testSummingAddsEveryProvidersGrid() {
+        let one = UsageHeatmap(tool: .claude, cells: (0..<7).map { row in (0..<24).map { _ in row } }, totalTokens: 1)
+        let two = UsageHeatmap(tool: .codex, cells: (0..<7).map { row in (0..<24).map { _ in row } }, totalTokens: 1)
+        let summed = EInkHeatmap.summing([one, two])
+        XCTAssertEqual(summed.cells[3][0], 6)
+        XCTAssertEqual(summed.cells[0][0], 0)
+    }
+
+    // MARK: - Top models
+
+    func testTopModelsListsTodaysHeaviestAndFootersTheLeadersShare() throws {
+        let printed = try strings(.topModels, .degrees0)
+        XCTAssertTrue(printed.contains("claude-opus-5"))
+        XCTAssertTrue(printed.contains("TOP MODEL"))
+        XCTAssertTrue(printed.contains { $0.hasSuffix("% of today's cost") })
+        XCTAssertEqual(
+            printed.filter { $0.hasPrefix("claude-") || $0.hasPrefix("gpt-") || $0.hasPrefix("gemini-") || $0.hasPrefix("grok-") }.count,
+            EInkPreset.topModels.rowCount(for: .degrees0)
+        )
+    }
+
+    func testTopModelsSaysSoWhenThereIsNothingRatherThanDrawingAnEmptyTable() throws {
+        var empty = snapshot
+        empty.topModels = []
+        let tree = EInkRenderer.presetTree(
+            .topModels,
+            slide: EInkFixtures.slide(preset: .topModels),
+            orientation: .degrees0,
+            snapshot: empty,
+            frame: EInkRect(x: 0, y: 0, width: 296, height: 152)
+        )
+        let printed = EInkBoxLayout.resolve(tree, in: EInkRect(x: 0, y: 0, width: 296, height: 152)).compactMap { box -> String? in
+            if case let .text(value, _, _) = box.content { return value }
+            return nil
+        }
+        XCTAssertTrue(printed.contains("NO MODEL ACTIVITY TODAY"))
+    }
+
+    // MARK: - Alert
+
+    func testTheAlertSlideNamesTheOffendingBucketAndItsRunOutTime() throws {
+        let slide = EInkAlertEvaluator.alertSlide(fieldID: "cursor.models")
+        let tree = try EInkRenderer.tree(
+            slide: slide,
+            orientation: .degrees0,
+            snapshot: snapshot,
+            calendar: EInkFixtures.calendar()
+        )
+        let printed = EInkBoxLayout.resolve(tree, in: EInkRect(x: 0, y: 0, width: 296, height: 152)).compactMap { box -> String? in
+            if case let .text(value, _, _) = box.content { return value }
+            return nil
+        }
+        // Two centred lines: the SubProvider, then the rest of the name.
+        XCTAssertTrue(printed.contains("CURSOR"))
+        XCTAssertTrue(printed.contains("MODELS"))
+        XCTAssertTrue(printed.contains { $0.hasPrefix("RUNS OUT ") || $0.hasSuffix("% LEFT") })
+        XCTAssertTrue(printed.contains { $0.hasPrefix("RESETS IN ") })
+    }
+
+    /// The alert is the engine's, so it never appears in a picker.
+    func testTheAlertLayoutIsNotUserSelectable() {
+        XCTAssertFalse(EInkPreset.userSelectable.contains(.alert))
+        XCTAssertTrue(EInkPreset.allCases.contains(.alert))
+    }
+}

--- a/Tests/VibeBarCoreTests/EInkSettingsTests.swift
+++ b/Tests/VibeBarCoreTests/EInkSettingsTests.swift
@@ -66,6 +66,8 @@ final class EInkSettingsTests: XCTestCase {
             Set(device.keys),
             [
                 "deviceID", "alias", "profile", "enabled", "orientation", "playback",
+                "playbackMode", "secondsPerSlide", "singleSlideID",
+                "alerts", "tapLink", "quietHours",
                 "dataRefreshMinutes", "batteryRefreshMinutes", "taskKeys", "slides"
             ]
         )
@@ -138,7 +140,15 @@ final class EInkSettingsTests: XCTestCase {
         XCTAssertEqual(EInkPreset.usageDual.capacity(for: landscape), 4)
         XCTAssertEqual(EInkPreset.usageDual.capacity(for: portrait), 5)
         XCTAssertEqual(EInkPreset.usageTrend.capacity(for: landscape), 1)
-        XCTAssertEqual(EInkPreset.allCases.count, 8)
+        XCTAssertEqual(EInkPreset.briefing.capacity(for: landscape), 6)
+        XCTAssertEqual(EInkPreset.briefing.capacity(for: portrait), 8)
+        XCTAssertEqual(EInkPreset.forecast.capacity(for: landscape), 4)
+        XCTAssertEqual(EInkPreset.resets.capacity(for: portrait), 7)
+        XCTAssertEqual(EInkPreset.heatmap.capacity(for: landscape), 1)
+        XCTAssertEqual(EInkPreset.topModels.rowCount(for: portrait), 7)
+        XCTAssertEqual(EInkPreset.allCases.count, 14)
+        XCTAssertEqual(EInkPreset.userSelectable.count, 13)
+        XCTAssertFalse(EInkPreset.userSelectable.contains(.alert))
     }
 
     func testOrientationRotationAngles() {

--- a/Tests/VibeBarCoreTests/EInkSlideOptionsTests.swift
+++ b/Tests/VibeBarCoreTests/EInkSlideOptionsTests.swift
@@ -193,6 +193,19 @@ final class EInkSlideOptionsTests: XCTestCase {
         XCTAssertEqual(slide.orderedQuotaFieldIDs, ["codex.weekly", "claude.weekly", "claude.five_hour"])
     }
 
+    /// Two slides may want different names for the same bucket — a wide
+    /// landscape ledger and a 140 px portrait rail are not the same column.
+    func testASlidesOwnLabelWinsAtDrawTimeOverTheSharedDefault() throws {
+        var slide = EInkFixtures.slide(preset: .quotaLedger, fieldIDs: ["claude.five_hour"])
+        slide.customLabels = ["claude.five_hour": "Desk · 5 Hours"]
+        let drawn = EInkBoxLayout.resolve(
+            try EInkRenderer.tree(slide: slide, orientation: .degrees0, snapshot: snapshot),
+            in: EInkRect(x: 0, y: 0, width: 296, height: 152)
+        )
+        XCTAssertTrue(strings(drawn).contains("Desk · 5 Hours"))
+        XCTAssertFalse(strings(drawn).contains("Claude · 5 Hours"))
+    }
+
     /// A saved order predates whatever the user ticked a moment ago, so it may
     /// never be the thing that hides it.
     func testAnOrderNeverDropsASlotItDoesNotMention() {

--- a/Tests/VibeBarCoreTests/EInkSlideOptionsTests.swift
+++ b/Tests/VibeBarCoreTests/EInkSlideOptionsTests.swift
@@ -165,8 +165,11 @@ final class EInkSlideOptionsTests: XCTestCase {
         options.footer = EInkFooterConfig(content: .text("DESK PANEL"))
         XCTAssertTrue(strings(try boxes(.quotaLedger, orientation: .degrees0, options: options)).contains("DESK PANEL"))
 
+        // The clock, not the timestamp — "Clock" must not smuggle in the date.
         options.footer = EInkFooterConfig(content: .clock)
-        XCTAssertTrue(strings(try boxes(.quotaLedger, orientation: .degrees0, options: options)).contains(snapshot.generatedAtLabel))
+        let clockFooter = strings(try boxes(.quotaLedger, orientation: .degrees0, options: options))
+        XCTAssertTrue(clockFooter.contains(snapshot.clockLabel))
+        XCTAssertEqual(clockFooter.filter { $0 == snapshot.generatedAtLabel }.count, 0)
 
         options.footer = EInkFooterConfig(content: .usageSummary(periods: [.month]))
         XCTAssertTrue(strings(try boxes(.quotaLedger, orientation: .degrees0, options: options)).contains { $0.hasPrefix("30 DAYS ") })

--- a/Tests/VibeBarCoreTests/EInkSlideOptionsTests.swift
+++ b/Tests/VibeBarCoreTests/EInkSlideOptionsTests.swift
@@ -1,0 +1,230 @@
+import XCTest
+@testable import VibeBarCore
+
+/// Round 2 made the header and the footer optional, movable and editable. The
+/// first test here is the one that matters: a slide nobody has configured
+/// still draws exactly the panel round 1 drew.
+final class EInkSlideOptionsTests: XCTestCase {
+    private let snapshot = EInkFixtures.snapshot()
+
+    private func boxes(
+        _ preset: EInkPreset,
+        orientation: EInkOrientation,
+        options: EInkSlideOptions = .default
+    ) throws -> [EInkDrawBox] {
+        var slide = EInkFixtures.slide(preset: preset)
+        slide.options = options
+        let size = EInkDeviceProfile.quote0.frameSize(for: orientation)
+        return EInkBoxLayout.resolve(
+            try EInkRenderer.tree(
+                slide: slide,
+                orientation: orientation,
+                snapshot: snapshot,
+                calendar: EInkFixtures.calendar()
+            ),
+            in: EInkRect(x: 0, y: 0, width: size.width, height: size.height)
+        )
+    }
+
+    private func strings(_ boxes: [EInkDrawBox]) -> [String] {
+        boxes.compactMap { box in
+            if case let .text(value, _, _) = box.content { return value }
+            return nil
+        }
+    }
+
+    // MARK: - Golden
+
+    /// A settings file written by round 1 has no `options` key at all. It must
+    /// decode into the defaults, and the defaults must draw the same bytes.
+    func testASlideWithNoStoredOptionsDrawsTheRoundOnePanelByteForByte() throws {
+        let legacy = Data("""
+        {"id":"slide-1","title":"Quota · Ledger","kind":{"kind":"preset","preset":"quotaLedger"},
+         "quotaFieldIDs":[],"usagePeriods":["today","week","month","allTime"]}
+        """.utf8)
+        let decoded = try JSONDecoder().decode(EInkSlide.self, from: legacy)
+        XCTAssertEqual(decoded.options, .default)
+
+        for preset in EInkPreset.allCases {
+            for orientation in EInkOrientation.allCases {
+                var slide = EInkFixtures.slide(preset: preset)
+                slide.options = decoded.options
+                let withDefaults = try EInkRenderer.render(
+                    slide: slide,
+                    device: EInkFixtures.device(orientation: orientation),
+                    snapshot: snapshot,
+                    calendar: EInkFixtures.calendar()
+                )
+                var untouched = EInkFixtures.slide(preset: preset)
+                untouched.options = .default
+                let reference = try EInkRenderer.render(
+                    slide: untouched,
+                    device: EInkFixtures.device(orientation: orientation),
+                    snapshot: snapshot,
+                    calendar: EInkFixtures.calendar()
+                )
+                XCTAssertEqual(
+                    try withDefaults.jsonData(),
+                    try reference.jsonData(),
+                    "\(preset.rawValue) at \(orientation.rawValue)°"
+                )
+            }
+        }
+    }
+
+    func testTheDefaultHeaderIsStillVibeBarAndTheShippedRightHandLabel() throws {
+        let printed = strings(try boxes(.quotaLedger, orientation: .degrees0))
+        XCTAssertEqual(printed.first, "VIBE BAR")
+        XCTAssertTrue(printed.contains("QUOTA LEFT · \(snapshot.generatedAtLabel)"))
+    }
+
+    // MARK: - Header
+
+    func testTurningTheHeaderOffRemovesItAndHandsTheHeightToTheBody() throws {
+        let withHeader = try boxes(.quotaLedger, orientation: .degrees0)
+        var options = EInkSlideOptions.default
+        options.header = nil
+        let without = try boxes(.quotaLedger, orientation: .degrees0, options: options)
+
+        XCTAssertFalse(strings(without).contains("VIBE BAR"))
+        // The first bar is the top of the body proper.
+        let firstBarTop = { (list: [EInkDrawBox]) in
+            list.first { $0.content == .outline }?.frame.y ?? 0
+        }
+        XCTAssertLessThan(
+            firstBarTop(without),
+            firstBarTop(withHeader),
+            "the body starts higher when there is no header above it"
+        )
+    }
+
+    func testMovingTheHeaderToTheBottomPutsItUnderEverythingElse() throws {
+        var options = EInkSlideOptions.default
+        options.header = EInkBarConfig(position: .bottom)
+        let drawn = try boxes(.quotaLedger, orientation: .degrees0, options: options)
+        let header = try XCTUnwrap(drawn.first { box in
+            if case let .text(value, _, _) = box.content { return value == "VIBE BAR" }
+            return false
+        })
+        let others = drawn.filter { $0.frame != header.frame }.map(\.frame.y)
+        XCTAssertGreaterThan(header.frame.y, others.min() ?? 0)
+    }
+
+    func testEachBarSideCanBeFixedTextAClockADateOrTheProviderStatus() throws {
+        var options = EInkSlideOptions.default
+        options.header = EInkBarConfig(position: .top, left: .text("DESK PANEL"), right: .clock)
+        XCTAssertTrue(strings(try boxes(.quotaLedger, orientation: .degrees0, options: options)).contains("DESK PANEL"))
+        XCTAssertTrue(strings(try boxes(.quotaLedger, orientation: .degrees0, options: options)).contains(snapshot.clockLabel))
+
+        options.header = EInkBarConfig(position: .top, left: .date, right: .providerStatus)
+        XCTAssertFalse(snapshot.providerStatusLine.isEmpty)
+        let printed = strings(try boxes(.quotaLedger, orientation: .degrees0, options: options))
+        XCTAssertTrue(printed.contains(snapshot.dateLabel))
+        XCTAssertTrue(printed.contains(snapshot.providerStatusLine))
+
+        options.header = EInkBarConfig(position: .top, left: .none, right: .none)
+        XCTAssertFalse(strings(try boxes(.quotaLedger, orientation: .degrees0, options: options)).contains("VIBE BAR"))
+    }
+
+    /// One line of provider health, in English, naming the provider that is
+    /// actually in trouble.
+    func testTheProviderStatusLineNamesTheWorstProvider() {
+        XCTAssertEqual(EInkProviderStatusLine.compose([]), "")
+        let healthy = ServiceStatusSnapshot(
+            tool: .claude,
+            indicator: .none,
+            description: "",
+            updatedAt: EInkFixtures.referenceDate,
+            groups: [],
+            components: [],
+            recentIncidents: []
+        )
+        XCTAssertEqual(EInkProviderStatusLine.compose([healthy]), "All providers operational")
+        let degraded = ServiceStatusSnapshot(
+            tool: .claude,
+            indicator: .minor,
+            description: "",
+            updatedAt: EInkFixtures.referenceDate,
+            groups: [],
+            components: [],
+            recentIncidents: []
+        )
+        XCTAssertEqual(EInkProviderStatusLine.compose([healthy, degraded]), "Anthropic: degraded")
+    }
+
+    // MARK: - Footer
+
+    func testTheFooterCanBeTurnedOffOrReplacedWithAClockOrFixedText() throws {
+        var options = EInkSlideOptions.default
+        let shipped = strings(try boxes(.quotaLedger, orientation: .degrees0))
+        XCTAssertTrue(shipped.contains { $0.hasPrefix("TODAY ") })
+
+        options.footer = nil
+        XCTAssertFalse(strings(try boxes(.quotaLedger, orientation: .degrees0, options: options)).contains { $0.hasPrefix("TODAY ") })
+
+        options.footer = EInkFooterConfig(content: .text("DESK PANEL"))
+        XCTAssertTrue(strings(try boxes(.quotaLedger, orientation: .degrees0, options: options)).contains("DESK PANEL"))
+
+        options.footer = EInkFooterConfig(content: .clock)
+        XCTAssertTrue(strings(try boxes(.quotaLedger, orientation: .degrees0, options: options)).contains(snapshot.generatedAtLabel))
+
+        options.footer = EInkFooterConfig(content: .usageSummary(periods: [.month]))
+        XCTAssertTrue(strings(try boxes(.quotaLedger, orientation: .degrees0, options: options)).contains { $0.hasPrefix("30 DAYS ") })
+    }
+
+    func testWithBothBarsOffTheRowsGrowToFillThePanel() throws {
+        var options = EInkSlideOptions.default
+        options.header = nil
+        options.footer = nil
+        options.compact = true
+        let compact = try boxes(.quotaLedger, orientation: .degrees0, options: options)
+        options.compact = false
+        let plain = try boxes(.quotaLedger, orientation: .degrees0, options: options)
+        func span(_ list: [EInkDrawBox]) -> Int { (list.map(\.frame.maxY).max() ?? 0) - (list.map(\.frame.y).min() ?? 0) }
+        XCTAssertGreaterThan(span(compact), span(plain), "compact fills the height the bars gave back")
+        XCTAssertLessThanOrEqual(compact.map(\.frame.maxY).max() ?? 0, 146, "and still respects the safe margin")
+    }
+
+    // MARK: - Slot order
+
+    func testSlotOrderPutsTheSelectedBucketsInTheOrderTheEditorChose() throws {
+        var slide = EInkFixtures.slide(preset: .quotaLedger, fieldIDs: ["claude.five_hour", "claude.weekly", "codex.weekly"])
+        slide.options.slotOrder = ["codex.weekly", "claude.weekly"]
+        XCTAssertEqual(slide.orderedQuotaFieldIDs, ["codex.weekly", "claude.weekly", "claude.five_hour"])
+    }
+
+    /// A saved order predates whatever the user ticked a moment ago, so it may
+    /// never be the thing that hides it.
+    func testAnOrderNeverDropsASlotItDoesNotMention() {
+        let options = EInkSlideOptions(slotOrder: ["b", "gone"])
+        XCTAssertEqual(options.ordered(["a", "b", "c"]), ["b", "a", "c"])
+    }
+
+    func testOptionsRoundTripThroughSettingsIncludingTheOffStates() throws {
+        var options = EInkSlideOptions.default
+        options.header = nil
+        options.footer = EInkFooterConfig(content: .usageSummary(periods: [.today, .month]))
+        options.slotOrder = ["claude.weekly"]
+        options.customLabels = ["claude.weekly": "Weekly"]
+        options.compact = true
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let decoded = try JSONDecoder().decode(EInkSlideOptions.self, from: try encoder.encode(options))
+        XCTAssertEqual(decoded, options)
+        XCTAssertNil(decoded.header)
+    }
+
+    /// `{{` is the Canvas API's template marker and a payload carrying one is
+    /// rejected outright, so a bar's fixed text must not be able to hold it.
+    func testFixedBarTextCannotSmuggleATemplateMarker() throws {
+        let encoder = JSONEncoder()
+        var options = EInkSlideOptions.default
+        options.header = EInkBarConfig(position: .top, left: .text("{{alias}}"), right: .none)
+        let decoded = try JSONDecoder().decode(EInkSlideOptions.self, from: try encoder.encode(options))
+        if case let .text(value) = decoded.header?.left {
+            XCTAssertFalse(value.contains("{{"))
+        } else {
+            XCTFail("the left side should still be fixed text")
+        }
+    }
+}

--- a/Tests/VibeBarCoreTests/EInkSlotLabelTests.swift
+++ b/Tests/VibeBarCoreTests/EInkSlotLabelTests.swift
@@ -1,0 +1,158 @@
+import XCTest
+@testable import VibeBarCore
+
+/// The naming the owner asked for after round 1: a slot says *which* bucket
+/// it is, in the same three tiers the mini window shows, written out.
+final class EInkSlotLabelTests: XCTestCase {
+    private func bucket(_ id: String, title: String, group: String? = nil) -> QuotaBucket {
+        QuotaBucket(id: id, title: title, shortLabel: "x", usedPercent: 10, groupTitle: group)
+    }
+
+    func testAHeadlineBucketNamesItsSubProviderAndWindowAndNothingElse() {
+        // "All Models" is the catch-all lane, not a name: printing it would
+        // claim three tiers where the bucket has two.
+        XCTAssertEqual(EInkSlotLabel.default(for: "codex.weekly"), "ChatGPT Agentic · Weekly")
+        XCTAssertEqual(EInkSlotLabel.default(for: "codex.five_hour"), "ChatGPT Agentic · 5 Hours")
+        XCTAssertEqual(EInkSlotLabel.default(for: "claude.weekly"), "Claude · Weekly")
+        XCTAssertEqual(EInkSlotLabel.default(for: "claude.five_hour"), "Claude · 5 Hours")
+    }
+
+    func testABranchBucketNamesItsQuotaGroupBetweenTheOtherTwo() {
+        XCTAssertEqual(EInkSlotLabel.default(for: "claude.weekly_fable"), "Claude · Fable · Weekly")
+        XCTAssertEqual(EInkSlotLabel.default(for: "claude.weekly_opus"), "Claude · Opus · Weekly")
+        XCTAssertEqual(
+            EInkSlotLabel.default(for: "codex.gpt_5_3_codex_spark_weekly"),
+            "ChatGPT Agentic · GPT-5.3 Codex Spark · Weekly"
+        )
+        XCTAssertEqual(
+            EInkSlotLabel.default(for: "antigravity.claude_gpt_weekly"),
+            "AntiGravity · Claude and GPT Models · Weekly"
+        )
+    }
+
+    /// Grok Bot rides Cursor's adapter but is its own SubProvider, and Cursor's
+    /// own groups restate the product. Neither may be printed twice.
+    func testATierThatRestatesAnEarlierOneIsDropped() {
+        XCTAssertEqual(EInkSlotLabel.default(for: "cursor.grok_bot_weekly"), "Grok Bot · Weekly")
+        XCTAssertEqual(EInkSlotLabel.default(for: "cursor.models"), "Cursor · Monthly")
+        XCTAssertEqual(EInkSlotLabel.default(for: "cursor.other_models"), "Cursor · Other Models · Monthly")
+    }
+
+    /// The live bucket wins when it has one: a provider that renamed a window
+    /// should be named by what it actually returned.
+    func testTheLiveBucketOverridesTheCatalogTitle() {
+        XCTAssertEqual(
+            EInkSlotLabel.default(for: "claude.weekly_fable", bucket: bucket("weekly_fable", title: "Seven Days", group: "Fable")),
+            "Claude · Fable · Seven Days"
+        )
+    }
+
+    /// A bucket the static catalog has never heard of is named from the
+    /// registry rather than printed as a raw field id.
+    func testADiscoveredBucketIsNamedFromTheRegistry() {
+        let registry = QuotaFieldRegistry(fields: [
+            DiscoveredQuotaField(
+                tool: .chatgptChat,
+                bucketId: "reserve_weekly",
+                title: "Weekly",
+                groupTitle: "Reserve Pool",
+                shortLabel: "Reserve",
+                firstSeen: EInkFixtures.referenceDate,
+                lastSeen: EInkFixtures.referenceDate
+            )
+        ])
+        XCTAssertEqual(
+            EInkSlotLabel.default(for: "chatgptChat.reserve_weekly", registry: registry),
+            "ChatGPT Chat · Reserve Pool · Weekly"
+        )
+    }
+
+    func testASlideLabelOverridesTheDefault() {
+        var options = EInkSlideOptions.default
+        options.customLabels = ["claude.weekly_fable": "  Story Weekly  "]
+        XCTAssertEqual(
+            EInkSlotLabel.resolved(for: "claude.weekly_fable", options: options),
+            "Story Weekly"
+        )
+        // An empty override is not an override.
+        options.customLabels = ["claude.weekly_fable": "   "]
+        XCTAssertEqual(
+            EInkSlotLabel.resolved(for: "claude.weekly_fable", options: options),
+            "Claude · Fable · Weekly"
+        )
+    }
+
+    func testTheTwoLineFormSplitsAfterTheSubProvider() {
+        let split = EInkSlotLabel.twoLines("Claude · Fable · Weekly")
+        XCTAssertEqual(split.first, "Claude")
+        XCTAssertEqual(split.second, "Fable · Weekly")
+        // A one-part name has no second line to invent.
+        XCTAssertEqual(EInkSlotLabel.twoLines("Claude").second, "")
+    }
+
+    func testALabelWiderThanItsColumnAsksForTwoLines() {
+        let long = EInkSlotLabel.default(for: "antigravity.claude_gpt_weekly")
+        XCTAssertTrue(EInkSlotLabel.needsTwoLines(long, columnWidth: 126))
+        XCTAssertFalse(EInkSlotLabel.needsTwoLines("Claude · Weekly", columnWidth: 126))
+    }
+
+    /// The ledger's label column grows before anything else gives way, and
+    /// only then does the slot split in two.
+    func testTheLedgerGrowsItsLabelColumnBeforeSplittingTheSlot() throws {
+        func drawn(_ labels: [(String, String)]) throws -> [EInkDrawBox] {
+            var snapshot = EInkFixtures.snapshot()
+            snapshot.quota = labels.enumerated().map { index, pair in
+                EInkQuotaRow(
+                    fieldID: "tool.bucket\(index)",
+                    providerDisplayName: pair.0,
+                    windowTitle: pair.1,
+                    remainingPercent: 50,
+                    resetAt: EInkFixtures.referenceDate.addingTimeInterval(3_600),
+                    countdown: "1h 00m"
+                )
+            }
+            let slide = EInkFixtures.slide(preset: .quotaLedger, fieldIDs: snapshot.quota.map(\.fieldID))
+            return EInkBoxLayout.resolve(
+                try EInkRenderer.tree(slide: slide, orientation: .degrees0, snapshot: snapshot),
+                in: EInkRect(x: 0, y: 0, width: 296, height: 152)
+            )
+        }
+
+        // Short names keep the shipped 126 px column.
+        let short = try drawn([("Claude", "Weekly"), ("Grok", "Weekly")])
+        let shortLabel = try XCTUnwrap(short.first { box in
+            if case let .text(value, _, _) = box.content { return value == "Claude · Weekly" }
+            return false
+        })
+        XCTAssertEqual(shortLabel.frame.width, 126)
+
+        // A longer name grows the column instead of clipping in it.
+        let long = try drawn([("AntiGravity", "Claude and GPT Models · Weekly"), ("Grok", "Weekly")])
+        let grown = try XCTUnwrap(long.first { box in
+            if case let .text(value, _, _) = box.content { return value.hasPrefix("AntiGravity") }
+            return false
+        })
+        XCTAssertEqual(grown.frame.width, 153, "the column grows to everything the row can spare")
+
+        // Two rows leave enough height for the slot to take two lines.
+        let firstLines = long.compactMap { box -> String? in
+            if case let .text(value, _, _) = box.content { return value }
+            return nil
+        }
+        XCTAssertTrue(firstLines.contains("AntiGravity"))
+        XCTAssertTrue(firstLines.contains("Claude and GPT Models · Weekly"))
+    }
+
+    /// The panel never abbreviates, and the naming change is where an
+    /// abbreviation would most easily creep back in.
+    func testNoDefaultLabelIsAnAbbreviation() {
+        let banned: Set<String> = ["WK", "5H", "7D", "30D", "GPT+", "Claude+"]
+        for field in MenuBarFieldCatalog.allFields {
+            let label = EInkSlotLabel.default(for: field.id)
+            for word in label.split(whereSeparator: { !$0.isLetter && !$0.isNumber }).map(String.init) {
+                XCTAssertFalse(banned.contains(word), "\(field.id) prints \"\(label)\"")
+            }
+            XCTAssertFalse(label.contains(" + "), "\(field.id) prints \"\(label)\"")
+        }
+    }
+}

--- a/Tests/VibeBarCoreTests/EInkSyncServiceTests.swift
+++ b/Tests/VibeBarCoreTests/EInkSyncServiceTests.swift
@@ -1937,6 +1937,29 @@ final class EInkSyncServiceTests: XCTestCase {
         XCTAssertFalse(client.sleepWrites.last?.enabled ?? true)
     }
 
+    /// Changing where a tap goes changes nothing on screen, so the digest has
+    /// to carry it or the new link never leaves the Mac.
+    func testChangingTheTapLinkAloneStillReachesThePanel() async {
+        let client = FakeDotClient()
+        let service = service(client: client, device: alertDevice(), snapshot: alertingSnapshot(remaining: 90))
+        await service.refresh(deviceID: "panel-1")
+        let pushedFirst = client.pushes.count
+        XCTAssertGreaterThan(pushedFirst, 0)
+
+        client.reset()
+        service.apply(
+            settings: EInkSyncSettings(
+                apiKeyPresent: true,
+                syncEnabled: true,
+                devices: [alertDevice(tapLink: .custom("https://example.com/panel"))]
+            ),
+            layouts: [:]
+        )
+        await service.refresh(deviceID: "panel-1")
+        XCTAssertEqual(client.pushes.first?.link, "https://example.com/panel")
+        XCTAssertGreaterThan(client.pushes.count, 0, "a link-only change is still a change")
+    }
+
     /// A reset just happened, so the numbers behind the panel jumped: redraw
     /// rather than sitting on the old ones for the rest of the cadence.
     func testAResetBoundaryForcesAnImmediateRedrawOnTheNextPass() {

--- a/Tests/VibeBarCoreTests/EInkSyncServiceTests.swift
+++ b/Tests/VibeBarCoreTests/EInkSyncServiceTests.swift
@@ -11,6 +11,9 @@ private final class FakeDotClient: DotDeviceClienting, @unchecked Sendable {
         let deviceID: String
         let taskKey: String?
         let refreshNow: Bool
+        let border: Int
+        let link: String?
+        let payload: DotCanvasPayload
         let windowDataDigest: String
         let at: Date
         /// Monotonic stamp: the gate the engine uses is a `ContinuousClock`,
@@ -22,6 +25,7 @@ private final class FakeDotClient: DotDeviceClienting, @unchecked Sendable {
     private let lock = NSLock()
     private var pushLog: [Push] = []
     private var statusCallCount = 0
+    private var sleepLog: [(enabled: Bool, start: String, end: String)] = []
 
     var devices: [DotDevice] = []
     var tasks: [DotTask] = []
@@ -42,6 +46,19 @@ private final class FakeDotClient: DotDeviceClienting, @unchecked Sendable {
     var statusReads: Int {
         lock.lock(); defer { lock.unlock() }
         return statusCallCount
+    }
+
+    var sleepWrites: [(enabled: Bool, start: String, end: String)] {
+        lock.lock(); defer { lock.unlock() }
+        return sleepLog
+    }
+
+    @discardableResult
+    func updateSleep(deviceID: String, enabled: Bool, start: String, end: String, apiKey: String) async throws -> String {
+        lock.lock()
+        sleepLog.append((enabled, start, end))
+        lock.unlock()
+        return "ok"
     }
 
     func reset() {
@@ -78,6 +95,9 @@ private final class FakeDotClient: DotDeviceClienting, @unchecked Sendable {
                 deviceID: deviceID,
                 taskKey: payload.taskKey,
                 refreshNow: payload.refreshNow,
+                border: payload.border,
+                link: payload.link,
+                payload: payload,
                 windowDataDigest: EInkSyncService.digest(of: payload),
                 at: Date(),
                 elapsed: ContinuousClock.now
@@ -197,13 +217,15 @@ final class EInkSyncServiceTests: XCTestCase {
         snapshot: @escaping @Sendable (EInkSnapshotRequest) async throws -> EInkAssemblyOutcome
             = { _ in EInkAssemblyOutcome(snapshot: EInkFixtures.snapshot()) },
         requestSpacing: Duration = .milliseconds(150),
-        retryDelays: [Duration] = []
+        retryDelays: [Duration] = [],
+        remoteDashboardURL: @escaping @Sendable () -> URL? = { nil }
     ) -> EInkSyncService {
         let service = EInkSyncService(
             client: client,
             store: EInkSyncStateStore(homeDirectory: temporaryHome.path),
             apiKeyProvider: { .key("synthetic-key") },
             snapshotProvider: snapshot,
+            remoteDashboardURL: remoteDashboardURL,
             requestSpacing: requestSpacing,
             retryDelays: retryDelays,
             snapshotReuseWindow: .zero
@@ -1708,5 +1730,223 @@ final class EInkSyncServiceTests: XCTestCase {
         )
         XCTAssertTrue(plan.boxes.isEmpty)
         XCTAssertEqual(plan.failure, EInkRenderError.layoutMissing(layoutID: "layout-1"))
+    }
+
+    // MARK: - Alerts, border, tap link, quiet hours
+
+    private func alertingSnapshot(remaining: Int) -> @Sendable (EInkSnapshotRequest) async throws -> EInkAssemblyOutcome {
+        { _ in
+            var snapshot = EInkFixtures.snapshot()
+            snapshot.quota = snapshot.quota.map { row in
+                guard row.fieldID == "claude.five_hour" else { return row }
+                var copy = row
+                copy.remainingPercent = remaining
+                copy.forecast = nil
+                return copy
+            }
+            return EInkAssemblyOutcome(snapshot: snapshot)
+        }
+    }
+
+    /// A two-slot loop on purpose: the device drives the rotation, so the plan
+    /// asks for no immediate redraw and an `refreshNow` in a push can only
+    /// have come from the alert.
+    private func alertDevice(threshold: Int = 10, tapLink: EInkTapLink = .none) -> EInkDeviceConfig {
+        var config = device(
+            slides: [
+                EInkSlide(id: "a", title: "a", kind: .preset(.quotaLedger), quotaFieldIDs: ["claude.five_hour"]),
+                EInkSlide(id: "b", title: "b", kind: .preset(.quotaRings), quotaFieldIDs: ["claude.five_hour"])
+            ],
+            taskKeys: ["k1", "k2"],
+            playback: .carousel(driver: .deviceLoop, secondsPerSlide: 300)
+        )
+        config.alerts = EInkAlertConfig(enabled: true, thresholdPercent: threshold)
+        config.tapLink = tapLink
+        return config
+    }
+
+    /// The whole point of the alert: the panel says the one thing that
+    /// matters, framed in black, and says it *once*.
+    func testABucketCrossingTheThresholdReplacesTheSlideAndBlackensTheBorder() async {
+        let client = FakeDotClient()
+        let service = service(client: client, device: alertDevice(), snapshot: alertingSnapshot(remaining: 4))
+        await service.refresh(deviceID: "panel-1")
+
+        let push = try? XCTUnwrap(client.pushes.first)
+        XCTAssertEqual(push?.border, 1)
+        XCTAssertEqual(push?.refreshNow, true, "a new alert redraws immediately")
+        let strings = push?.payload.windowData.allStrings ?? []
+        XCTAssertTrue(strings.contains("ALERT · \(EInkFixtures.snapshot().generatedAtLabel)"))
+        XCTAssertTrue(strings.contains("CLAUDE"))
+        XCTAssertTrue(strings.contains("5 HOURS"))
+    }
+
+    /// Edge-triggered and persisted: a second pass with the same bucket still
+    /// in trouble must not ask the panel to flash again.
+    func testAnAlertThatIsAlreadyStandingDoesNotAskForAnotherRedraw() async {
+        let client = FakeDotClient()
+        let service = service(client: client, device: alertDevice(), snapshot: alertingSnapshot(remaining: 4))
+        await service.refresh(deviceID: "panel-1")
+        XCTAssertEqual(service.state(for: "panel-1").alertingFieldID, "claude.five_hour")
+        client.reset()
+        await service.pushNow(deviceID: "panel-1")
+        XCTAssertEqual(client.pushes.first?.refreshNow, false, "the same alert is not news")
+        XCTAssertEqual(client.pushes.first?.border, 1)
+    }
+
+    /// Restarting the app with the same bucket still under its threshold is
+    /// the case the persisted state exists for.
+    func testARestartWithTheSameAlertStandingDoesNotReAlert() async {
+        let client = FakeDotClient()
+        let first = service(client: client, device: alertDevice(), snapshot: alertingSnapshot(remaining: 4))
+        await first.refresh(deviceID: "panel-1")
+        await first.flushPendingWrites()
+        client.reset()
+
+        let second = service(client: client, device: alertDevice(), snapshot: alertingSnapshot(remaining: 4))
+        XCTAssertEqual(second.state(for: "panel-1").alertingFieldID, "claude.five_hour")
+        await second.pushNow(deviceID: "panel-1")
+        XCTAssertEqual(client.pushes.first?.refreshNow, false)
+    }
+
+    func testWhenTheConditionClearsTheNormalSlideAndTheWhiteBorderComeBack() async {
+        let client = FakeDotClient()
+        let service = service(client: client, device: alertDevice(), snapshot: alertingSnapshot(remaining: 4))
+        await service.refresh(deviceID: "panel-1")
+        client.reset()
+
+        service.apply(
+            settings: EInkSyncSettings(apiKeyPresent: true, syncEnabled: true, devices: [alertDevice(threshold: 1)]),
+            layouts: [:]
+        )
+        await service.pushNow(deviceID: "panel-1")
+        XCTAssertNil(service.state(for: "panel-1").alertingFieldID)
+        XCTAssertEqual(client.pushes.last?.border, 0)
+        XCTAssertFalse(client.pushes.contains { $0.payload.windowData.allStrings.contains("5 HOURS") })
+    }
+
+    func testAlertsCanBeTurnedOffPerDevice() async {
+        let client = FakeDotClient()
+        var config = alertDevice()
+        config.alerts = EInkAlertConfig(enabled: false, thresholdPercent: 10)
+        let service = service(client: client, device: config, snapshot: alertingSnapshot(remaining: 1))
+        await service.refresh(deviceID: "panel-1")
+        XCTAssertEqual(client.pushes.first?.border, 0)
+        XCTAssertNil(service.state(for: "panel-1").alertingFieldID)
+    }
+
+    /// A panel only alerts about what it shows. Anything else is news about
+    /// something the reader never asked this panel to watch.
+    func testADeviceOnlyAlertsAboutBucketsItsOwnSlidesDraw() {
+        var config = alertDevice()
+        config.slides = [EInkSlide(id: "a", kind: .preset(.quotaLedger), quotaFieldIDs: ["codex.weekly"])]
+        var snapshot = EInkFixtures.snapshot()
+        snapshot.quota = snapshot.quota.map { row in
+            guard row.fieldID == "claude.five_hour" else { return row }
+            var copy = row
+            copy.remainingPercent = 1
+            copy.forecast = nil
+            return copy
+        }
+        XCTAssertNil(EInkAlertEvaluator.offendingFieldID(device: config, snapshot: snapshot))
+    }
+
+    /// A bucket well above the threshold still alerts when the pace model says
+    /// it will not last the window.
+    func testAnAtRiskVerdictAlertsEvenAboveTheThreshold() {
+        let config = alertDevice()
+        var snapshot = EInkFixtures.snapshot()
+        snapshot.quota = snapshot.quota.map { row in
+            guard row.fieldID == "claude.five_hour" else { return row }
+            var copy = row
+            copy.remainingPercent = 62
+            copy.forecast = EInkQuotaForecast(verdict: .atRisk, projectedUsedPercent: 130, runOutAt: nil)
+            return copy
+        }
+        XCTAssertEqual(EInkAlertEvaluator.offendingFieldID(device: config, snapshot: snapshot), "claude.five_hour")
+    }
+
+    func testTheTapLinkRidesOnEveryPayloadAndIsOmittedWhenThereIsNone() async {
+        let client = FakeDotClient()
+        let linked = service(
+            client: client,
+            device: alertDevice(tapLink: .custom("https://example.com/panel")),
+            snapshot: alertingSnapshot(remaining: 90)
+        )
+        await linked.refresh(deviceID: "panel-1")
+        XCTAssertEqual(client.pushes.first?.link, "https://example.com/panel")
+
+        client.reset()
+        let unlinked = service(client: client, device: alertDevice(), snapshot: alertingSnapshot(remaining: 90))
+        await unlinked.pushNow(deviceID: "panel-1")
+        XCTAssertNil(client.pushes.first?.link)
+    }
+
+    func testTheRemoteDashboardLinkIsOnlySentWhenRemoteIsConfigured() async {
+        let client = FakeDotClient()
+        let withWorkspace = service(
+            client: client,
+            device: alertDevice(tapLink: .remoteDashboard),
+            snapshot: alertingSnapshot(remaining: 90),
+            remoteDashboardURL: { URL(string: "https://example.com/dashboard") }
+        )
+        await withWorkspace.refresh(deviceID: "panel-1")
+        XCTAssertEqual(client.pushes.first?.link, "https://example.com/dashboard")
+
+        client.reset()
+        let without = service(
+            client: client,
+            device: alertDevice(tapLink: .remoteDashboard),
+            snapshot: alertingSnapshot(remaining: 90),
+            remoteDashboardURL: { nil }
+        )
+        await without.pushNow(deviceID: "panel-1")
+        XCTAssertNil(client.pushes.first?.link)
+    }
+
+    /// Quiet hours live on the device, so the write happens once per change —
+    /// not once per refresh.
+    func testQuietHoursAreWrittenOnceAndOnlyAfterTheUserTurnsThemOn() async {
+        let client = FakeDotClient()
+        let service = service(client: client, device: alertDevice(), snapshot: alertingSnapshot(remaining: 90))
+        await service.refresh(deviceID: "panel-1")
+        XCTAssertTrue(client.sleepWrites.isEmpty, "a device nobody configured is not written to")
+
+        var config = alertDevice()
+        config.quietHours = EInkQuietHours(enabled: true, start: "23:00", end: "07:00")
+        service.apply(
+            settings: EInkSyncSettings(apiKeyPresent: true, syncEnabled: true, devices: [config]),
+            layouts: [:]
+        )
+        await service.pushNow(deviceID: "panel-1")
+        XCTAssertEqual(client.sleepWrites.count, 1)
+        XCTAssertEqual(client.sleepWrites.first?.start, "23:00")
+        XCTAssertEqual(client.sleepWrites.first?.end, "07:00")
+        XCTAssertTrue(client.sleepWrites.first?.enabled ?? false)
+
+        await service.pushNow(deviceID: "panel-1")
+        XCTAssertEqual(client.sleepWrites.count, 1, "an unchanged window is not rewritten")
+
+        config.quietHours = EInkQuietHours(enabled: false, start: "23:00", end: "07:00")
+        service.apply(
+            settings: EInkSyncSettings(apiKeyPresent: true, syncEnabled: true, devices: [config]),
+            layouts: [:]
+        )
+        await service.pushNow(deviceID: "panel-1")
+        XCTAssertEqual(client.sleepWrites.count, 2, "turning it off is a change worth sending")
+        XCTAssertFalse(client.sleepWrites.last?.enabled ?? true)
+    }
+
+    /// A reset just happened, so the numbers behind the panel jumped: redraw
+    /// rather than sitting on the old ones for the rest of the cadence.
+    func testAResetBoundaryForcesAnImmediateRedrawOnTheNextPass() {
+        let now = EInkFixtures.referenceDate
+        XCTAssertFalse(EInkAlertEvaluator.resetBoundaryPassed(recorded: nil, now: now))
+        XCTAssertFalse(EInkAlertEvaluator.resetBoundaryPassed(recorded: now.addingTimeInterval(60), now: now))
+        XCTAssertTrue(EInkAlertEvaluator.resetBoundaryPassed(recorded: now.addingTimeInterval(-1), now: now))
+
+        let snapshot = EInkFixtures.snapshot()
+        let next = EInkAlertEvaluator.nextResetAt(snapshot, after: EInkFixtures.referenceDate)
+        XCTAssertEqual(next, snapshot.quota.compactMap(\.resetAt).min())
     }
 }

--- a/Tests/VibeBarCoreTests/EInkSyncServiceTests.swift
+++ b/Tests/VibeBarCoreTests/EInkSyncServiceTests.swift
@@ -1937,6 +1937,32 @@ final class EInkSyncServiceTests: XCTestCase {
         XCTAssertFalse(client.sleepWrites.last?.enabled ?? true)
     }
 
+    /// A slide keeps its buckets when it is switched to a usage layout. Those
+    /// buckets are not on screen, so an alert about one would be news from
+    /// nowhere.
+    func testASlideSwitchedToAUsageLayoutStopsBeingWatched() {
+        var config = alertDevice()
+        config.slides = [
+            EInkSlide(id: "a", kind: .preset(.heatmap), quotaFieldIDs: ["claude.five_hour"])
+        ]
+        var snapshot = EInkFixtures.snapshot()
+        snapshot.quota = snapshot.quota.map { row in
+            guard row.fieldID == "claude.five_hour" else { return row }
+            var copy = row
+            copy.remainingPercent = 1
+            copy.forecast = nil
+            return copy
+        }
+        XCTAssertEqual(EInkAlertEvaluator.watchedFieldIDs(config), [])
+        XCTAssertNil(EInkAlertEvaluator.offendingFieldID(device: config, snapshot: snapshot))
+
+        config.slides = [EInkSlide(id: "a", kind: .preset(.forecast), quotaFieldIDs: ["claude.five_hour"])]
+        XCTAssertEqual(
+            EInkAlertEvaluator.offendingFieldID(device: config, snapshot: snapshot),
+            "claude.five_hour"
+        )
+    }
+
     /// Changing where a tap goes changes nothing on screen, so the digest has
     /// to carry it or the new link never leaves the Mac.
     func testChangingTheTapLinkAloneStillReachesThePanel() async {


### PR DESCRIPTION
Round 2, part A (Core) of the E-ink Displays feature. Part B redesigns the
settings pane and the Studio on top of this.

The owner's review of 1.7.0-dev.81 found four things wrong with round 1, and
one thing missing.

## §1 · Naming

A slot said "Claude · Weekly" on a panel showing two Claude weeklies. The new
`EInkSlotLabel` resolves the same three tiers the mini window shows —
SubProvider, quota group, window — in English and unabbreviated:

- `Claude · Fable · Weekly`, `ChatGPT Agentic · Weekly`, `Grok Bot · Weekly`,
  `AntiGravity · Claude and GPT Models · Weekly`
- the catch-all "All Models" lane is dropped (it is the absence of a name, not
  a name), and a tier that restates an earlier one goes with it
- `EInkProviderLabel.short` is deleted

Every slot takes a per-slide override (`EInkSlide.customLabels`). A name too
long for the ledger's column grows the column to everything the row can spare
before the slot splits into two lines; rings and the rail were already
two-line and now carry the real tiers.

## §2 · Composition options

`EInkSlideOptions` on every slide: header on/off, top or bottom, each side
independently fixed text / clock / date / date-and-clock / provider status;
footer off, the usage summary over chosen windows, a clock or fixed text;
slot order; per-slot labels; and a compact flag that lets the body fill the
panel when both bars are off.

The defaults reproduce the round 1 panel **byte for byte** — a round 1
settings file has no `options` key, and the golden test renders every preset ×
orientation both ways and compares the encoded payloads.

## §3 · Exploder and per-orientation layouts

`EInkNode` gains an optional `binding` and `moduleID`; `EInkBoxLayout` can
resolve annotated boxes; `EInkPresetExploder.explode(slide:orientation:…)`
turns a preset into a Studio layout whose groups are the header, each quota
slot and the footer, with bindings preserved. The contract is asserted for all
14 presets × 4 orientations: the exploded layout draws the same boxes. A
binding whose printed text is decorated ("in 3h 00m", an uppercased alert
headline) becomes fixed text rather than silently redrawing as the bare figure.

`einkCanvasLayouts` is keyed `"<layoutID>/<degrees>"`, with a migration that
puts a round 1 entry on the device's current orientation and an
explode-on-the-fly fallback for an orientation nobody has authored yet.
`EInkCanvasLayout.reflow(from:orientation:…)` is the Studio's "Re-layout".

## §4 · Cadence

`playbackMode` and `secondsPerSlide` are independent stored fields, migrated
from the old `playback` enum (both shapes are still written, so a downgrade
keeps working). Ranges 1…1440 / 1…1440 / 10…86400, clamped, with the battery
cadence round-tripped through `settings.json` in a test.

## §8 · New content and dynamics

Data: per-slot pace forecast (verdict, projected use, run-out time) injected
by closure like the quota lookup; the 7 × 24 activity grid summed over every
provider; today's top models; a one-line provider-status summary.

Layouts: **Briefing** (all text, one line per slot in landscape, two in
portrait, with today's and the week's spend underneath), **Forecast** (a bar
per slot with the projected-use tick and the verdict in full), **Resets** (a
seven-day strip with a tick per bucket, soonest first), **Heatmap** (a
pre-thresholded 1-bit PNG through the new `EInkHeatmapRasterizer`, dots by
quantile, "busiest Tue 21:00"), **Top Models**, and the engine's own
**Alert**.

Engine: alerts are edge-triggered and persisted in `eink_state.json` (a
relaunch with the same bucket still under its threshold does not push again),
the alert replaces the single slide or the first loop slot and puts `border: 1`
on every payload, a `link` from the per-device tap-link setting rides on every
payload, a reset that has just happened forces an immediate redraw, and the
quiet-hours window is written to the device once per change through the new
`DotDeviceClient.updateSleep`.

## Verification

`swift build`, `swift test` (2659 tests, 0 failures), `./Scripts/build_app.sh
release`, `codesign -d --entitlements` (empty `<dict/>`, no `app-sandbox`),
`python3 Scripts/lint_localization.py`.

Hardware: the Briefing preset and the alert slide were pushed to a Quote/0 and
read back. Two bugs came out of that and are fixed in this diff — the briefing
printed "67%" as "7%" because a fixed column trusted an estimated font metric,
and the alert headline ran through both edges of the black border. No version
bump, no pin changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)